### PR TITLE
V1.11.0 Sprint 2: Add Fortran NcZarr example (f_nczarr_simple.f90)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,6 +222,10 @@ examples/parallelIO/f_square16_par
 # Example binaries - NcZarr
 examples/nczarr/nczarr_simple
 examples/nczarr/simple_nczarr.zarr
+examples/nczarr/f_nczarr_simple
+examples/nczarr/f_simple_nczarr.zarr
+examples/nczarr/test_nczarr_simple.sh
+examples/nczarr/test_f_nczarr_simple.sh
 
 # Valgrind logs
 valgrind*.log

--- a/configure.ac
+++ b/configure.ac
@@ -440,6 +440,30 @@ for flag in $LDFLAGS; do
             ;;
     esac
 done
+
+# Also derive HDF5 lib dir from nc-config --cflags (e.g. -I/path/hdf5/include -> /path/hdf5/lib).
+# This ensures test scripts find HDF5 even when the user only provides -L for NetCDF-C.
+if test "x$NC_CONFIG" != "x"; then
+    _nc_cflags=`$NC_CONFIG --cflags 2>/dev/null`
+    for flag in $_nc_cflags; do
+        case $flag in
+            -I*)
+                _inc_dir=`echo $flag | sed 's/^-I//'`
+                _maybe_lib=`echo $_inc_dir | sed 's|/include$|/lib|'`
+                if test "$_maybe_lib" != "$_inc_dir" && test -d "$_maybe_lib"; then
+                    # Only append if not already present
+                    case ":$MY_LD_LIBRARY_PATH:" in
+                        *":$_maybe_lib:"*) ;;
+                        *)
+                            MY_LD_LIBRARY_PATH="$MY_LD_LIBRARY_PATH:$_maybe_lib"
+                            ;;
+                    esac
+                fi
+                ;;
+        esac
+    done
+fi
+
 AC_MSG_CHECKING([runtime library path for tests])
 AC_MSG_RESULT([$MY_LD_LIBRARY_PATH])
 AC_SUBST([MY_LD_LIBRARY_PATH])
@@ -611,6 +635,7 @@ AC_CONFIG_FILES([test_h5/run_tests.sh], [chmod ugo+x test_h5/run_tests.sh])
 AC_CONFIG_FILES([examples/validate_cdl.sh], [chmod ugo+x examples/validate_cdl.sh])
 AC_CONFIG_FILES([examples/parallelIO/run_par_examples.sh], [chmod ugo+x examples/parallelIO/run_par_examples.sh])
 AC_CONFIG_FILES([examples/nczarr/test_nczarr_simple.sh], [chmod ugo+x examples/nczarr/test_nczarr_simple.sh])
+AC_CONFIG_FILES([examples/nczarr/test_f_nczarr_simple.sh], [chmod ugo+x examples/nczarr/test_f_nczarr_simple.sh])
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile

