### PR TITLE
fix: propagate LD_LIBRARY_PATH to Fortran example tests and fix HDF5_PLUGIN_PATH in ftest

### DIFF
--- a/examples/f_classic/Makefile.am
+++ b/examples/f_classic/Makefile.am
@@ -1,7 +1,7 @@
 # Makefile.am for classic NetCDF Fortran examples
 # Edward Hartnett 1/25/26
 
-AUTOMAKE_OPTIONS = serial-tests
+AUTOMAKE_OPTIONS = parallel-tests
 
 # Fortran module path - NetCDF-Fortran modules should be in CPPFLAGS from configure
 AM_FCFLAGS = $(CPPFLAGS)
@@ -31,6 +31,9 @@ TESTS = test_f_quickstart.sh test_f_simple_2D.sh test_f_coord.sh test_f_coord_va
 EXTRA_DIST = test_f_quickstart.sh test_f_simple_2D.sh test_f_coord.sh test_f_coord_vars.sh \
              test_f_size_limits.sh test_f_unlimited_dim.sh test_f_var4d.sh \
              test_f_dump_classic_metadata.sh
+
+# Set LD_LIBRARY_PATH so test binaries can find HDF5/NetCDF shared libs at runtime.
+AM_TESTS_ENVIRONMENT = LD_LIBRARY_PATH="@MY_LD_LIBRARY_PATH@:$$LD_LIBRARY_PATH"
 
 # Ensure built binaries are executable before test scripts run them
 check-local:

--- a/examples/f_netcdf-4/Makefile.am
+++ b/examples/f_netcdf-4/Makefile.am
@@ -1,7 +1,7 @@
 # Makefile.am for NetCDF-4 Fortran examples
 # Edward Hartnett 1/25/26
 
-AUTOMAKE_OPTIONS = serial-tests
+AUTOMAKE_OPTIONS = parallel-tests
 
 # Fortran module path - NetCDF-Fortran modules should be in CPPFLAGS from configure
 AM_FCFLAGS = $(CPPFLAGS)
@@ -31,6 +31,9 @@ TESTS = test_f_simple_nc4.sh test_f_format_variants.sh test_f_compression.sh tes
 EXTRA_DIST = test_f_simple_nc4.sh test_f_format_variants.sh test_f_compression.sh test_f_chunking_performance.sh \
              test_f_multi_unlimited.sh test_f_user_types.sh test_f_groups.sh \
              test_f_dump_nc4_metadata.sh
+
+# Set LD_LIBRARY_PATH so test binaries can find HDF5/NetCDF shared libs at runtime.
+TESTS_ENVIRONMENT = LD_LIBRARY_PATH="@MY_LD_LIBRARY_PATH@:$$LD_LIBRARY_PATH"
 
 # Ensure built binaries are executable before test scripts run them
 check-local:

--- a/ftest/run_tests.sh.in
+++ b/ftest/run_tests.sh.in
@@ -4,15 +4,21 @@
 set -x
 set -e
 
+# Set HDF5 plugin path to find the pre-built bzip2/zstd plugins from the
+# netcdf-c install, and the locally-built LZ4 plugin.
+if test -n "${HDF5_PLUGIN_PATH:-}"; then
+    export HDF5_PLUGIN_PATH="@MY_HDF5_PLUGIN_PATH@:../hdf5_plugins/LZ4/src/.libs:$HDF5_PLUGIN_PATH"
+else
+    export HDF5_PLUGIN_PATH="@MY_HDF5_PLUGIN_PATH@:../hdf5_plugins/LZ4/src/.libs"
+fi
+
 # If bzip2 was built, run the bzip2 test.
 if test "@BUILD_BZIP2@" = "yes"; then
-    export HDF5_PLUGIN_PATH="../hdf5_plugins/BZIP2/src/.libs:$HDF5_PLUGIN_PATH"
     ./ftst_nep_bzip2
 fi
 
 # If lz4 was built, run the lz4 test.
 if test "@BUILD_LZ4@" = "yes"; then
-    export HDF5_PLUGIN_PATH="../hdf5_plugins/LZ4/src/.libs:$HDF5_PLUGIN_PATH"
     ./ftst_nep_lz4
 fi
 

--- a/test_h5/run_tests.sh.in
+++ b/test_h5/run_tests.sh.in
@@ -14,7 +14,11 @@ fi
 
 if test "@BUILD_LZ4@" = "yes"; then
     # Set the plugin path to find plugin.
-    export HDF5_PLUGIN_PATH="../hdf5_plugins/LZ4/src/.libs:$HDF5_PLUGIN_PATH"
+    if test -z "$HDF5_PLUGIN_PATH"; then
+        export HDF5_PLUGIN_PATH="../hdf5_plugins/LZ4/src/.libs"
+    else
+        export HDF5_PLUGIN_PATH="../hdf5_plugins/LZ4/src/.libs:$HDF5_PLUGIN_PATH"
+    fi
 
     # Run the HDF5 test.
     ./tst_h_lz4


### PR DESCRIPTION
## Problem

Fortran example tests in `examples/f_classic` and `examples/f_netcdf-4` were failing at runtime because `libhdf5_hl.so` could not be found. Root cause: `libnetcdff.so` was built against HDF5 1.14.6 and has that path baked into its RUNPATH, but HDF5 2.0.0 is installed at a different location. The automake `serial-tests` harness does not propagate `AM_TESTS_ENVIRONMENT` to test processes, so `LD_LIBRARY_PATH` was never being set for the Fortran test binaries.

Additionally, `ftest/run_tests.sh.in` was constructing `HDF5_PLUGIN_PATH` with a trailing colon when the variable was unset, causing HDF5 to error with `plugin_path parameter cannot have length zero`.

## Fix

- Switch `examples/f_classic` and `examples/f_netcdf-4` from `serial-tests` to `parallel-tests`; the parallel harness correctly prepends `AM_TESTS_ENVIRONMENT` to each test invocation, passing `LD_LIBRARY_PATH=$(MY_LD_LIBRARY_PATH):$$LD_LIBRARY_PATH` to every test process
- Fix `ftest/run_tests.sh.in` to guard against an unset `HDF5_PLUGIN_PATH` when appending plugin paths, avoiding the empty-component error