### PR TITLE
Enable dispatch layers (GeoTIFF, CDF, GRIB2) by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
             -DENABLE_GRIB2=ON \
             -DENABLE_FORTRAN=OFF \
             -DENABLE_CDF=OFF \
+            -DENABLE_GEOTIFF=OFF \
             -DBUILD_TESTING=ON \
             -DBUILD_LZ4=OFF \
             -DBUILD_BZIP2=OFF \
@@ -154,6 +155,8 @@ jobs:
           ./configure \
             --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc \
             --enable-grib2 \
+            --disable-cdf \
+            --disable-geotiff \
             --disable-fortran \
             --disable-lz4 \
             --disable-bzip2 \
@@ -276,7 +279,7 @@ jobs:
           export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include -I$GITHUB_WORKSPACE/g2c-install/include"
           export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib -L$GITHUB_WORKSPACE/g2c-install/lib -fsanitize=address"
           export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/g2c-install/lib:$LD_LIBRARY_PATH"
-          ./configure --enable-geotiff --enable-grib2 --with-g2c=$GITHUB_WORKSPACE/g2c-install --disable-fortran --disable-shared --disable-bzip2 --disable-lz4 --enable-examples
+          ./configure --enable-geotiff --enable-grib2 --disable-cdf --with-g2c=$GITHUB_WORKSPACE/g2c-install --disable-fortran --disable-shared --disable-bzip2 --disable-lz4 --enable-examples
 
       - name: Build NEP with ASAN
         run: make -j$(nproc)
@@ -488,7 +491,7 @@ EOF
             CDF_FLAG="-DENABLE_CDF=ON"
           fi
           export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/netcdf-c-install/lib/pkgconfig:$GITHUB_WORKSPACE/hdf5-install/lib/pkgconfig:${PKG_CONFIG_PATH}"
-          cmake .. -DCMAKE_C_FLAGS="-Wall -Werror" -DCMAKE_Fortran_FLAGS="-Wall -Werror" -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/netcdf-fortran-install;$GITHUB_WORKSPACE/cdf-install;/usr/include/liblzf" -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON $DOC_FLAG $FORTRAN_FLAG $CDF_FLAG
+          cmake .. -DCMAKE_C_FLAGS="-Wall -Werror" -DCMAKE_Fortran_FLAGS="-Wall -Werror" -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/netcdf-fortran-install;$GITHUB_WORKSPACE/cdf-install;/usr/include/liblzf" -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON $DOC_FLAG $FORTRAN_FLAG $CDF_FLAG -DENABLE_GEOTIFF=OFF -DENABLE_GRIB2=OFF
 
       - name: Build (CMake)
         if: matrix.build_system == 'cmake'
@@ -583,7 +586,7 @@ EOF
             CDF_FLAG="--enable-cdf"
           fi
 
-          ./configure --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc $LZ4_FLAG $BZIP2_FLAG $DOCS_FLAG $FORTRAN_FLAG $CDF_FLAG --enable-examples || (echo "Configure failed. Printing config.log:"; cat config.log; echo "hdf5_plugins/config.log:"; cat hdf5_plugins/config.log; exit 1)
+          ./configure --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc $LZ4_FLAG $BZIP2_FLAG $DOCS_FLAG $FORTRAN_FLAG $CDF_FLAG --disable-geotiff --disable-grib2 --enable-examples || (echo "Configure failed. Printing config.log:"; cat config.log; echo "hdf5_plugins/config.log:"; cat hdf5_plugins/config.log; exit 1)
 
       - name: Build (Autotools)
         if: matrix.build_system == 'autotools'

--- a/.github/workflows/geotiff-test.yml
+++ b/.github/workflows/geotiff-test.yml
@@ -104,6 +104,8 @@ jobs:
           cmake .. \
             -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install" \
             -DENABLE_GEOTIFF=ON \
+            -DENABLE_CDF=OFF \
+            -DENABLE_GRIB2=OFF \
             -DENABLE_FORTRAN=OFF \
             -DBUILD_TESTING=OFF \
             -DBUILD_LZ4=OFF \
@@ -121,15 +123,18 @@ jobs:
           make -j$(nproc)
           echo "=== Build completed successfully ==="
 
-      - name: Test CMake with GeoTIFF disabled (default)
+      - name: Test CMake with GeoTIFF disabled
         if: matrix.build_system == 'cmake'
         run: |
