### PR TITLE
v1.7.0 Sprint 2: Implement NC_GRIB2_open(), NC_GRIB2_close(), and tst_grib2_udf test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ option(ENABLE_GRIB2 "Enable GRIB2 support" OFF)
 
 if(ENABLE_GRIB2)
     find_library(G2C_LIBRARY NAMES g2c)
-    find_path(G2C_INCLUDE_DIR g2c.h)
+    find_path(G2C_INCLUDE_DIR grib2.h)
 
     if(G2C_LIBRARY AND G2C_INCLUDE_DIR)
         message(STATUS "Found g2c library: ${G2C_LIBRARY}")

--- a/config.h.in
+++ b/config.h.in
@@ -18,9 +18,6 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
-/* Define to 1 if you have the <g2c.h> header file. */
-#undef HAVE_G2C_H
-
 /* Define if GeoTIFF library is found */
 #undef HAVE_GEOTIFF
 
@@ -32,6 +29,9 @@
 
 /* Define if GRIB2 (g2c) library is found */
 #undef HAVE_GRIB2
+
+/* Define to 1 if you have the <grib2.h> header file. */
+#undef HAVE_GRIB2_H
 
 /* Defined if you have HDF5 support */
 #undef HAVE_HDF5

--- a/configure.ac
+++ b/configure.ac
@@ -190,7 +190,7 @@ test "x$enable_grib2" = xyes || enable_grib2=no
 AC_MSG_RESULT([$enable_grib2])
 
 if test "x$enable_grib2" = "xyes"; then
-    AC_CHECK_HEADERS([g2c.h], [g2c_header=yes], [g2c_header=no])
+    AC_CHECK_HEADERS([grib2.h], [g2c_header=yes], [g2c_header=no])
     AC_SEARCH_LIBS([g2c_open], [g2c], [g2c_lib=yes; G2C_LIBS="-lg2c"], [g2c_lib=no])
 
     if test "x$g2c_header" = "xyes" && test "x$g2c_lib" = "xyes"; then

--- a/src/grib2file.c
+++ b/src/grib2file.c
@@ -9,8 +9,10 @@
  */
 
 #include "config.h"
+#include <stdlib.h>
 #include "nep_nc4.h"
 #include "grib2dispatch.h"
+#include <grib2.h>
 
 /** @internal These flags may not be set for open mode. */
 static const int
@@ -28,40 +30,82 @@ ILLEGAL_OPEN_FLAGS = (NC_MMAP|NC_64BIT_OFFSET|NC_DISKLESS|NC_WRITE);
  * @param ncid NetCDF ID assigned to this file.
  *
  * @return ::NC_NOERR No error.
