### PR TITLE
build: fix .ncrc template to use separate plugin libraries instead of…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ dkms.conf
 *.dwo
 
 # Autotools generated files
+.ncrc
 Makefile
 Makefile.in
 aclocal.m4
@@ -147,7 +148,9 @@ tst_geotiff_edge_cases
 tst_simple_geotiff
 bench_geotiff_performance
 tst_geotiff_self_load
+tst_geotiff_ncrc_autoload
 tst_cdf_self_load
+tst_cdf_ncrc_autoload
 
 # Copied test data files (should only exist in test/data/)
 test_geotiff/MCDWD_L3_F1C_NRT.A2025353.h00v02.061.tif

--- a/.ncrc.in
+++ b/.ncrc.in
@@ -13,16 +13,16 @@
 # Reference: https://docs.unidata.ucar.edu/netcdf/NUG/user_defined_formats.html
 
 # GeoTIFF BigTIFF (little-endian, UDF slot 0)
-NETCDF.UDF0.LIBRARY=@NEP_LIBDIR@/libnep.so
+NETCDF.UDF0.LIBRARY=@NEP_LIBDIR@/libncgeotiff.so
 NETCDF.UDF0.INIT=NC_GEOTIFF_initialize
 NETCDF.UDF0.MAGIC=II+
 
 # GeoTIFF standard TIFF (little-endian, UDF slot 1)
-NETCDF.UDF1.LIBRARY=@NEP_LIBDIR@/libnep.so
+NETCDF.UDF1.LIBRARY=@NEP_LIBDIR@/libncgeotiff.so
 NETCDF.UDF1.INIT=NC_GEOTIFF_initialize
 NETCDF.UDF1.MAGIC=II*
 
 # NASA CDF format (UDF slot 2)
-NETCDF.UDF2.LIBRARY=@NEP_LIBDIR@/libnep.so
+NETCDF.UDF2.LIBRARY=@NEP_LIBDIR@/libnccdf.so
 NETCDF.UDF2.INIT=NC_CDF_initialize
 NETCDF.UDF2.MAGIC=\xCD\xF3\x00\x01


### PR DESCRIPTION
… monolithic libnep

- Update .ncrc.in to reference libncgeotiff.so for UDF0/UDF1 (GeoTIFF) entries
- Update .ncrc.in to reference libnccdf.so for UDF2 (CDF) entry
- Add .ncrc to .gitignore (generated file from .ncrc.in template)
- Add tst_geotiff_ncrc_autoload and tst_cdf_ncrc_autoload to .gitignore