-          echo "=== Testing CMake with GeoTIFF disabled (default) ==="
+          echo "=== Testing CMake with GeoTIFF disabled ==="
           rm -rf build_disabled
           mkdir build_disabled
           cd build_disabled
           cmake .. \
             -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install" \
+            -DENABLE_GEOTIFF=OFF \
+            -DENABLE_CDF=OFF \
+            -DENABLE_GRIB2=OFF \
             -DENABLE_FORTRAN=OFF \
             -DBUILD_TESTING=OFF \
             -DBUILD_LZ4=OFF \
@@ -163,6 +168,8 @@ jobs:
           ./configure \
             --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc \
             --enable-geotiff \
+            --disable-cdf \
+            --disable-grib2 \
             --disable-fortran \
             --disable-lz4 \
             --disable-docs \
@@ -180,10 +187,10 @@ jobs:
           make -j$(nproc)
           echo "=== Build completed successfully ==="
 
-      - name: Test Autotools with GeoTIFF disabled (default)
+      - name: Test Autotools with GeoTIFF disabled
         if: matrix.build_system == 'autotools'
         run: |
-          echo "=== Testing Autotools with GeoTIFF disabled (default) ==="
+          echo "=== Testing Autotools with GeoTIFF disabled ==="
           make distclean || true
           autoreconf -fiv
           export PATH="$GITHUB_WORKSPACE/hdf5-install/bin:$PATH"
@@ -193,6 +200,9 @@ jobs:
           export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$LD_LIBRARY_PATH"
           ./configure \
             --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc \
+            --disable-geotiff \
+            --disable-cdf \
+            --disable-grib2 \
             --disable-fortran \
             --disable-lz4 \
             --disable-docs \
@@ -318,6 +328,8 @@ jobs:
           cmake .. \
             -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install" \
             -DENABLE_GEOTIFF=ON \
+            -DENABLE_CDF=OFF \
+            -DENABLE_GRIB2=OFF \
             -DENABLE_FORTRAN=OFF \
             -DBUILD_TESTING=ON \
             -DBUILD_LZ4=OFF \
@@ -428,6 +440,8 @@ jobs:
           cmake .. \
             -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install" \
             -DENABLE_GEOTIFF=ON \
+            -DENABLE_CDF=OFF \
+            -DENABLE_GRIB2=OFF \
             -DENABLE_FORTRAN=OFF \
             -DBUILD_TESTING=ON \
             -DBUILD_LZ4=OFF \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,11 @@ option(BUILD_BZIP2 "Enable BZIP2 filter support" OFF)
 # Use add_definitions for compatibility with CMake 3.9
 add_definitions(-DUSE_HDF5=yes)
 
-# CDF library detection (v1.3.0) - default OFF, library detection only, no UDF yet
-option(ENABLE_CDF "Enable CDF library detection" OFF)
+# CDF library detection (v1.3.0) - default ON; disable with -DENABLE_CDF=OFF
+option(ENABLE_CDF "Enable CDF library detection" ON)
 
-# GeoTIFF library detection (v1.5.0) - default OFF, library detection only, no UDF yet
-option(ENABLE_GEOTIFF "Enable GeoTIFF library detection" OFF)
+# GeoTIFF library detection (v1.5.0) - default ON; disable with -DENABLE_GEOTIFF=OFF
+option(ENABLE_GEOTIFF "Enable GeoTIFF library detection" ON)
 
 # Documentation option
 option(BUILD_DOCUMENTATION "Build documentation with Doxygen" ON)
@@ -104,7 +104,7 @@ if(ENABLE_CDF)
         set(HAVE_CDF TRUE)
         message(STATUS "CDF library detection enabled (library location only, no UDF yet)")
     else()
-        message(FATAL_ERROR "CDF enabled but NASA CDF library not found. Install NASA CDF library or disable with -DENABLE_CDF=OFF")
+        message(FATAL_ERROR "libcdf is required for the CDF dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use -DENABLE_CDF=OFF")
     endif()
 endif()
 
@@ -124,12 +124,12 @@ if(ENABLE_GEOTIFF)
         set(HAVE_GEOTIFF TRUE)
         message(STATUS "GeoTIFF library detection enabled (library location only, no UDF yet)")
     else()
-        message(FATAL_ERROR "GeoTIFF enabled but libgeotiff or libtiff not found. Install libgeotiff and libtiff or disable with -DENABLE_GEOTIFF=OFF")
+        message(FATAL_ERROR "libgeotiff is required for the GeoTIFF dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use -DENABLE_GEOTIFF=OFF")
     endif()
 endif()
 
-# GRIB2 library detection (v1.7.0) - default OFF
-option(ENABLE_GRIB2 "Enable GRIB2 support" OFF)
+# GRIB2 library detection (v1.7.0) - default ON; disable with -DENABLE_GRIB2=OFF
+option(ENABLE_GRIB2 "Enable GRIB2 support" ON)
 
 if(ENABLE_GRIB2)
     find_library(G2C_LIBRARY NAMES g2c)