- * @return ::NC_EINVAL Invalid mode flags.
- * @return ::NC_ENOTBUILT GRIB2 support not yet implemented.
+ * @return ::NC_EINVAL Invalid parameters or mode flags.
+ * @return ::NC_ENOTNC File is not a valid GRIB2 file.
+ * @return ::NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 int
 NC_GRIB2_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
               void *parameters, const NC_Dispatch *dispatch, int ncid)
 {
-    (void)path;
-    (void)basepe;
-    (void)chunksizehintp;
-    (void)parameters;
-    (void)dispatch;
-    (void)ncid;
+    NC *nc;
+    NC_FILE_INFO_T *h5;
+    NC_GRIB2_FILE_INFO_T *grib2_file;
+    int g2cid, num_msg;
+    int retval;
+
+    assert(basepe || !basepe);
+    assert(chunksizehintp || !chunksizehintp);
+    assert(parameters || !parameters);
+    assert(dispatch);
+
+    if (!path)
+        return NC_EINVAL;
 
     if (mode & ILLEGAL_OPEN_FLAGS)
         return NC_EINVAL;
 
-    return NC_ENOTBUILT;
+    /* Find pointer to NC. */
+    if ((retval = NC_check_id(ncid, &nc)))
+        return retval;
+
+    /* Open the GRIB2 file with g2c. */
+    if (g2c_open(path, G2C_NOWRITE, &g2cid))
+        return NC_ENOTNC;
+
+    /* Add necessary structs to hold netcdf-4 file data. */
+    if ((retval = nc4_file_list_add(ncid, path, mode, (void **)&h5)))
+    {
+        g2c_close(g2cid);
+        return retval;
+    }
+    assert(h5 && h5->root_grp);
+    h5->no_write = NC_TRUE;
+    h5->root_grp->atts_read = 1;
+
+    /* Query number of GRIB2 messages. */
+    num_msg = 0;
+    g2c_inq(g2cid, &num_msg);
+
+    /* Allocate GRIB2-specific file info. */
+    if (!(grib2_file = calloc(1, sizeof(NC_GRIB2_FILE_INFO_T))))
+    {
+        g2c_close(g2cid);
+        return NC_ENOMEM;
+    }
+    grib2_file->g2cid = g2cid;
+    grib2_file->num_messages = num_msg;
+    h5->format_file_info = grib2_file;
+
+    return NC_NOERR;
 }
 
 /**
- * @internal Abort a GRIB2 file open operation.
+ * @internal Abort (close) a GRIB2 file.
+ *
+ * For read-only files, abort is identical to close.
  *
  * @param ncid NetCDF ID.
  *
- * @return ::NC_ENOTBUILT GRIB2 support not yet implemented.
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int
 NC_GRIB2_abort(int ncid)
 {
-    (void)ncid;
-    return NC_ENOTBUILT;
+    return NC_GRIB2_close(ncid, NULL);
 }
 
 /**
@@ -70,15 +114,38 @@ NC_GRIB2_abort(int ncid)
  * @param ncid NetCDF ID.
  * @param ignore Ignored.
  *
- * @return ::NC_ENOTBUILT GRIB2 support not yet implemented.
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int
 NC_GRIB2_close(int ncid, void *ignore)
 {
-    (void)ncid;
-    (void)ignore;
-    return NC_ENOTBUILT;
+    NC_FILE_INFO_T *h5;
+    NC_GRP_INFO_T *grp;
+    NC_GRIB2_FILE_INFO_T *grib2_file;
+    int retval;
+
+    assert(ignore || !ignore);
+
+    /* Get file info structure. */
+    if ((retval = nc4_find_grp_h5(ncid, &grp, &h5)))
+        return retval;
+
+    /* Get GRIB2-specific info. */
+    grib2_file = (NC_GRIB2_FILE_INFO_T *)h5->format_file_info;
+    if (!grib2_file)
+        return NC_NOERR;
+
+    /* Close the g2c file handle. */
+    g2c_close(grib2_file->g2cid);
+
+    /* Free GRIB2-specific info. */
+    free(grib2_file->path);
+    free(grib2_file);
+    h5->format_file_info = NULL;
+
+    return NC_NOERR;
 }
 
 /**

--- a/test/tst_grib2_udf.c
+++ b/test/tst_grib2_udf.c
@@ -1,12 +1,12 @@
 /**
  * @file tst_grib2_udf.c
- * @brief Placeholder test for GRIB2 User Defined Format (UDF) handler.
+ * @brief Test for GRIB2 User Defined Format (UDF) handler open/close.
  *
- * This test will validate that GRIB2 files can be opened and read through
- * the standard NetCDF API using the GRIB2 UDF handler. Full implementation
- * follows in a subsequent sprint once NC_GRIB2_open() is complete.
+ * Validates that a GRIB2 file can be opened and closed through the standard
+ * NetCDF API using the GRIB2 UDF handler, and that non-GRIB2 files are
+ * correctly rejected.
  *
- * This test is part of v1.7.0 Sprint 1.
+ * This test is part of v1.7.0 Sprint 2.
  *
  * @author Edward Hartnett
  * @date 2026-03-08
@@ -17,16 +17,56 @@
 
 #include <stdio.h>
 #include <netcdf.h>
+#include <grib2.h>
 #include "grib2dispatch.h"
+
+/** @internal Error macro: print location and return failure. */
+#define ERR do { \
+    fprintf(stderr, "ERROR at %s:%d\n", __FILE__, __LINE__); \
+    return 1; \
+} while(0)
+
+/** @internal Check return value; jump to ERR on non-zero. */
+#define CHECK(e) do { if ((e)) ERR; } while(0)
+
+/** Path to the GRIB2 test data file (relative to test build directory). */
+#define GRIB2_TEST_FILE "data/gdaswave.t00z.wcoast.0p16.f000.grib2"
 
 int
 main(void)
 {
-    printf("GRIB2 UDF placeholder test\n");
+    int ncid, ret;
+
+    /* Enable verbose g2c logging for CI diagnostics. */
+    g2c_set_log_level(3);
+
+    /* Register the GRIB2 dispatch table. */
+    NC_GRIB2_initialize();
+
+    /* Test 1: open a valid GRIB2 file. */
+    CHECK(nc_open(GRIB2_TEST_FILE, NC_NOWRITE, &ncid));
+    printf("PASS: nc_open GRIB2 file\n");
+
+    /* Test 2: close the file. */
+    CHECK(nc_close(ncid));
+    printf("PASS: nc_close GRIB2 file\n");
+
+    /* Test 3: opening a non-GRIB2 path must return an error. */
+    ret = nc_open("/dev/null", NC_NOWRITE, &ncid);
+    if (ret == NC_NOERR)
+        ERR;
+    printf("PASS: nc_open non-GRIB2 file returned error (%d)\n", ret);
+
+    /* Restore default g2c log level. */
+    g2c_set_log_level(0);
+
+    printf("PASS: all tests passed\n");
     return 0;
 }
 
-#else
+#else /* !HAVE_GRIB2 */
+
+#include <stdio.h>
 
 int
 main(void)


### PR DESCRIPTION
## Summary

Implements GRIB2 file open/close functionality via NCEPLIBS-g2c and expands the GRIB2 UDF test.

## Changes

### `src/grib2file.c`
- Implement `NC_GRIB2_open()`: calls `g2c_open()`, registers file with `nc4_file_list_add()`, allocates and attaches `NC_GRIB2_FILE_INFO_T`; returns `NC_ENOTNC` on invalid file
- Implement `NC_GRIB2_close()`: calls `g2c_close()`, frees `NC_GRIB2_FILE_INFO_T`
- Implement `NC_GRIB2_abort()`: delegates to `NC_GRIB2_close()`

### `test/tst_grib2_udf.c`
- Replace placeholder with real test: open valid GRIB2 file, close it, verify non-GRIB2 path returns error
- Add `ERR`/`CHECK` macros; bracket with `g2c_set_log_level(3/0)` for CI diagnostics

### `configure.ac` / `CMakeLists.txt`
- Fix g2c header detection: `g2c.h` → `grib2.h` (g2c installs `grib2.h`, not `g2c.h`)

Fixes #163
Fixes #164
Fixes #165