--- a/docs/plan/v1.11.0-sprint2-nczarr-fortran.md
+++ b/docs/plan/v1.11.0-sprint2-nczarr-fortran.md
@@ -1,0 +1,400 @@
+<!-- Author: Edward Hartnett, Intelligent Data Design, Inc. -->
+<!-- Date: 2026-06-26 -->
+
+# V1.11.0 Sprint 2: Fortran NcZarr Example
+
+**Objective**: Create `examples/nczarr/f_nczarr_simple.f90` — the Fortran equivalent of `nczarr_simple.c` — producing the same 4×5 `float temperature(y, x)` dataset in a local NcZarr store. The example lives alongside the C source in `examples/nczarr/` and is gated on both `HAVE_NCZARR` (inherited from the parent subdir) and `ENABLE_FORTRAN` / `NetCDF_Fortran_FOUND` within the subdirectory.
+
+---
+
+## Background
+
+Sprint 1 established the `examples/nczarr/` directory, build gating on `NC_HAS_NCZARR`, and the `nczarr_simple.c` C example. Sprint 2 adds the Fortran equivalent in the same directory, following the `parallelIO/` precedent where C and Fortran programs share one directory.
+
+**Storage URL**: `file://f_simple_nczarr.zarr#mode=nczarr`
+
+Using a distinct Zarr store name (`f_simple_nczarr` vs `simple_nczarr`) avoids race conditions when the C and Fortran tests run in parallel under `AUTOMAKE_OPTIONS = parallel-tests`.
+
+**Dataset**: 2D temperature on a 4×5 y×x grid, `NF90_FLOAT`, with `units` and `long_name` attributes — identical content to `nczarr_simple.c`.
+
+**Fortran column-major note**: In Fortran the dimension order is reversed from C. The C program declares `dimids[0]=y, dimids[1]=x` and arrays as `float data[NY][NX]`. The Fortran equivalent declares `dimids(1)=x_dimid, dimids(2)=y_dimid` and `real :: data(NX, NY)`, which produces the same logical (y,x) variable in the file.
+
+---
+
+## Dependencies
+
+- **Sprint 1 (Complete)**: `examples/nczarr/` directory, `HAVE_NCZARR` detection in CMake and Autotools, `nczarr_simple.c`, `examples/nczarr/CMakeLists.txt`, `examples/nczarr/Makefile.am`.
+- **NetCDF-Fortran**: Must be present (`NetCDF_Fortran_FOUND` in CMake; `enable_fortran=yes` in Autotools).
+
+---
+
+## Tasks
+
+### 1. Create `examples/nczarr/f_nczarr_simple.f90`
+
+**File**: `examples/nczarr/f_nczarr_simple.f90`
+
+Fortran 90 program using the `netcdf` module (`use netcdf`). Error handling via `handle_err` subroutine (matching `f_simple_nc4.f90` style). Compact `print *` output matching NEP conventions.
+
+```fortran
+!> @file f_nczarr_simple.f90
+!! @brief Demonstrate creating, writing, and reading a local NcZarr dataset (Fortran).
+!!
+!! Fortran equivalent of nczarr_simple.c. Creates a 4x5 temperature array in a
+!! local NcZarr Zarr store, attaches units and long_name attributes, closes the
+!! dataset, reopens it read-only, and verifies metadata and data values.
+!!
+!! **Learning Objectives:**
+!! - Use `file://...#mode=nczarr` URL from Fortran via nf90_create / nf90_open
+!! - Apply the same nf90_def_dim, nf90_def_var, nf90_put_att, nf90_put_var APIs
+!!   used for NetCDF-4/HDF5 files
+!! - Understand Fortran column-major dimension ordering vs C row-major
+!! - Validate a round-trip write/read through the Fortran NetCDF API
+!!
+!! **Key Concepts:**
+!! - **NcZarr**: NetCDF-4 data model backed by Zarr V2 storage
+!! - **URL fragment**: `#mode=nczarr` selects the NcZarr dispatcher
+!! - **Fortran column-major**: dimids(1)=x, dimids(2)=y produces temperature(y,x) in the file
+!! - **NF90_NETCDF4**: Required mode flag for NcZarr
+!!
+!! **Fortran vs C Differences:**
+!! - Array declaration: Fortran `real :: data(NX, NY)` vs C `float data[NY][NX]`
+!! - Dimension order: Fortran dimids(1)=x, dimids(2)=y vs C dimids[0]=y, dimids[1]=x
+!! - API prefix: Fortran nf90_* vs C nc_*
+!!
+!! **Related Examples:**
+!! - nczarr_simple.c - C equivalent
+!! - f_simple_nc4.f90 - NetCDF-4/HDF5 Fortran example
+!!
+!! **Compilation:**
+!! @code
+!! gfortran -o f_nczarr_simple f_nczarr_simple.f90 -lnetcdff -lnetcdf
+!! @endcode
+!!
+!! **Usage:**
+!! @code
+!! ./f_nczarr_simple
+!! ncdump 'file://f_simple_nczarr.zarr#mode=nczarr'
+!! @endcode
+!!
+!! @author Edward Hartnett, Intelligent Data Design, Inc.
+!! @date 2026-06-26
+
+program f_nczarr_simple
+   use netcdf
+   implicit none
+
+   character(len=*), parameter :: FILE_URL = "file://f_simple_nczarr.zarr#mode=nczarr"
+   integer, parameter :: NX = 5, NY = 4
+   integer, parameter :: NDIMS = 2
+
+   integer :: ncid, varid, retval
+   integer :: y_dimid, x_dimid
+   integer :: dimids(NDIMS)
+   integer :: ndims_in, nvars_in
+   integer :: len_y, len_x
+   integer :: i, j, errors
+   real :: data_out(NX, NY), data_in(NX, NY)
+   real :: expected_val
+
+   ! Generate a simple 2D temperature field (same formula as nczarr_simple.c).
+   ! Fortran is column-major: data_out(i, j) where i=x-index, j=y-index.
+   do j = 1, NY
+      do i = 1, NX
+         data_out(i, j) = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+      end do
+   end do
+
+   ! Create a local NcZarr dataset.
+   retval = nf90_create(FILE_URL, NF90_CLOBBER + NF90_NETCDF4, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Define dimensions. Fortran reverses C order: x first, then y.
+   retval = nf90_def_dim(ncid, "x", NX, x_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_def_dim(ncid, "y", NY, y_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! dimids(1)=x, dimids(2)=y produces temperature(y, x) in the file.
+   dimids(1) = x_dimid
+   dimids(2) = y_dimid
+   retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_att(ncid, varid, "units", "K")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "long_name", "Temperature")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "_FillValue", -999.0)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_enddef(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_var(ncid, varid, data_out)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Created ", FILE_URL
+
+   ! Reopen the dataset and validate metadata.
+   retval = nf90_open(FILE_URL, NF90_NOWRITE, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire(ncid, ndims_in, nvars_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_dimension(ncid, y_dimid, len=len_y)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_inquire_dimension(ncid, x_dimid, len=len_x)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Dataset:", ndims_in, "dims,", nvars_in, "vars, y=", len_y, ", x=", len_x
+
+   retval = nf90_inq_varid(ncid, "temperature", varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_get_var(ncid, varid, data_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Verify the data read back.
+   errors = 0
+   do j = 1, NY
+      do i = 1, NX
+         expected_val = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+         if (data_in(i, j) /= expected_val) then
+            print *, "Mismatch at", i, j, ": got", data_in(i, j), ", expected", expected_val
+            errors = errors + 1
+         end if
+      end do
+   end do
+
+   if (errors > 0) then
+      print *, "*** FAILED:", errors, "data validation errors"
+      stop 2
+   end if
+
+   print *, "Read", NX * NY, "values, all correct. Done."
+
+contains
+   subroutine handle_err(status)
+      integer, intent(in) :: status
+      print *, "Error: ", trim(nf90_strerror(status))
+      stop 2
+   end subroutine handle_err
+
+end program f_nczarr_simple
+```
+
+### 2. Update `examples/nczarr/CMakeLists.txt`
+
+Add the Fortran example after the existing C example block, gated on `ENABLE_FORTRAN` and `NetCDF_Fortran_FOUND`:
+
+```cmake
+# Fortran NcZarr example — only built when Fortran is enabled and NetCDF-Fortran is found
+if(ENABLE_FORTRAN AND NetCDF_Fortran_FOUND)
+    find_program(NF_CONFIG nf-config
+        HINTS ${NetCDF_Fortran_LIBRARY_DIRS}/../bin
+        PATHS ${NetCDF_Fortran_LIBRARY_DIRS}/../bin
+    )
+
+    if(NOT NF_CONFIG)
+        message(STATUS "nf-config not found — skipping f_nczarr_simple")
+    else()
+        execute_process(
+            COMMAND ${NF_CONFIG} --fflags
+            OUTPUT_VARIABLE NF_FFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND ${NF_CONFIG} --flibs
+            OUTPUT_VARIABLE NF_LIBS_F
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        separate_arguments(NF_FFLAGS_LIST UNIX_COMMAND "${NF_FFLAGS}")
+        separate_arguments(NF_LIBS_F_LIST UNIX_COMMAND "${NF_LIBS_F}")
+
+        add_executable(f_nczarr_simple f_nczarr_simple.f90)
+        target_compile_options(f_nczarr_simple PRIVATE ${NF_FFLAGS_LIST})
+        target_link_directories(f_nczarr_simple PRIVATE ${HDF5_LIB_DIR})
+        target_link_libraries(f_nczarr_simple PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
+        set_target_properties(f_nczarr_simple PROPERTIES
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+            SKIP_BUILD_RPATH OFF
+            BUILD_WITH_INSTALL_RPATH ON
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+        if(BUILD_TESTING)
+            add_test(NAME f_nczarr_simple
+                     COMMAND f_nczarr_simple
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_simple PROPERTIES ENVIRONMENT "${_nep_ld_env}")
+
+            add_test(NAME f_nczarr_simple_validate
+                     COMMAND bash -c "./f_nczarr_simple && bash validate_cdl.sh f_nczarr_simple 'file://f_simple_nczarr.zarr#mode=nczarr' ${CMAKE_CURRENT_SOURCE_DIR}/../expected_output/f_nczarr_simple_expected.cdl"
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_simple_validate PROPERTIES
+                                 DEPENDS f_nczarr_simple
+                                 ENVIRONMENT "${_nep_ld_env}")
+        endif()
+    endif()
+endif()
+```
+
+### 3. Update `examples/nczarr/Makefile.am`
+
+Add the Fortran program inside `if ENABLE_FORTRAN` to the existing `Makefile.am`:
+
+```makefile
+# Fortran NcZarr example — only built when Fortran is enabled (v1.11.0 sprint 2)
+if ENABLE_FORTRAN
+AM_FCFLAGS = $(CPPFLAGS)
+
+check_PROGRAMS += f_nczarr_simple
+f_nczarr_simple_SOURCES = f_nczarr_simple.f90
+f_nczarr_simple_LDADD = -lnetcdff
+
+TESTS += test_f_nczarr_simple.sh
+EXTRA_DIST += test_f_nczarr_simple.sh.in
+endif
+```
+
+Also extend `clean-local` to remove `f_simple_nczarr.zarr`:
+
+```makefile
+clean-local:
+	rm -rf simple_nczarr.zarr f_simple_nczarr.zarr
+```
+
+### 4. Create `examples/nczarr/test_f_nczarr_simple.sh.in`
+
+**File**: `examples/nczarr/test_f_nczarr_simple.sh.in`
+
+```bash
+#!/bin/bash
+# Run f_nczarr_simple and validate output CDL
+# Edward Hartnett, Intelligent Data Design, Inc.
+# 2026-06-26
+
+if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+    export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@:$LD_LIBRARY_PATH
+else
+    export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+fi
+
+./f_nczarr_simple
+bash ${srcdir}/../validate_cdl.sh f_nczarr_simple 'file://f_simple_nczarr.zarr#mode=nczarr' ${srcdir}/../expected_output/f_nczarr_simple_expected.cdl
+```
+
+### 5. Update `configure.ac`
+
+Add the Fortran test script to `AC_CONFIG_FILES` alongside the C test script:
+
+```bash
+AC_CONFIG_FILES([examples/nczarr/test_f_nczarr_simple.sh], [chmod ugo+x examples/nczarr/test_f_nczarr_simple.sh])
+```
+
+### 6. Generate Expected CDL Output
+
+**File**: `examples/expected_output/f_nczarr_simple_expected.cdl`
+
+Capture from `ncdump 'file://f_simple_nczarr.zarr#mode=nczarr'` after the example runs. Expected content (subject to ncdump formatting):
+
+```cdl
+netcdf f_simple_nczarr {
+dimensions:
+	y = 4 ;
+	x = 5 ;
+variables:
+	float temperature(y, x) ;
+		temperature:units = "K" ;
+		temperature:long_name = "Temperature" ;
+		temperature:_FillValue = -999.f ;
+data:
+
+ temperature =
+  280, 280.5, 281, 281.5, 282,
+  282, 282.5, 283, 283.5, 284,
+  284, 284.5, 285, 285.5, 286,
+  286, 286.5, 287, 287.5, 288 ;
+}
+```
+
+**Note**: Capture the actual CDL from a live run before committing the expected file. If NcZarr adds runtime-specific global attributes, rely on the example's internal validation (return code) and skip the CDL diff in `test_f_nczarr_simple.sh`.
+
+### 7. Update `docs/prd.md`
+
+Extend the existing **NcZarr Examples (C) (v1.11.0)** subsection to cover the Fortran example:
+
+- Rename the heading to **NcZarr Examples (v1.11.0)**
+- Add `f_nczarr_simple.f90` bullet under a **Fortran** sub-list
+- Note the distinct store name `f_simple_nczarr.zarr` and the `ENABLE_FORTRAN` gate
+
+### 8. Update `docs/roadmap.md`
+
+Replace the terse Sprint 2 entry with a reference to this plan file and a concise summary.
+
+---
+
+## Definition of Done
+
+- [ ] `examples/nczarr/f_nczarr_simple.f90` created, produces same 4×5 temperature data as C example.
+- [ ] Uses `file://f_simple_nczarr.zarr#mode=nczarr` (distinct from C example's store).
+- [ ] `examples/nczarr/CMakeLists.txt` builds `f_nczarr_simple` when `ENABLE_FORTRAN` and `NetCDF_Fortran_FOUND`.
+- [ ] `examples/nczarr/Makefile.am` builds and tests `f_nczarr_simple` under `if ENABLE_FORTRAN`.
+- [ ] `examples/nczarr/test_f_nczarr_simple.sh.in` created; configured by `configure.ac`.
+- [ ] `configure.ac` lists `examples/nczarr/test_f_nczarr_simple.sh` in `AC_CONFIG_FILES`.
+- [ ] `clean-local` removes both `simple_nczarr.zarr` and `f_simple_nczarr.zarr`.
+- [ ] `examples/expected_output/f_nczarr_simple_expected.cdl` captured from live run.
+- [ ] `docs/prd.md` NcZarr section updated to cover Fortran example.
+- [ ] `docs/roadmap.md` Sprint 2 entry updated to reference this plan.
+- [ ] Example compiles and passes with both CMake and Autotools on a Fortran + NcZarr build.
+
+---
+
+## Key API Functions Demonstrated
+
+| Fortran Function | C Equivalent | Purpose |
+|------------------|-------------|---------|
+| `nf90_create()` with `file://...#mode=nczarr` | `nc_create()` | Create local NcZarr dataset |
+| `nf90_open()` with `file://...#mode=nczarr` | `nc_open()` | Open existing NcZarr dataset |
+| `nf90_def_dim()` | `nc_def_dim()` | Define dimensions |
+| `nf90_def_var()` | `nc_def_var()` | Define a variable |
+| `nf90_put_att()` | `nc_put_att_text()` | Add text attributes |
+| `nf90_put_var()` / `nf90_get_var()` | `nc_put_var_float()` / `nc_get_var_float()` | Write and read data |
+| `nf90_inquire()` | `nc_inq()` | Query file metadata |
+
+---
+
+## Dataset Specifications
+
+| Attribute | Value |
+|-----------|-------|
+| Dimensions | y = 4, x = 5 |
+| Variable | `temperature(y, x)` of type `NF90_FLOAT` |
+| Attributes | `units = "K"`, `long_name = "Temperature"`, `_FillValue = -999.0` |
+| Storage | Local NcZarr directory `f_simple_nczarr.zarr` |
+| Data formula | `280.0 + (y_idx) * 2.0 + (x_idx) * 0.5` (0-based indices) |
+
+---
+
+## Dependencies Between Sprints
+
+- **Sprint 1 (Complete)**: `examples/nczarr/` directory, `HAVE_NCZARR` detection, C example.
+- **Sprint 2 (This sprint)**: Fortran equivalent in same directory.
+- **Future sprints**: NcZarr chunking, compression, or groups examples.
+
+---
+
+## Notes
+
+- **Same directory as C**: Follows `parallelIO/` precedent; avoids new build system wiring for the parent `examples/CMakeLists.txt` and `examples/Makefile.am`.
+- **Distinct store name**: `f_simple_nczarr.zarr` prevents parallel-test collisions with `simple_nczarr.zarr`.
+- **Fortran column-major**: `dimids(1)=x, dimids(2)=y` is correct; NetCDF stores the variable as `temperature(y, x)` in the file regardless of the Fortran declaration order.
+- **`_FillValue` attribute**: Added via `nf90_put_att` rather than `nf90_def_var_fill` to match the C example's `nc_put_att_float` approach and CF convention.
+- **CDL stability**: Same caveat as Sprint 1 — skip CDL diff if NcZarr adds runtime-specific global attributes.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -296,11 +296,16 @@ Located in `examples/performance/`:
 
 **Note**: Performance examples are excluded from regular CI. They are built and run only when `ENABLE_BENCHMARKS=ON` (CMake) or `--enable-benchmarks` (Autotools) is specified. All four examples operate on a 500×180×360 (time×lat×lon) NC_FLOAT temperature dataset matching a meteorological grid.
 
-#### NcZarr Examples (C) (v1.11.0)
+#### NcZarr Examples (v1.11.0)
 Located in `examples/nczarr/`:
-- `nczarr_simple.c` - Create, write, and read a local NcZarr dataset; demonstrates `file://...#mode=nczarr` URL, dimensions, variables, attributes, and data verification
 
-**Note**: NcZarr examples are only built when NetCDF-C reports NcZarr support (`NC_HAS_NCZARR` in `netcdf_meta.h`) and examples are enabled. The example produces a local Zarr directory store rather than a single file.
+**C examples** (Sprint 1):
+- `nczarr_simple.c` - Create, write, and read a local NcZarr dataset; demonstrates `file://simple_nczarr.zarr#mode=nczarr` URL, dimensions, variables, attributes, and data verification
+
+**Fortran examples** (Sprint 2):
+- `f_nczarr_simple.f90` - Fortran equivalent of `nczarr_simple.c`; produces the same 4×5 `temperature(y, x)` dataset at `file://f_simple_nczarr.zarr#mode=nczarr`; demonstrates Fortran column-major dimension ordering with NcZarr
+
+**Note**: NcZarr examples are only built when NetCDF-C reports NcZarr support (`NC_HAS_NCZARR` in `netcdf_meta.h`) and examples are enabled. The Fortran example additionally requires `--enable-fortran` (Autotools) or `ENABLE_FORTRAN=ON` (CMake). Each example writes to a distinct Zarr directory store to allow safe parallel test execution.
 
 ### 8.4 Build Configuration
 **CMake:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,6 +26,31 @@
 - Generate expected CDL output and validation (or rely on internal validation if CDL is unstable)
 - Update `docs/prd.md` with an NcZarr Examples subsection
 
+#### Sprint 2: Fortran NcZarr Example
+**Detailed Plan**: See `docs/plan/v1.11.0-sprint2-nczarr-fortran.md`
+
+**Purpose**: Add `examples/nczarr/f_nczarr_simple.f90` — the Fortran equivalent of `nczarr_simple.c` — producing the same 4×5 `temperature(y, x)` dataset at `file://f_simple_nczarr.zarr#mode=nczarr`.
+
+**What it shows**:
+- `nf90_create()` / `nf90_open()` with a `file://...#mode=nczarr` URL
+- Fortran column-major dimension ordering: `dimids(1)=x, dimids(2)=y` produces `temperature(y, x)` in the file
+- Same `nf90_def_dim()`, `nf90_def_var()`, `nf90_put_att()`, `nf90_put_var()`, `nf90_get_var()` APIs used for NetCDF-4/HDF5 files
+- Distinct store name `f_simple_nczarr.zarr` avoids parallel-test collisions with the C example
+
+**Key API**: `nf90_create()`, `nf90_open()`, `nf90_def_dim()`, `nf90_def_var()`, `nf90_put_att()`, `nf90_put_var()`, `nf90_get_var()`
+
+**Build Gating**: Built only when `HAVE_NCZARR` (inherited from parent subdir) and `ENABLE_FORTRAN` are both true.
+
+**Tasks**:
+- Create `examples/nczarr/f_nczarr_simple.f90`
+- Update `examples/nczarr/CMakeLists.txt` — add `f_nczarr_simple` gated on `ENABLE_FORTRAN AND NetCDF_Fortran_FOUND`
+- Update `examples/nczarr/Makefile.am` — add `f_nczarr_simple` inside `if ENABLE_FORTRAN`; extend `clean-local` for `f_simple_nczarr.zarr`
+- Create `examples/nczarr/test_f_nczarr_simple.sh.in`
+- Add `examples/nczarr/test_f_nczarr_simple.sh` to `configure.ac` `AC_CONFIG_FILES`
+- Generate `examples/expected_output/f_nczarr_simple_expected.cdl` from live `ncdump` output
+- Update `docs/prd.md` NcZarr section to cover Fortran example
+
+
 ### V1.10.0 More Performance Examples
 
 #### Sprint 1: Add example: cache_tuning.c — Chunk Cache Configuration

--- a/examples/expected_output/f_nczarr_simple_expected.cdl
+++ b/examples/expected_output/f_nczarr_simple_expected.cdl
@@ -1,0 +1,17 @@
+netcdf f_simple_nczarr {
+dimensions:
+	x = 5 ;
+	y = 4 ;
+variables:
+	float temperature(y, x) ;
+		temperature:units = "K" ;
+		temperature:long_name = "Temperature" ;
+		temperature:_FillValue = -999.f ;
+data:
+
+ temperature =
+  280, 280.5, 281, 281.5, 282,
+  282, 282.5, 283, 283.5, 284,
+  284, 284.5, 285, 285.5, 286,
+  286, 286.5, 287, 287.5, 288 ;
+}

--- a/examples/nczarr/CMakeLists.txt
+++ b/examples/nczarr/CMakeLists.txt
@@ -43,8 +43,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-set(_nep_ld_env "LD_LIBRARY_PATH=${HDF5_LIB_DIR}:${NC_LIBDIR}:$ENV{LD_LIBRARY_PATH}")
-
 add_executable(nczarr_simple nczarr_simple.c)
 target_compile_options(nczarr_simple PRIVATE ${NC_CFLAGS_LIST})
 target_link_directories(nczarr_simple PRIVATE ${HDF5_LIB_DIR})
@@ -59,7 +57,9 @@ if(BUILD_TESTING)
     add_test(NAME nczarr_simple
              COMMAND nczarr_simple
              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-    set_tests_properties(nczarr_simple PROPERTIES ENVIRONMENT "${_nep_ld_env}")
+    set_tests_properties(nczarr_simple PROPERTIES
+        ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
 endif()
 
 # Configure validation script with ncdump path from top-level CMakeLists.txt
@@ -73,7 +73,8 @@ if(BUILD_TESTING)
              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     set_tests_properties(nczarr_simple_validate PROPERTIES
                          DEPENDS nczarr_simple
-                         ENVIRONMENT "${_nep_ld_env}")
+                         ENVIRONMENT_MODIFICATION
+                             "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
 endif()
 
 # Fortran NcZarr example — only built when Fortran is enabled and NetCDF-Fortran is found (v1.11.0 sprint 2)
@@ -99,28 +100,41 @@ if(ENABLE_FORTRAN AND NetCDF_Fortran_FOUND)
         separate_arguments(NF_FFLAGS_LIST UNIX_COMMAND "${NF_FFLAGS}")
         separate_arguments(NF_LIBS_F_LIST UNIX_COMMAND "${NF_LIBS_F}")
 
+        # Extract the NetCDF-Fortran lib dir from --flibs since --libdir is not
+        # supported by all nf-config versions.
+        set(NF_LIBDIR "")
+        foreach(_flag IN LISTS NF_LIBS_F_LIST)
+            if(_flag MATCHES "^-L(.+)")
+                set(NF_LIBDIR "${CMAKE_MATCH_1}")
+                break()
+            endif()
+        endforeach()
+
         add_executable(f_nczarr_simple f_nczarr_simple.f90)
         target_compile_options(f_nczarr_simple PRIVATE ${NF_FFLAGS_LIST})
-        target_link_directories(f_nczarr_simple PRIVATE ${HDF5_LIB_DIR})
+        target_link_directories(f_nczarr_simple PRIVATE ${HDF5_LIB_DIR} ${NF_LIBDIR})
         target_link_libraries(f_nczarr_simple PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
         set_target_properties(f_nczarr_simple PROPERTIES
-            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}"
             SKIP_BUILD_RPATH OFF
             BUILD_WITH_INSTALL_RPATH ON
-            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}")
 
         if(BUILD_TESTING)
             add_test(NAME f_nczarr_simple
                      COMMAND f_nczarr_simple
                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-            set_tests_properties(f_nczarr_simple PROPERTIES ENVIRONMENT "${_nep_ld_env}")
+            set_tests_properties(f_nczarr_simple PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
 
             add_test(NAME f_nczarr_simple_validate
                      COMMAND bash -c "./f_nczarr_simple && bash validate_cdl.sh f_nczarr_simple 'file://f_simple_nczarr.zarr#mode=nczarr' ${CMAKE_CURRENT_SOURCE_DIR}/../expected_output/f_nczarr_simple_expected.cdl"
                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
             set_tests_properties(f_nczarr_simple_validate PROPERTIES
                                  DEPENDS f_nczarr_simple
-                                 ENVIRONMENT "${_nep_ld_env}")
+                                 ENVIRONMENT_MODIFICATION
+                                     "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
         endif()
     endif()
 endif()

--- a/examples/nczarr/CMakeLists.txt
+++ b/examples/nczarr/CMakeLists.txt
@@ -75,3 +75,52 @@ if(BUILD_TESTING)
                          DEPENDS nczarr_simple
                          ENVIRONMENT "${_nep_ld_env}")
 endif()
+
+# Fortran NcZarr example — only built when Fortran is enabled and NetCDF-Fortran is found (v1.11.0 sprint 2)
+if(ENABLE_FORTRAN AND NetCDF_Fortran_FOUND)
+    find_program(NF_CONFIG nf-config
+        HINTS ${NetCDF_Fortran_LIBRARY_DIRS}/../bin
+        PATHS ${NetCDF_Fortran_LIBRARY_DIRS}/../bin
+    )
+
+    if(NOT NF_CONFIG)
+        message(STATUS "nf-config not found — skipping f_nczarr_simple")
+    else()
+        execute_process(
+            COMMAND ${NF_CONFIG} --fflags
+            OUTPUT_VARIABLE NF_FFLAGS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND ${NF_CONFIG} --flibs
+            OUTPUT_VARIABLE NF_LIBS_F
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        separate_arguments(NF_FFLAGS_LIST UNIX_COMMAND "${NF_FFLAGS}")
+        separate_arguments(NF_LIBS_F_LIST UNIX_COMMAND "${NF_LIBS_F}")
+
+        add_executable(f_nczarr_simple f_nczarr_simple.f90)
+        target_compile_options(f_nczarr_simple PRIVATE ${NF_FFLAGS_LIST})
+        target_link_directories(f_nczarr_simple PRIVATE ${HDF5_LIB_DIR})
+        target_link_libraries(f_nczarr_simple PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
+        set_target_properties(f_nczarr_simple PROPERTIES
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+            SKIP_BUILD_RPATH OFF
+            BUILD_WITH_INSTALL_RPATH ON
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+        if(BUILD_TESTING)
+            add_test(NAME f_nczarr_simple
+                     COMMAND f_nczarr_simple
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_simple PROPERTIES ENVIRONMENT "${_nep_ld_env}")
+
+            add_test(NAME f_nczarr_simple_validate
+                     COMMAND bash -c "./f_nczarr_simple && bash validate_cdl.sh f_nczarr_simple 'file://f_simple_nczarr.zarr#mode=nczarr' ${CMAKE_CURRENT_SOURCE_DIR}/../expected_output/f_nczarr_simple_expected.cdl"
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_simple_validate PROPERTIES
+                                 DEPENDS f_nczarr_simple
+                                 ENVIRONMENT "${_nep_ld_env}")
+        endif()
+    endif()
+endif()

--- a/examples/nczarr/Makefile.am
+++ b/examples/nczarr/Makefile.am
@@ -16,10 +16,22 @@ TESTS = nczarr_simple test_nczarr_simple.sh
 
 EXTRA_DIST = test_nczarr_simple.sh.in
 
+# Fortran NcZarr example — only built when Fortran is enabled (v1.11.0 sprint 2)
+if ENABLE_FORTRAN
+AM_FCFLAGS = $(CPPFLAGS)
+
+check_PROGRAMS += f_nczarr_simple
+f_nczarr_simple_SOURCES = f_nczarr_simple.f90
+f_nczarr_simple_LDADD = -lnetcdff
+
+TESTS += test_f_nczarr_simple.sh
+EXTRA_DIST += test_f_nczarr_simple.sh.in
+endif
+
 # Ensure built binaries are executable before test scripts run them
 check-local:
 	chmod +x $(check_PROGRAMS)
 
-# NcZarr produces a directory tree, not a single file
+# NcZarr produces directory trees, not single files
 clean-local:
-	rm -rf simple_nczarr.zarr
+	rm -rf simple_nczarr.zarr f_simple_nczarr.zarr

--- a/examples/nczarr/f_nczarr_simple.f90
+++ b/examples/nczarr/f_nczarr_simple.f90
@@ -1,0 +1,159 @@
+!> @file f_nczarr_simple.f90
+!! @brief Demonstrate creating, writing, and reading a local NcZarr dataset (Fortran).
+!!
+!! Fortran equivalent of nczarr_simple.c. Creates a 4x5 temperature array in a
+!! local NcZarr Zarr store, attaches units, long_name, and _FillValue attributes,
+!! closes the dataset, reopens it read-only, and verifies metadata and data values.
+!!
+!! **Learning Objectives:**
+!! - Use `file://...#mode=nczarr` URL from Fortran via nf90_create / nf90_open
+!! - Apply the same nf90_def_dim, nf90_def_var, nf90_put_att, nf90_put_var APIs
+!!   used for NetCDF-4/HDF5 files
+!! - Understand Fortran column-major dimension ordering vs C row-major
+!! - Validate a round-trip write/read through the Fortran NetCDF API
+!!
+!! **Key Concepts:**
+!! - **NcZarr**: NetCDF-4 data model backed by Zarr V2 storage
+!! - **URL fragment**: `#mode=nczarr` selects the NcZarr dispatcher
+!! - **Fortran column-major**: dimids(1)=x, dimids(2)=y produces temperature(y,x) in the file
+!! - **NF90_NETCDF4**: Required mode flag for NcZarr
+!!
+!! **Fortran vs C Differences:**
+!! - Array declaration: Fortran `real :: data(NX, NY)` vs C `float data[NY][NX]`
+!! - Dimension order: Fortran dimids(1)=x, dimids(2)=y vs C dimids[0]=y, dimids[1]=x
+!! - API prefix: Fortran nf90_* vs C nc_*
+!!
+!! **Related Examples:**
+!! - nczarr_simple.c - C equivalent
+!! - f_simple_nc4.f90 - NetCDF-4/HDF5 Fortran example
+!!
+!! **Compilation:**
+!! @code
+!! gfortran -o f_nczarr_simple f_nczarr_simple.f90 -lnetcdff -lnetcdf
+!! @endcode
+!!
+!! **Usage:**
+!! @code
+!! ./f_nczarr_simple
+!! ncdump 'file://f_simple_nczarr.zarr#mode=nczarr'
+!! @endcode
+!!
+!! **Expected Output:**
+!! Creates the directory f_simple_nczarr.zarr containing:
+!! - 2 dimensions: y(4), x(5)
+!! - 1 variable: temperature(y, x) of type NF90_FLOAT
+!! - Attributes: units="K", long_name="Temperature", _FillValue=-999.0
+!! - A 4x5 temperature data grid (same values as nczarr_simple.c)
+!!
+!! @author Edward Hartnett, Intelligent Data Design, Inc.
+!! @date 2026-06-26
+
+program f_nczarr_simple
+   use netcdf
+   implicit none
+
+   character(len=*), parameter :: FILE_URL = "file://f_simple_nczarr.zarr#mode=nczarr"
+   integer, parameter :: NX = 5, NY = 4
+   integer, parameter :: NDIMS = 2
+
+   integer :: ncid, varid, retval
+   integer :: y_dimid, x_dimid
+   integer :: dimids(NDIMS)
+   integer :: ndims_in, nvars_in
+   integer :: len_y, len_x
+   integer :: i, j, errors
+   real :: data_out(NX, NY), data_in(NX, NY)
+   real :: expected_val
+
+   ! Generate a simple 2D temperature field (same formula as nczarr_simple.c).
+   ! Fortran is column-major: data_out(i, j) where i=x-index, j=y-index.
+   do j = 1, NY
+      do i = 1, NX
+         data_out(i, j) = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+      end do
+   end do
+
+   ! Create a local NcZarr dataset.
+   retval = nf90_create(FILE_URL, NF90_CLOBBER + NF90_NETCDF4, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Define dimensions. Fortran reverses C order: x first, then y.
+   retval = nf90_def_dim(ncid, "x", NX, x_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_def_dim(ncid, "y", NY, y_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! dimids(1)=x, dimids(2)=y produces temperature(y, x) in the file.
+   dimids(1) = x_dimid
+   dimids(2) = y_dimid
+   retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_att(ncid, varid, "units", "K")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "long_name", "Temperature")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "_FillValue", -999.0)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_enddef(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_var(ncid, varid, data_out)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Created ", FILE_URL
+
+   ! Reopen the dataset and validate metadata.
+   retval = nf90_open(FILE_URL, NF90_NOWRITE, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire(ncid, ndims_in, nvars_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_dimension(ncid, y_dimid, len=len_y)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_inquire_dimension(ncid, x_dimid, len=len_x)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Dataset:", ndims_in, "dims,", nvars_in, "vars, y=", len_y, ", x=", len_x
+
+   retval = nf90_inq_varid(ncid, "temperature", varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_get_var(ncid, varid, data_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Verify the data read back.
+   errors = 0
+   do j = 1, NY
+      do i = 1, NX
+         expected_val = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+         if (data_in(i, j) /= expected_val) then
+            print *, "Mismatch at", i, j, ": got", data_in(i, j), ", expected", expected_val
+            errors = errors + 1
+         end if
+      end do
+   end do
+
+   if (errors > 0) then
+      print *, "*** FAILED:", errors, "data validation errors"
+      stop 2
+   end if
+
+   print *, "Read", NX * NY, "values, all correct. Done."
+
+contains
+   subroutine handle_err(status)
+      integer, intent(in) :: status
+      print *, "Error: ", trim(nf90_strerror(status))
+      stop 2
+   end subroutine handle_err
+
+end program f_nczarr_simple

--- a/examples/nczarr/test_f_nczarr_simple.sh.in
+++ b/examples/nczarr/test_f_nczarr_simple.sh.in
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Run f_nczarr_simple and validate output CDL
+# Edward Hartnett, Intelligent Data Design, Inc.
+# 2026-06-26
+
+if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
+    export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@:$LD_LIBRARY_PATH
+else
+    export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+fi
+
+./f_nczarr_simple
+bash ${srcdir}/../validate_cdl.sh f_nczarr_simple 'file://f_simple_nczarr.zarr#mode=nczarr' ${srcdir}/../expected_output/f_nczarr_simple_expected.cdl

--- a/examples/nczarr/test_nczarr_simple.sh
+++ b/examples/nczarr/test_nczarr_simple.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Run nczarr_simple and validate output CDL
+# Edward Hartnett, Intelligent Data Design, Inc.
+# 2026-06-26
 
 if [[ -n "${LD_LIBRARY_PATH:-}" ]]; then
-    export LD_LIBRARY_PATH=/home/ed/NEP/src/.libs:/usr/local/hdf5-2.1.0/lib:/usr/local/netcdf-c-4.10.0/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=/home/ed/NEP/src/.libs:/usr/local/hdf5-2.1.0/lib:/usr/local/netcdf-c-4.10.0/lib:/usr/local/netcdf-fortran/lib:$LD_LIBRARY_PATH
 else
-    export LD_LIBRARY_PATH=/home/ed/NEP/src/.libs:/usr/local/hdf5-2.1.0/lib:/usr/local/netcdf-c-4.10.0/lib
+    export LD_LIBRARY_PATH=/home/ed/NEP/src/.libs:/usr/local/hdf5-2.1.0/lib:/usr/local/netcdf-c-4.10.0/lib:/usr/local/netcdf-fortran/lib
 fi
 
 ./nczarr_simple


### PR DESCRIPTION
## Summary

Adds the Fortran equivalent of `nczarr_simple.c` (Sprint 1, #208) — a complete create/write/read/validate example using the NcZarr backend via the Fortran NetCDF API.

Detailed plan: `docs/plan/v1.11.0-sprint2-nczarr-fortran.md`

## Changes

- **`examples/nczarr/f_nczarr_simple.f90`** — Fortran NcZarr example: creates a 4×5 `temperature(y,x)` dataset at `file://f_simple_nczarr.zarr#mode=nczarr`, writes/reads data, validates all values
- **`examples/nczarr/test_f_nczarr_simple.sh.in`** — test script template; runs example and validates CDL output against expected
- **`examples/expected_output/f_nczarr_simple_expected.cdl`** — expected CDL for test validation
- **`examples/nczarr/CMakeLists.txt`** — add `f_nczarr_simple` gated on `ENABLE_FORTRAN AND NetCDF_Fortran_FOUND`
- **`examples/nczarr/Makefile.am`** — add `f_nczarr_simple` inside `if ENABLE_FORTRAN`; extend `clean-local` for `f_simple_nczarr.zarr`
- **`configure.ac`** — add `test_f_nczarr_simple.sh` to `AC_CONFIG_FILES`; extend `MY_LD_LIBRARY_PATH` with HDF5 lib dir derived from `nc-config --cflags`
- **`.gitignore`** — ignore Fortran NcZarr binary, generated test script, and zarr store directory
- **`docs/prd.md`** — extend NcZarr Examples section to cover Fortran example
- **`docs/roadmap.md`** — Sprint 2 entry with plan reference and summary
- **`docs/plan/v1.11.0-sprint2-nczarr-fortran.md`** — sprint plan

## Test Results

All 3 nczarr tests pass:
```
PASS: nczarr_simple
PASS: test_nczarr_simple.sh
PASS: test_f_nczarr_simple.sh
```

## Key Design Notes

- Uses distinct store name `f_simple_nczarr.zarr` to avoid parallel-test collisions with `simple_nczarr.zarr` (C example)
- Fortran column-major ordering: `dimids(1)=x, dimids(2)=y` produces `temperature(y,x)` in the file — same layout as the C example
- Gated on both `HAVE_NCZARR` (inherited from parent subdir) and `ENABLE_FORTRAN`