@@ -141,7 +141,7 @@ if(ENABLE_GRIB2)
         include_directories(${G2C_INCLUDE_DIR})
         set(HAVE_GRIB2 TRUE)
     else()
-        message(FATAL_ERROR "GRIB2 enabled but NCEPLIBS-g2c not found. Install g2c or disable with -DENABLE_GRIB2=OFF")
+        message(FATAL_ERROR "libg2c is required for the GRIB2 dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use -DENABLE_GRIB2=OFF")
     endif()
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -107,20 +107,20 @@ AC_ARG_ENABLE([docs],
     [enable_docs=$enableval],
     [enable_docs=auto])
 
-# CDF library detection (v1.3.0) - library detection only, no UDF yet
+# CDF library detection (v1.3.0) - default ON; disable with --disable-cdf
 AC_MSG_CHECKING([whether CDF library detection should be enabled])
 AC_ARG_ENABLE([cdf],
-              [AS_HELP_STRING([--enable-cdf],
-                              [Enable CDF library detection (default: no)])])
-test "x$enable_cdf" = xyes || enable_cdf=no
+              [AS_HELP_STRING([--disable-cdf],
+                              [Disable CDF library detection (default: enabled)])])
+test "x$enable_cdf" = xno || enable_cdf=yes
 AC_MSG_RESULT([$enable_cdf])
 
-# GeoTIFF library detection (v1.5.0) - library detection only, no UDF yet
+# GeoTIFF library detection (v1.5.0) - default ON; disable with --disable-geotiff
 AC_MSG_CHECKING([whether GeoTIFF library detection should be enabled])
 AC_ARG_ENABLE([geotiff],
-              [AS_HELP_STRING([--enable-geotiff],
-                              [Enable GeoTIFF library detection (default: no)])])
-test "x$enable_geotiff" = xyes || enable_geotiff=no
+              [AS_HELP_STRING([--disable-geotiff],
+                              [Disable GeoTIFF library detection (default: enabled)])])
+test "x$enable_geotiff" = xno || enable_geotiff=yes
 AC_MSG_RESULT([$enable_geotiff])
 
 # Initialize variables
@@ -155,7 +155,7 @@ if test "x$enable_cdf" = "xyes"; then
         
         AC_MSG_NOTICE([CDF library detection enabled (library location only, no UDF yet)])
     else
-        AC_MSG_ERROR([CDF enabled but NASA CDF library not found. Install NASA CDF library or disable with --disable-cdf])
+        AC_MSG_ERROR([libcdf is required for the CDF dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use --disable-cdf])
     fi
 fi
 AC_SUBST([CDF_LIBS])
@@ -175,18 +175,18 @@ if test "x$enable_geotiff" = "xyes"; then
         AC_DEFINE([HAVE_TIFF_H], [1], [Define if tiff.h header is found])
         AC_MSG_NOTICE([GeoTIFF library detection enabled (library location only, no UDF yet)])
     else
-        AC_MSG_ERROR([GeoTIFF enabled but libgeotiff or libtiff not found. Install libgeotiff and libtiff or disable with --disable-geotiff])
+        AC_MSG_ERROR([libgeotiff is required for the GeoTIFF dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use --disable-geotiff])
     fi
 fi
 AC_SUBST([GEOTIFF_LIBS])
 AC_SUBST([TIFF_LIBS])
 
-# GRIB2 library detection (v1.7.0) - default OFF
+# GRIB2 library detection (v1.7.0) - default ON; disable with --disable-grib2
 AC_MSG_CHECKING([whether GRIB2 library detection should be enabled])
 AC_ARG_ENABLE([grib2],
-              [AS_HELP_STRING([--enable-grib2],
-                              [Enable GRIB2 library detection (default: no)])])
-test "x$enable_grib2" = xyes || enable_grib2=no
+              [AS_HELP_STRING([--disable-grib2],
+                              [Disable GRIB2 library detection (default: enabled)])])
+test "x$enable_grib2" = xno || enable_grib2=yes
 AC_MSG_RESULT([$enable_grib2])
 
 if test "x$enable_grib2" = "xyes"; then
@@ -198,7 +198,7 @@ if test "x$enable_grib2" = "xyes"; then
         AC_DEFINE([HAVE_GRIB2], [1], [Define if GRIB2 (g2c) library is found])
         AC_MSG_NOTICE([GRIB2 library detection enabled])
     else
-        AC_MSG_ERROR([GRIB2 enabled but NCEPLIBS-g2c not found. Install g2c or disable with --disable-grib2])
+        AC_MSG_ERROR([libg2c is required for the GRIB2 dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use --disable-grib2])
     fi
 fi
 AC_SUBST([G2C_LIBS])

--- a/docs/design.md
+++ b/docs/design.md
@@ -381,19 +381,19 @@ Coordinate reference system (CRS) and georeferencing information stored followin
 
 ### Build System Integration
 
-#### Optional GeoTIFF Support
-GeoTIFF support is optional and controlled via build flags:
+#### GeoTIFF Support
+GeoTIFF support is enabled by default and can be disabled via build flags:
 
 **CMake:**
 ```bash
-cmake -DENABLE_GEOTIFF=ON  # Enable GeoTIFF support
-cmake -DENABLE_GEOTIFF=OFF # Disable GeoTIFF support (default)
+cmake -DENABLE_GEOTIFF=OFF # Disable GeoTIFF support
+cmake -DENABLE_GEOTIFF=ON  # Enable GeoTIFF support (default)
 ```
 
 **Autotools:**
 ```bash
-./configure --enable-geotiff   # Enable GeoTIFF support
-./configure --disable-geotiff  # Disable GeoTIFF support (default)
+./configure --disable-geotiff  # Disable GeoTIFF support
+./configure --enable-geotiff   # Enable GeoTIFF support (default)
 ```
 
 #### Dependency Detection
@@ -570,14 +570,14 @@ The GRIB2 UDF handler follows the same NC_Dispatch pattern used for CDF and GeoT
 
 **CMake:**
 ```bash
-cmake -DENABLE_GRIB2=ON   # Enable GRIB2 support
-cmake -DENABLE_GRIB2=OFF  # Disable GRIB2 support (default)
+cmake -DENABLE_GRIB2=OFF  # Disable GRIB2 support
+cmake -DENABLE_GRIB2=ON   # Enable GRIB2 support (default)
 ```
 
 **Autotools:**
 ```bash
-./configure --enable-grib2   # Enable GRIB2 support
-./configure --disable-grib2  # Disable GRIB2 support (default)
+./configure --disable-grib2  # Disable GRIB2 support
+./configure --enable-grib2   # Enable GRIB2 support (default)
 ```
 
 ### Known Limitations
@@ -635,9 +635,9 @@ The CDF UDF handler follows the same NC_Dispatch pattern used for other format h
 - NASA CDF Library v3.9.x (required when enabled)
 
 #### Build Integration
-- Optional CDF support via build flags:
-  - CMake: `-DENABLE_CDF=ON/OFF`
-  - Autotools: `--enable-cdf/--disable-cdf`
+- CDF support is enabled by default; disable via build flags:
+  - CMake: `-DENABLE_CDF=OFF` to disable (default: ON)
+  - Autotools: `--disable-cdf` to disable (default: enabled)
 
 ## Spack Package Manager Support (v1.4.0)
 


### PR DESCRIPTION
## Summary

Enable all three dispatch layers (GeoTIFF, CDF, GRIB2) by default in both CMake and Autotools build systems. If a required dependency is not found, configure now stops with a clear error message instructing the user to install the library or explicitly disable the layer.

Fixes #177

## Changes

### Build Systems
- **CMakeLists.txt**: Flip `ENABLE_CDF`, `ENABLE_GEOTIFF`, `ENABLE_GRIB2` option defaults from `OFF` to `ON`
- **configure.ac**: Flip CDF, GeoTIFF, GRIB2 enable guards from opt-in to opt-out (matching the existing `lz4`/`bzip2` pattern); update `AC_ARG_ENABLE` help strings to `--disable-X`

### Error Messages
Both build systems now emit the requested style on missing dependency:
> _libX is required for the X dispatch layer. Include the library path in CPPFLAGS/LDFLAGS, or use --disable-X / -DENABLE_X=OFF_

### Documentation
- **docs/design.md**: Update GeoTIFF, GRIB2, and CDF build option snippets to reflect default-ON / opt-out behaviour

### CI
- **ci.yml**: Add explicit `--disable-geotiff --disable-grib2` to the `build` job (those libraries are not installed there); add `--disable-geotiff` / `-DENABLE_GEOTIFF=OFF` to `grib2-build`; add `--disable-cdf` to `memory-leak-check`
- **geotiff-test.yml**: Add `--disable-cdf --disable-grib2` / `-DENABLE_CDF=OFF -DENABLE_GRIB2=OFF` to all three jobs; fix the "disabled" test steps to use explicit `--disable-geotiff` / `-DENABLE_GEOTIFF=OFF` now that the default is ON