### PR TITLE
v1.11.0 Sprint 3: NcZarr chunking and compression examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,14 @@ examples/nczarr/f_nczarr_simple
 examples/nczarr/f_simple_nczarr.zarr
 examples/nczarr/test_nczarr_simple.sh
 examples/nczarr/test_f_nczarr_simple.sh
+examples/nczarr/nczarr_chunking
+examples/nczarr/nczarr_chunking.zarr
+examples/nczarr/nczarr_compression
+examples/nczarr/nczarr_compression.zarr
+examples/nczarr/f_nczarr_chunking
+examples/nczarr/f_nczarr_chunking.zarr
+examples/nczarr/f_nczarr_compression
+examples/nczarr/f_nczarr_compression.zarr
 
 # Valgrind logs
 valgrind*.log

--- a/README.md
+++ b/README.md
@@ -448,18 +448,18 @@ and the [NetCDF UDF documentation](https://docs.unidata.ucar.edu/netcdf/NUG/user
 
 ## Example Programs
 
-NEP v3.5.1 includes comprehensive example programs in C and Fortran to help you learn NetCDF API usage. These examples demonstrate both read and write operations, covering basic to advanced features.
+NEP includes comprehensive example programs in C and Fortran to help you learn NetCDF API usage. These examples demonstrate both read and write operations, covering basic to advanced features.
 
 ### What's Included
 
-**Classic NetCDF Examples:**
+**Classic NetCDF Examples** (`examples/classic/`, `examples/f_classic/`):
 - Quickstart introduction to NetCDF
 - Basic 2D arrays and coordinate variables
 - Format variants (classic, 64-bit offset, CDF-5)
 - Size limits and unlimited dimensions
 - 4-dimensional variables
 
-**NetCDF-4 Examples:**
+**NetCDF-4 Examples** (`examples/netcdf-4/`, `examples/f_netcdf-4/`):
 - NetCDF-4 file creation
 - Compression filters (deflate, shuffle)
 - Chunking strategies and performance
@@ -467,10 +467,27 @@ NEP v3.5.1 includes comprehensive example programs in C and Fortran to help you 
 - User-defined compound and enum types
 - Hierarchical groups and dimension visibility
 
+**NcZarr Examples** (`examples/nczarr/`):
+- Local NcZarr create/read/write with `file://...#mode=nczarr` URLs
+- Explicit chunk shape selection with `nc_def_var_chunking()`
+- Deflate + shuffle compression with `nc_def_var_deflate()`
+- All examples in both C and Fortran
+
+**Performance Examples** (`examples/performance/`):
+- Chunk cache tuning with `nc_set_chunk_cache()`
+- Chunking strategy comparison (row-optimized, column-optimized, balanced)
+- Compression level benchmarking across deflate levels
+- Balanced chunking with compression
+- Built only with `-DENABLE_BENCHMARKS=ON` (CMake) or `--enable-benchmarks` (Autotools)
+
+**Parallel I/O Examples** (`examples/parallelIO/`):
+- MPI-based parallel NetCDF-4 write and read
+- Built only when parallel tests are enabled
+
 **Dual Language Support:**
-- All examples provided in both C and Fortran
+- Classic, NetCDF-4, and NcZarr examples provided in both C and Fortran
 - Equivalent functionality across languages
-- Demonstrates language-specific API usage
+- Demonstrates language-specific API usage (column-major vs row-major ordering)
 
 ### Running Examples
 

--- a/docs/plan/v1.11.0-sprint3-nczarr-advanced.md
+++ b/docs/plan/v1.11.0-sprint3-nczarr-advanced.md
@@ -1,0 +1,801 @@
+<!-- Author: Edward Hartnett, Intelligent Data Design, Inc. -->
+<!-- Date: 2026-06-26 -->
+
+# V1.11.0 Sprint 3: NcZarr Chunking and Compression Examples
+
+**Objective**: Create four new NcZarr examples — `nczarr_chunking.c`, `nczarr_compression.c`, `f_nczarr_chunking.f90`, and `f_nczarr_compression.f90` — demonstrating explicit chunk shape selection and deflate+shuffle compression on local NcZarr stores.
+
+---
+
+## Background
+
+Sprints 1 and 2 established the `examples/nczarr/` directory with `nczarr_simple.c` and `f_nczarr_simple.f90`, which create a basic 4×5 `temperature(y, x)` dataset in a local NcZarr store using default storage settings. Sprint 3 adds chunking and compression examples that show how to control storage layout and apply filters — the same APIs used for NetCDF-4/HDF5 files work identically with NcZarr.
+
+**Design decisions** (from clarifying questions):
+- **Single chunk shape** (2×5) on the 4×5 grid — keeps the example minimal and teaching-focused
+- **Deflate level 4 + shuffle** — the most common real-world filter combination; universally available
+- **Same 4×5 dataset** as sprints 1–2 — consistency across the NcZarr example series
+- **Explicit chunking in compression example** — demonstrates the recommended workflow of setting chunk shape before applying compression
+- **File naming**: `nczarr_chunking.zarr` / `nczarr_compression.zarr` (C), `f_nczarr_chunking.zarr` / `f_nczarr_compression.zarr` (Fortran)
+
+---
+
+## Dependencies
+
+- **Sprint 1 (Complete)**: `examples/nczarr/` directory, `HAVE_NCZARR` detection, CMake and Autotools build infrastructure, `nczarr_simple.c`.
+- **Sprint 2 (Complete)**: `f_nczarr_simple.f90`, Fortran gating in `CMakeLists.txt` and `Makefile.am`.
+- **NetCDF-C**: Must be built with NcZarr support (`NC_HAS_NCZARR == 1`).
+
+---
+
+## Tasks
+
+### 1. Create `examples/nczarr/nczarr_chunking.c`
+
+**File**: `examples/nczarr/nczarr_chunking.c`
+
+Demonstrates explicit chunk shape selection for a local NcZarr dataset. Uses the same 4×5 temperature grid as `nczarr_simple.c` but sets chunk sizes to 2×5 (two rows per chunk), verifies the chunking metadata after reopening, and reads back data.
+
+```c
+/* nczarr_chunking.c - Demonstrate chunked storage in a local NcZarr dataset.
+ * Edward Hartnett, Intelligent Data Design, Inc. */
+
+#include <netcdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FILE_URL "file://nczarr_chunking.zarr#mode=nczarr"
+#define NY 4
+#define NX 5
+#define NDIMS 2
+#define CHUNK_Y 2
+#define CHUNK_X 5
+
+#define ERR(e) do { \
+    if (e) { \
+        fprintf(stderr, "Error: %s at line %d\n", nc_strerror(e), __LINE__); \
+        return 1; \
+    } \
+} while(0)
+
+int main(void)
+{
+    int ncid, dimids[NDIMS], varid, retval;
+    int ndims_in, nvars_in, storage_in;
+    size_t i, j;
+    size_t ylen, xlen, chunksizes[NDIMS], chunks_in[NDIMS];
+    float fill_value = -999.0f;
+    float data[NY][NX], data_in[NY][NX];
+
+    /* Generate a simple 2D temperature field. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            data[j][i] = 280.0f + (float)j * 2.0f + (float)i * 0.5f;
+
+    /* Create a local NcZarr dataset with explicit chunking. */
+    if ((retval = nc_create(FILE_URL, NC_CLOBBER | NC_NETCDF4, &ncid)))
+        ERR(retval);
+
+    if ((retval = nc_def_dim(ncid, "y", NY, &dimids[0])))
+        ERR(retval);
+    if ((retval = nc_def_dim(ncid, "x", NX, &dimids[1])))
+        ERR(retval);
+
+    if ((retval = nc_def_var(ncid, "temperature", NC_FLOAT, NDIMS, dimids, &varid)))
+        ERR(retval);
+
+    /* Set chunk sizes: 2 rows x 5 columns per chunk. */
+    chunksizes[0] = CHUNK_Y;
+    chunksizes[1] = CHUNK_X;
+    if ((retval = nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksizes)))
+        ERR(retval);
+
+    if ((retval = nc_put_att_text(ncid, varid, "units", 1, "K")))
+        ERR(retval);
+    if ((retval = nc_put_att_text(ncid, varid, "long_name", 11, "Temperature")))
+        ERR(retval);
+    if ((retval = nc_put_att_float(ncid, varid, "_FillValue", NC_FLOAT, 1, &fill_value)))
+        ERR(retval);
+
+    if ((retval = nc_enddef(ncid)))
+        ERR(retval);
+    if ((retval = nc_put_var_float(ncid, varid, &data[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    printf("Created %s with chunks [%d, %d]\n", FILE_URL, CHUNK_Y, CHUNK_X);
+
+    /* Reopen and verify chunking metadata. */
+    if ((retval = nc_open(FILE_URL, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq(ncid, &ndims_in, &nvars_in, NULL, NULL)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 0, &ylen)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 1, &xlen)))
+        ERR(retval);
+
+    printf("Dataset: %d dims, %d vars, y=%zu, x=%zu\n", ndims_in, nvars_in, ylen, xlen);
+
+    if ((retval = nc_inq_varid(ncid, "temperature", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var_chunking(ncid, varid, &storage_in, chunks_in)))
+        ERR(retval);
+
+    printf("Chunking: storage=%s, chunks=[%zu, %zu]\n",
+           storage_in == NC_CHUNKED ? "chunked" : "contiguous",
+           chunks_in[0], chunks_in[1]);
+
+    if (storage_in != NC_CHUNKED || chunks_in[0] != CHUNK_Y || chunks_in[1] != CHUNK_X) {
+        fprintf(stderr, "Chunk metadata mismatch\n");
+        return 1;
+    }
+
+    if ((retval = nc_get_var_float(ncid, varid, &data_in[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    /* Verify data. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            if (data_in[j][i] != data[j][i]) {
+                fprintf(stderr, "Mismatch at %zu,%zu: got %f, expected %f\n",
+                        j, i, data_in[j][i], data[j][i]);
+                return 1;
+            }
+
+    printf("Read %d values, all correct. Done.\n", NY * NX);
+    return 0;
+}
+```
+
+**Key API demonstrated**: `nc_def_var_chunking()`, `nc_inq_var_chunking()`
+
+### 2. Create `examples/nczarr/nczarr_compression.c`
+
+**File**: `examples/nczarr/nczarr_compression.c`
+
+Demonstrates deflate compression with shuffle on a chunked NcZarr variable. Sets explicit chunk shape (2×5), then applies deflate level 4 with shuffle enabled.
+
+```c
+/* nczarr_compression.c - Demonstrate deflate+shuffle compression in NcZarr.
+ * Edward Hartnett, Intelligent Data Design, Inc. */
+
+#include <netcdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FILE_URL "file://nczarr_compression.zarr#mode=nczarr"
+#define NY 4
+#define NX 5
+#define NDIMS 2
+#define CHUNK_Y 2
+#define CHUNK_X 5
+#define DEFLATE_LEVEL 4
+
+#define ERR(e) do { \
+    if (e) { \
+        fprintf(stderr, "Error: %s at line %d\n", nc_strerror(e), __LINE__); \
+        return 1; \
+    } \
+} while(0)
+
+int main(void)
+{
+    int ncid, dimids[NDIMS], varid, retval;
+    int ndims_in, nvars_in;
+    int shuffle_in, deflate_in, deflate_level_in;
+    size_t i, j;
+    size_t ylen, xlen, chunksizes[NDIMS];
+    float fill_value = -999.0f;
+    float data[NY][NX], data_in[NY][NX];
+
+    /* Generate a simple 2D temperature field. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            data[j][i] = 280.0f + (float)j * 2.0f + (float)i * 0.5f;
+
+    /* Create a local NcZarr dataset with chunking and compression. */
+    if ((retval = nc_create(FILE_URL, NC_CLOBBER | NC_NETCDF4, &ncid)))
+        ERR(retval);
+
+    if ((retval = nc_def_dim(ncid, "y", NY, &dimids[0])))
+        ERR(retval);
+    if ((retval = nc_def_dim(ncid, "x", NX, &dimids[1])))
+        ERR(retval);
+
+    if ((retval = nc_def_var(ncid, "temperature", NC_FLOAT, NDIMS, dimids, &varid)))
+        ERR(retval);
+
+    /* Step 1: Set chunk shape — required before compression. */
+    chunksizes[0] = CHUNK_Y;
+    chunksizes[1] = CHUNK_X;
+    if ((retval = nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksizes)))
+        ERR(retval);
+
+    /* Step 2: Enable shuffle filter and deflate compression (level 4). */
+    if ((retval = nc_def_var_deflate(ncid, varid, 1, 1, DEFLATE_LEVEL)))
+        ERR(retval);
+
+    if ((retval = nc_put_att_text(ncid, varid, "units", 1, "K")))
+        ERR(retval);
+    if ((retval = nc_put_att_text(ncid, varid, "long_name", 11, "Temperature")))
+        ERR(retval);
+    if ((retval = nc_put_att_float(ncid, varid, "_FillValue", NC_FLOAT, 1, &fill_value)))
+        ERR(retval);
+
+    if ((retval = nc_enddef(ncid)))
+        ERR(retval);
+    if ((retval = nc_put_var_float(ncid, varid, &data[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    printf("Created %s with deflate=%d, shuffle=on\n", FILE_URL, DEFLATE_LEVEL);
+
+    /* Reopen and verify compression metadata. */
+    if ((retval = nc_open(FILE_URL, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq(ncid, &ndims_in, &nvars_in, NULL, NULL)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 0, &ylen)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 1, &xlen)))
+        ERR(retval);
+
+    printf("Dataset: %d dims, %d vars, y=%zu, x=%zu\n", ndims_in, nvars_in, ylen, xlen);
+
+    if ((retval = nc_inq_varid(ncid, "temperature", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var_deflate(ncid, varid, &shuffle_in, &deflate_in, &deflate_level_in)))
+        ERR(retval);
+
+    printf("Compression: shuffle=%s, deflate=%s, level=%d\n",
+           shuffle_in ? "on" : "off",
+           deflate_in ? "on" : "off",
+           deflate_level_in);
+
+    if (!shuffle_in || !deflate_in || deflate_level_in != DEFLATE_LEVEL) {
+        fprintf(stderr, "Compression metadata mismatch\n");
+        return 1;
+    }
+
+    if ((retval = nc_get_var_float(ncid, varid, &data_in[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    /* Verify data. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            if (data_in[j][i] != data[j][i]) {
+                fprintf(stderr, "Mismatch at %zu,%zu: got %f, expected %f\n",
+                        j, i, data_in[j][i], data[j][i]);
+                return 1;
+            }
+
+    printf("Read %d values, all correct. Done.\n", NY * NX);
+    return 0;
+}
+```
+
+**Key API demonstrated**: `nc_def_var_chunking()`, `nc_def_var_deflate()`, `nc_inq_var_deflate()`
+
+### 3. Create `examples/nczarr/f_nczarr_chunking.f90`
+
+**File**: `examples/nczarr/f_nczarr_chunking.f90`
+
+Fortran equivalent of `nczarr_chunking.c`. Uses `nf90_def_var_chunking()` to set chunk shape [5, 2] (Fortran column-major: x first, then y), producing the same chunked `temperature(y, x)` variable in `f_nczarr_chunking.zarr`.
+
+```fortran
+!> @file f_nczarr_chunking.f90
+!! @brief Demonstrate chunked storage in a local NcZarr dataset (Fortran).
+!!
+!! Fortran equivalent of nczarr_chunking.c. Creates a 4x5 temperature array
+!! with explicit chunk shape [2, 5] (y, x) in a local NcZarr store, verifies
+!! chunking metadata after reopening, and validates data values.
+!!
+!! **Key Concepts:**
+!! - nc_def_var_chunking() sets chunk shape for NcZarr storage
+!! - Fortran column-major: chunksizes(1)=CHUNK_X, chunksizes(2)=CHUNK_Y
+!! - Chunking controls how data is split into Zarr chunk files
+!!
+!! @author Edward Hartnett, Intelligent Data Design, Inc.
+!! @date 2026-06-26
+
+program f_nczarr_chunking
+   use netcdf
+   implicit none
+
+   character(len=*), parameter :: FILE_URL = "file://f_nczarr_chunking.zarr#mode=nczarr"
+   integer, parameter :: NX = 5, NY = 4
+   integer, parameter :: NDIMS = 2
+   integer, parameter :: CHUNK_Y = 2, CHUNK_X = 5
+
+   integer :: ncid, varid, retval
+   integer :: y_dimid, x_dimid
+   integer :: dimids(NDIMS)
+   integer :: chunksizes(NDIMS), chunks_in(NDIMS)
+   integer :: ndims_in, nvars_in, storage_in
+   integer :: len_y, len_x
+   integer :: i, j, errors
+   real :: data_out(NX, NY), data_in(NX, NY)
+   real :: expected_val
+
+   ! Generate a simple 2D temperature field.
+   do j = 1, NY
+      do i = 1, NX
+         data_out(i, j) = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+      end do
+   end do
+
+   ! Create a local NcZarr dataset.
+   retval = nf90_create(FILE_URL, NF90_CLOBBER + NF90_NETCDF4, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_def_dim(ncid, "x", NX, x_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_def_dim(ncid, "y", NY, y_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   dimids(1) = x_dimid
+   dimids(2) = y_dimid
+   retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Set chunk sizes (Fortran order: x first, y second).
+   chunksizes(1) = CHUNK_X
+   chunksizes(2) = CHUNK_Y
+   retval = nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, chunksizes)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_att(ncid, varid, "units", "K")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "long_name", "Temperature")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "_FillValue", -999.0)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_enddef(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_var(ncid, varid, data_out)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Created ", FILE_URL, " with chunks [", CHUNK_Y, ",", CHUNK_X, "]"
+
+   ! Reopen and verify chunking metadata.
+   retval = nf90_open(FILE_URL, NF90_NOWRITE, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire(ncid, ndims_in, nvars_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_dimension(ncid, y_dimid, len=len_y)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_inquire_dimension(ncid, x_dimid, len=len_x)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Dataset:", ndims_in, "dims,", nvars_in, "vars, y=", len_y, ", x=", len_x
+
+   retval = nf90_inq_varid(ncid, "temperature", varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_variable(ncid, varid, chunksizes=chunks_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Chunking: chunks=[", chunks_in(2), ",", chunks_in(1), "]"
+
+   if (chunks_in(1) /= CHUNK_X .or. chunks_in(2) /= CHUNK_Y) then
+      print *, "*** FAILED: chunk metadata mismatch"
+      stop 2
+   end if
+
+   retval = nf90_get_var(ncid, varid, data_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Verify data.
+   errors = 0
+   do j = 1, NY
+      do i = 1, NX
+         expected_val = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+         if (data_in(i, j) /= expected_val) then
+            print *, "Mismatch at", i, j, ": got", data_in(i, j), ", expected", expected_val
+            errors = errors + 1
+         end if
+      end do
+   end do
+
+   if (errors > 0) then
+      print *, "*** FAILED:", errors, "data validation errors"
+      stop 2
+   end if
+
+   print *, "Read", NX * NY, "values, all correct. Done."
+
+contains
+   subroutine handle_err(status)
+      integer, intent(in) :: status
+      print *, "Error: ", trim(nf90_strerror(status))
+      stop 2
+   end subroutine handle_err
+
+end program f_nczarr_chunking
+```
+
+### 4. Create `examples/nczarr/f_nczarr_compression.f90`
+
+**File**: `examples/nczarr/f_nczarr_compression.f90`
+
+Fortran equivalent of `nczarr_compression.c`. Sets explicit chunk shape, then applies deflate level 4 with shuffle.
+
+```fortran
+!> @file f_nczarr_compression.f90
+!! @brief Demonstrate deflate+shuffle compression in a local NcZarr dataset (Fortran).
+!!
+!! Fortran equivalent of nczarr_compression.c. Creates a 4x5 temperature array
+!! with explicit chunking [2, 5] (y, x) and deflate level 4 + shuffle in a
+!! local NcZarr store, verifies compression metadata after reopening, and
+!! validates data values.
+!!
+!! **Key Concepts:**
+!! - Set chunk shape before compression (recommended workflow)
+!! - nf90_def_var_deflate() enables shuffle and deflate filters
+!! - Compression is transparent: nf90_get_var returns original values
+!!
+!! @author Edward Hartnett, Intelligent Data Design, Inc.
+!! @date 2026-06-26
+
+program f_nczarr_compression
+   use netcdf
+   implicit none
+
+   character(len=*), parameter :: FILE_URL = "file://f_nczarr_compression.zarr#mode=nczarr"
+   integer, parameter :: NX = 5, NY = 4
+   integer, parameter :: NDIMS = 2
+   integer, parameter :: CHUNK_Y = 2, CHUNK_X = 5
+   integer, parameter :: DEFLATE_LEVEL = 4
+
+   integer :: ncid, varid, retval
+   integer :: y_dimid, x_dimid
+   integer :: dimids(NDIMS)
+   integer :: chunksizes(NDIMS)
+   integer :: ndims_in, nvars_in
+   integer :: shuffle_in, deflate_in, deflate_level_in
+   integer :: len_y, len_x
+   integer :: i, j, errors
+   real :: data_out(NX, NY), data_in(NX, NY)
+   real :: expected_val
+
+   ! Generate a simple 2D temperature field.
+   do j = 1, NY
+      do i = 1, NX
+         data_out(i, j) = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+      end do
+   end do
+
+   ! Create a local NcZarr dataset.
+   retval = nf90_create(FILE_URL, NF90_CLOBBER + NF90_NETCDF4, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_def_dim(ncid, "x", NX, x_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_def_dim(ncid, "y", NY, y_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   dimids(1) = x_dimid
+   dimids(2) = y_dimid
+   retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Step 1: Set chunk shape (required before compression).
+   chunksizes(1) = CHUNK_X
+   chunksizes(2) = CHUNK_Y
+   retval = nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, chunksizes)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Step 2: Enable shuffle + deflate level 4.
+   retval = nf90_def_var_deflate(ncid, varid, 1, 1, DEFLATE_LEVEL)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_att(ncid, varid, "units", "K")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "long_name", "Temperature")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "_FillValue", -999.0)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_enddef(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_var(ncid, varid, data_out)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Created ", FILE_URL, " with deflate=", DEFLATE_LEVEL, ", shuffle=on"
+
+   ! Reopen and verify compression metadata.
+   retval = nf90_open(FILE_URL, NF90_NOWRITE, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire(ncid, ndims_in, nvars_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_dimension(ncid, y_dimid, len=len_y)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_inquire_dimension(ncid, x_dimid, len=len_x)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Dataset:", ndims_in, "dims,", nvars_in, "vars, y=", len_y, ", x=", len_x
+
+   retval = nf90_inq_varid(ncid, "temperature", varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inq_var_deflate(ncid, varid, shuffle_in, deflate_in, deflate_level_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Compression: shuffle=", shuffle_in, ", deflate=", deflate_in, ", level=", deflate_level_in
+
+   if (shuffle_in /= 1 .or. deflate_in /= 1 .or. deflate_level_in /= DEFLATE_LEVEL) then
+      print *, "*** FAILED: compression metadata mismatch"
+      stop 2
+   end if
+
+   retval = nf90_get_var(ncid, varid, data_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Verify data.
+   errors = 0
+   do j = 1, NY
+      do i = 1, NX
+         expected_val = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+         if (data_in(i, j) /= expected_val) then
+            print *, "Mismatch at", i, j, ": got", data_in(i, j), ", expected", expected_val
+            errors = errors + 1
+         end if
+      end do
+   end do
+
+   if (errors > 0) then
+      print *, "*** FAILED:", errors, "data validation errors"
+      stop 2
+   end if
+
+   print *, "Read", NX * NY, "values, all correct. Done."
+
+contains
+   subroutine handle_err(status)
+      integer, intent(in) :: status
+      print *, "Error: ", trim(nf90_strerror(status))
+      stop 2
+   end subroutine handle_err
+
+end program f_nczarr_compression
+```
+
+### 5. Update `examples/nczarr/CMakeLists.txt`
+
+Add the two new C examples after the existing `nczarr_simple` block, using the same pattern:
+
+```cmake
+# Chunking example (v1.11.0 sprint 3)
+add_executable(nczarr_chunking nczarr_chunking.c)
+target_compile_options(nczarr_chunking PRIVATE ${NC_CFLAGS_LIST})
+target_link_directories(nczarr_chunking PRIVATE ${HDF5_LIB_DIR})
+target_link_libraries(nczarr_chunking PRIVATE ${NC_LIBS_LIST})
+set_target_properties(nczarr_chunking PROPERTIES
+    BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+    SKIP_BUILD_RPATH OFF
+    BUILD_WITH_INSTALL_RPATH ON
+    INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+if(BUILD_TESTING)
+    add_test(NAME nczarr_chunking
+             COMMAND nczarr_chunking
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(nczarr_chunking PROPERTIES
+        ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+endif()
+
+# Compression example (v1.11.0 sprint 3)
+add_executable(nczarr_compression nczarr_compression.c)
+target_compile_options(nczarr_compression PRIVATE ${NC_CFLAGS_LIST})
+target_link_directories(nczarr_compression PRIVATE ${HDF5_LIB_DIR})
+target_link_libraries(nczarr_compression PRIVATE ${NC_LIBS_LIST})
+set_target_properties(nczarr_compression PROPERTIES
+    BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+    SKIP_BUILD_RPATH OFF
+    BUILD_WITH_INSTALL_RPATH ON
+    INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+if(BUILD_TESTING)
+    add_test(NAME nczarr_compression
+             COMMAND nczarr_compression
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(nczarr_compression PROPERTIES
+        ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+endif()
+```
+
+Add Fortran equivalents inside the existing `if(ENABLE_FORTRAN AND NetCDF_Fortran_FOUND)` block:
+
+```cmake
+        # Fortran chunking example (v1.11.0 sprint 3)
+        add_executable(f_nczarr_chunking f_nczarr_chunking.f90)
+        target_compile_options(f_nczarr_chunking PRIVATE ${NF_FFLAGS_LIST})
+        target_link_directories(f_nczarr_chunking PRIVATE ${HDF5_LIB_DIR} ${NF_LIBDIR})
+        target_link_libraries(f_nczarr_chunking PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
+        set_target_properties(f_nczarr_chunking PROPERTIES
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}"
+            SKIP_BUILD_RPATH OFF
+            BUILD_WITH_INSTALL_RPATH ON
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}")
+
+        if(BUILD_TESTING)
+            add_test(NAME f_nczarr_chunking
+                     COMMAND f_nczarr_chunking
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_chunking PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+        endif()
+
+        # Fortran compression example (v1.11.0 sprint 3)
+        add_executable(f_nczarr_compression f_nczarr_compression.f90)
+        target_compile_options(f_nczarr_compression PRIVATE ${NF_FFLAGS_LIST})
+        target_link_directories(f_nczarr_compression PRIVATE ${HDF5_LIB_DIR} ${NF_LIBDIR})
+        target_link_libraries(f_nczarr_compression PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
+        set_target_properties(f_nczarr_compression PROPERTIES
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}"
+            SKIP_BUILD_RPATH OFF
+            BUILD_WITH_INSTALL_RPATH ON
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}")
+
+        if(BUILD_TESTING)
+            add_test(NAME f_nczarr_compression
+                     COMMAND f_nczarr_compression
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_compression PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+        endif()
+```
+
+**CDL validation tests**: Unlike `nczarr_simple`, the chunking and compression examples may produce CDL with NcZarr-internal attributes (e.g., `_nczarr_attr`) that vary by NetCDF-C version. Sprint 3 relies on **exit-code validation only** — the examples' internal data verification is the primary correctness check. CDL validation can be added later if the output proves stable.
+
+### 6. Update `examples/nczarr/Makefile.am`
+
+Add the two C examples and two Fortran examples:
+
+```makefile
+# C chunking and compression examples (v1.11.0 sprint 3)
+check_PROGRAMS += nczarr_chunking nczarr_compression
+nczarr_chunking_SOURCES = nczarr_chunking.c
+nczarr_compression_SOURCES = nczarr_compression.c
+
+TESTS += nczarr_chunking nczarr_compression
+```
+
+Inside the existing `if ENABLE_FORTRAN` block, add:
+
+```makefile
+check_PROGRAMS += f_nczarr_chunking f_nczarr_compression
+f_nczarr_chunking_SOURCES = f_nczarr_chunking.f90
+f_nczarr_chunking_LDADD = -lnetcdff
+f_nczarr_compression_SOURCES = f_nczarr_compression.f90
+f_nczarr_compression_LDADD = -lnetcdff
+
+TESTS += f_nczarr_chunking f_nczarr_compression
+```
+
+Update `clean-local` to remove the new Zarr directories:
+
+```makefile
+clean-local:
+	rm -rf simple_nczarr.zarr f_simple_nczarr.zarr \
+	       nczarr_chunking.zarr nczarr_compression.zarr \
+	       f_nczarr_chunking.zarr f_nczarr_compression.zarr
+```
+
+### 7. Update `docs/prd.md`
+
+Extend the **NcZarr Examples (v1.11.0)** subsection:
+
+**C examples** (Sprint 3):
+- `nczarr_chunking.c` - Explicit chunk shape selection for NcZarr; demonstrates `nc_def_var_chunking()` and `nc_inq_var_chunking()` with a 2×5 chunk on a 4×5 grid
+- `nczarr_compression.c` - Deflate+shuffle compression on a chunked NcZarr variable; demonstrates the recommended workflow of setting chunk shape before applying `nc_def_var_deflate()`
+
+**Fortran examples** (Sprint 3):
+- `f_nczarr_chunking.f90` - Fortran equivalent of `nczarr_chunking.c`; demonstrates `nf90_def_var_chunking()` with Fortran column-major dimension ordering
+- `f_nczarr_compression.f90` - Fortran equivalent of `nczarr_compression.c`; demonstrates `nf90_def_var_deflate()` with explicit chunking
+
+### 8. Update `docs/roadmap.md`
+
+Replace the terse Sprint 3 entry with a reference to this plan file and a concise summary.
+
+---
+
+## Definition of Done
+
+- [ ] `examples/nczarr/nczarr_chunking.c` created with explicit 2×5 chunking and metadata verification.
+- [ ] `examples/nczarr/nczarr_compression.c` created with deflate level 4 + shuffle and metadata verification.
+- [ ] `examples/nczarr/f_nczarr_chunking.f90` created — Fortran equivalent of chunking example.
+- [ ] `examples/nczarr/f_nczarr_compression.f90` created — Fortran equivalent of compression example.
+- [ ] All four examples follow NEP style: `ERR(retval)` / `handle_err` pattern, compact prints.
+- [ ] All four examples use the same 4×5 temperature dataset and data formula as sprints 1–2.
+- [ ] Each example writes to a distinct Zarr store for safe parallel test execution.
+- [ ] `examples/nczarr/CMakeLists.txt` builds and tests all four new examples.
+- [ ] `examples/nczarr/Makefile.am` builds and tests all four new examples.
+- [ ] Fortran examples gated on `ENABLE_FORTRAN` / `NetCDF_Fortran_FOUND`.
+- [ ] `clean-local` removes all six Zarr directories (simple + chunking + compression × C/Fortran).
+- [ ] `docs/prd.md` updated with Sprint 3 example descriptions.
+- [ ] `docs/roadmap.md` Sprint 3 entry updated to reference this plan.
+- [ ] All examples compile and pass with both CMake and Autotools on a NetCDF-C with NcZarr support.
+
+---
+
+## Key API Functions Demonstrated
+
+### Chunking Examples
+
+| C Function | Fortran Function | Purpose |
+|-----------|-----------------|---------|
+| `nc_def_var_chunking()` | `nf90_def_var_chunking()` | Set chunk shape |
+| `nc_inq_var_chunking()` | `nf90_inquire_variable(chunksizes=)` | Query chunk metadata |
+
+### Compression Examples
+
+| C Function | Fortran Function | Purpose |
+|-----------|-----------------|---------|
+| `nc_def_var_chunking()` | `nf90_def_var_chunking()` | Set chunk shape (before compression) |
+| `nc_def_var_deflate()` | `nf90_def_var_deflate()` | Enable shuffle + deflate |
+| `nc_inq_var_deflate()` | `nf90_inq_var_deflate()` | Query compression metadata |
+
+---
+
+## Dataset Specifications
+
+All Sprint 3 examples use the same dataset as Sprints 1–2:
+
+| Attribute | Value |
+|-----------|-------|
+| Dimensions | y = 4, x = 5 |
+| Variable | `temperature(y, x)` of type `NC_FLOAT` / `NF90_FLOAT` |
+| Attributes | `units = "K"`, `long_name = "Temperature"`, `_FillValue = -999.0` |
+| Data formula | `280.0 + y_idx * 2.0 + x_idx * 0.5` (0-based indices) |
+| Chunk shape | 2×5 (y×x) |
+| Compression (compression examples only) | Deflate level 4 + shuffle |
+
+---
+
+## Dependencies Between Sprints
+
+- **Sprint 1 (Complete)**: `examples/nczarr/` directory, `HAVE_NCZARR` detection, C build infrastructure, `nczarr_simple.c`.
+- **Sprint 2 (Complete)**: Fortran gating, `f_nczarr_simple.f90`, Fortran build/test infrastructure.
+- **Sprint 3 (This sprint)**: Chunking and compression examples in C and Fortran.
+- **Future work**: NcZarr groups, unlimited dimensions, or S3 remote-access examples.
+
+---
+
+## Notes
+
+- **Exit-code validation only**: Unlike Sprint 1's CDL comparison, Sprint 3 examples rely on internal data verification. NcZarr may add implementation-specific metadata to the Zarr store that varies between NetCDF-C versions, making CDL diffs fragile for chunked/compressed stores.
+- **No new `configure.ac` changes**: The Sprint 3 C examples run as direct executables (not via shell scripts), so no `AC_CONFIG_FILES` additions are needed. The Fortran examples also run directly.
+- **Chunk shape 2×5**: Chosen so the 4×5 grid divides evenly into exactly 2 chunks along y, making the example predictable and easy to explain.
+- **Deflate level 4**: A moderate level that balances compression ratio with speed; not the focus of the example (v1.10.0 performance examples cover level comparisons).
+- **Distinct store names**: `nczarr_chunking.zarr`, `nczarr_compression.zarr`, `f_nczarr_chunking.zarr`, `f_nczarr_compression.zarr` prevent parallel-test collisions.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -305,7 +305,15 @@ Located in `examples/nczarr/`:
 **Fortran examples** (Sprint 2):
 - `f_nczarr_simple.f90` - Fortran equivalent of `nczarr_simple.c`; produces the same 4×5 `temperature(y, x)` dataset at `file://f_simple_nczarr.zarr#mode=nczarr`; demonstrates Fortran column-major dimension ordering with NcZarr
 
-**Note**: NcZarr examples are only built when NetCDF-C reports NcZarr support (`NC_HAS_NCZARR` in `netcdf_meta.h`) and examples are enabled. The Fortran example additionally requires `--enable-fortran` (Autotools) or `ENABLE_FORTRAN=ON` (CMake). Each example writes to a distinct Zarr directory store to allow safe parallel test execution.
+**C examples** (Sprint 3):
+- `nczarr_chunking.c` - Explicit chunk shape selection (2×5) for NcZarr; demonstrates `nc_def_var_chunking()` and `nc_inq_var_chunking()` with metadata verification
+- `nczarr_compression.c` - Deflate level 4 + shuffle compression on a chunked NcZarr variable; demonstrates the recommended workflow of setting chunk shape before applying `nc_def_var_deflate()`
+
+**Fortran examples** (Sprint 3):
+- `f_nczarr_chunking.f90` - Fortran equivalent of `nczarr_chunking.c`; demonstrates `nf90_def_var_chunking()` with Fortran column-major dimension ordering
+- `f_nczarr_compression.f90` - Fortran equivalent of `nczarr_compression.c`; demonstrates `nf90_def_var_deflate()` with explicit chunking
+
+**Note**: NcZarr examples are only built when NetCDF-C reports NcZarr support (`NC_HAS_NCZARR` in `netcdf_meta.h`) and examples are enabled. The Fortran examples additionally require `--enable-fortran` (Autotools) or `ENABLE_FORTRAN=ON` (CMake). Each example writes to a distinct Zarr directory store to allow safe parallel test execution.
 
 ### 8.4 Build Configuration
 **CMake:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,6 +50,27 @@
 - Generate `examples/expected_output/f_nczarr_simple_expected.cdl` from live `ncdump` output
 - Update `docs/prd.md` NcZarr section to cover Fortran example
 
+#### Sprint 3: NcZarr Chunking and Compression Examples
+**Detailed Plan**: See `docs/plan/v1.11.0-sprint3-nczarr-advanced.md`
+
+**Purpose**: Add four NcZarr examples demonstrating explicit chunk shape selection and deflate+shuffle compression, in both C and Fortran.
+
+**What it shows**:
+- Explicit chunk shape (2×5) on the 4×5 temperature grid via `nc_def_var_chunking()` / `nf90_def_var_chunking()`
+- Deflate level 4 + shuffle via `nc_def_var_deflate()` / `nf90_def_var_deflate()`
+- Recommended workflow: set chunk shape before applying compression
+- Metadata verification after reopen (`nc_inq_var_chunking()`, `nc_inq_var_deflate()`)
+- Same 4×5 `temperature(y, x)` dataset as sprints 1–2
+
+**Key API**: `nc_def_var_chunking()`, `nc_def_var_deflate()`, `nc_inq_var_chunking()`, `nc_inq_var_deflate()`
+
+**Tasks**:
+- Create `examples/nczarr/nczarr_chunking.c` and `examples/nczarr/nczarr_compression.c`
+- Create `examples/nczarr/f_nczarr_chunking.f90` and `examples/nczarr/f_nczarr_compression.f90`
+- Update `examples/nczarr/CMakeLists.txt` — add four new executables and tests
+- Update `examples/nczarr/Makefile.am` — add four new programs; Fortran gated on `ENABLE_FORTRAN`
+- Update `clean-local` for six Zarr directories
+- Update `docs/prd.md` NcZarr section with Sprint 3 examples
 
 ### V1.10.0 More Performance Examples
 

--- a/examples/nczarr/CMakeLists.txt
+++ b/examples/nczarr/CMakeLists.txt
@@ -77,6 +77,46 @@ if(BUILD_TESTING)
                              "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
 endif()
 
+# Chunking example (v1.11.0 sprint 3)
+add_executable(nczarr_chunking nczarr_chunking.c)
+target_compile_options(nczarr_chunking PRIVATE ${NC_CFLAGS_LIST})
+target_link_directories(nczarr_chunking PRIVATE ${HDF5_LIB_DIR})
+target_link_libraries(nczarr_chunking PRIVATE ${NC_LIBS_LIST})
+set_target_properties(nczarr_chunking PROPERTIES
+    BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+    SKIP_BUILD_RPATH OFF
+    BUILD_WITH_INSTALL_RPATH ON
+    INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+if(BUILD_TESTING)
+    add_test(NAME nczarr_chunking
+             COMMAND nczarr_chunking
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(nczarr_chunking PROPERTIES
+        ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+endif()
+
+# Compression example (v1.11.0 sprint 3)
+add_executable(nczarr_compression nczarr_compression.c)
+target_compile_options(nczarr_compression PRIVATE ${NC_CFLAGS_LIST})
+target_link_directories(nczarr_compression PRIVATE ${HDF5_LIB_DIR})
+target_link_libraries(nczarr_compression PRIVATE ${NC_LIBS_LIST})
+set_target_properties(nczarr_compression PROPERTIES
+    BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+    SKIP_BUILD_RPATH OFF
+    BUILD_WITH_INSTALL_RPATH ON
+    INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+if(BUILD_TESTING)
+    add_test(NAME nczarr_compression
+             COMMAND nczarr_compression
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(nczarr_compression PROPERTIES
+        ENVIRONMENT_MODIFICATION
+            "LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+endif()
+
 # Fortran NcZarr example — only built when Fortran is enabled and NetCDF-Fortran is found (v1.11.0 sprint 2)
 if(ENABLE_FORTRAN AND NetCDF_Fortran_FOUND)
     find_program(NF_CONFIG nf-config
@@ -135,6 +175,46 @@ if(ENABLE_FORTRAN AND NetCDF_Fortran_FOUND)
                                  DEPENDS f_nczarr_simple
                                  ENVIRONMENT_MODIFICATION
                                      "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+        endif()
+
+        # Fortran chunking example (v1.11.0 sprint 3)
+        add_executable(f_nczarr_chunking f_nczarr_chunking.f90)
+        target_compile_options(f_nczarr_chunking PRIVATE ${NF_FFLAGS_LIST})
+        target_link_directories(f_nczarr_chunking PRIVATE ${HDF5_LIB_DIR} ${NF_LIBDIR})
+        target_link_libraries(f_nczarr_chunking PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
+        set_target_properties(f_nczarr_chunking PROPERTIES
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}"
+            SKIP_BUILD_RPATH OFF
+            BUILD_WITH_INSTALL_RPATH ON
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}")
+
+        if(BUILD_TESTING)
+            add_test(NAME f_nczarr_chunking
+                     COMMAND f_nczarr_chunking
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_chunking PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
+        endif()
+
+        # Fortran compression example (v1.11.0 sprint 3)
+        add_executable(f_nczarr_compression f_nczarr_compression.f90)
+        target_compile_options(f_nczarr_compression PRIVATE ${NF_FFLAGS_LIST})
+        target_link_directories(f_nczarr_compression PRIVATE ${HDF5_LIB_DIR} ${NF_LIBDIR})
+        target_link_libraries(f_nczarr_compression PRIVATE ${NF_LIBS_F_LIST} ${NETCDF_LIBRARIES} hdf5 hdf5_hl)
+        set_target_properties(f_nczarr_compression PROPERTIES
+            BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}"
+            SKIP_BUILD_RPATH OFF
+            BUILD_WITH_INSTALL_RPATH ON
+            INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR};${NF_LIBDIR}")
+
+        if(BUILD_TESTING)
+            add_test(NAME f_nczarr_compression
+                     COMMAND f_nczarr_compression
+                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(f_nczarr_compression PROPERTIES
+                ENVIRONMENT_MODIFICATION
+                    "LD_LIBRARY_PATH=path_list_prepend:${NF_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${NC_LIBDIR};LD_LIBRARY_PATH=path_list_prepend:${HDF5_LIB_DIR}")
         endif()
     endif()
 endif()

--- a/examples/nczarr/Makefile.am
+++ b/examples/nczarr/Makefile.am
@@ -4,15 +4,17 @@
 
 AUTOMAKE_OPTIONS = parallel-tests
 
-check_PROGRAMS = nczarr_simple
+check_PROGRAMS = nczarr_simple nczarr_chunking nczarr_compression
 
 nczarr_simple_SOURCES = nczarr_simple.c
+nczarr_chunking_SOURCES = nczarr_chunking.c
+nczarr_compression_SOURCES = nczarr_compression.c
 
 LDADD = -lnetcdf -lhdf5_hl -lhdf5
 
 AM_TESTS_ENVIRONMENT = LD_LIBRARY_PATH="@MY_LD_LIBRARY_PATH@:$$LD_LIBRARY_PATH"
 
-TESTS = nczarr_simple test_nczarr_simple.sh
+TESTS = nczarr_simple nczarr_chunking nczarr_compression test_nczarr_simple.sh
 
 EXTRA_DIST = test_nczarr_simple.sh.in
 
@@ -20,11 +22,15 @@ EXTRA_DIST = test_nczarr_simple.sh.in
 if ENABLE_FORTRAN
 AM_FCFLAGS = $(CPPFLAGS)
 
-check_PROGRAMS += f_nczarr_simple
+check_PROGRAMS += f_nczarr_simple f_nczarr_chunking f_nczarr_compression
 f_nczarr_simple_SOURCES = f_nczarr_simple.f90
 f_nczarr_simple_LDADD = -lnetcdff
+f_nczarr_chunking_SOURCES = f_nczarr_chunking.f90
+f_nczarr_chunking_LDADD = -lnetcdff
+f_nczarr_compression_SOURCES = f_nczarr_compression.f90
+f_nczarr_compression_LDADD = -lnetcdff
 
-TESTS += test_f_nczarr_simple.sh
+TESTS += f_nczarr_chunking f_nczarr_compression test_f_nczarr_simple.sh
 EXTRA_DIST += test_f_nczarr_simple.sh.in
 endif
 
@@ -34,4 +40,6 @@ check-local:
 
 # NcZarr produces directory trees, not single files
 clean-local:
-	rm -rf simple_nczarr.zarr f_simple_nczarr.zarr
+	rm -rf simple_nczarr.zarr f_simple_nczarr.zarr \
+	       nczarr_chunking.zarr nczarr_compression.zarr \
+	       f_nczarr_chunking.zarr f_nczarr_compression.zarr

--- a/examples/nczarr/f_nczarr_chunking.f90
+++ b/examples/nczarr/f_nczarr_chunking.f90
@@ -1,0 +1,173 @@
+!> @file f_nczarr_chunking.f90
+!! @brief Demonstrate chunked storage in a local NcZarr dataset (Fortran).
+!!
+!! Fortran equivalent of nczarr_chunking.c. Creates a 4x5 temperature array
+!! with explicit chunk shape [2, 5] (y, x) in a local NcZarr store, verifies
+!! chunking metadata after reopening, and validates data values.
+!!
+!! **Learning Objectives:**
+!! - Set explicit chunk shape for a NcZarr variable from Fortran
+!! - Query chunk metadata after reopen using nf90_inquire_variable
+!! - Understand Fortran column-major chunksizes ordering
+!!
+!! **Key Concepts:**
+!! - nf90_def_var_chunking() sets chunk shape for NcZarr storage
+!! - Fortran column-major: chunksizes(1)=CHUNK_X, chunksizes(2)=CHUNK_Y
+!! - Chunking controls how data is split into Zarr chunk files
+!! - Same nf90_def_var_chunking() API works for NetCDF-4/HDF5 and NcZarr
+!!
+!! **Fortran vs C Differences:**
+!! - Chunk dimensions reversed: Fortran chunksizes(1)=x, (2)=y
+!!   vs C chunksizes[0]=y, [1]=x
+!! - Uses nf90_inquire_variable(chunksizes=) instead of separate function
+!!
+!! **Related Examples:**
+!! - nczarr_chunking.c - C equivalent
+!! - f_nczarr_simple.f90 - Basic NcZarr Fortran example
+!! - f_nczarr_compression.f90 - Adding compression on top of chunking
+!!
+!! **Compilation:**
+!! @code
+!! gfortran -o f_nczarr_chunking f_nczarr_chunking.f90 -lnetcdff -lnetcdf
+!! @endcode
+!!
+!! **Usage:**
+!! @code
+!! ./f_nczarr_chunking
+!! ncdump 'file://f_nczarr_chunking.zarr#mode=nczarr'
+!! @endcode
+!!
+!! **Expected Output:**
+!! Creates the directory f_nczarr_chunking.zarr containing:
+!! - 2 dimensions: y(4), x(5)
+!! - 1 variable: temperature(y, x) of type NF90_FLOAT with chunks [2, 5]
+!! - Attributes: units="K", long_name="Temperature", _FillValue=-999.0
+!! - A 4x5 temperature data grid stored in 2 chunks of 2x5 each
+!!
+!! @author Edward Hartnett, Intelligent Data Design, Inc.
+!! @date 2026-06-26
+
+program f_nczarr_chunking
+   use netcdf
+   implicit none
+
+   character(len=*), parameter :: FILE_URL = "file://f_nczarr_chunking.zarr#mode=nczarr"
+   integer, parameter :: NX = 5, NY = 4
+   integer, parameter :: NDIMS = 2
+   integer, parameter :: CHUNK_Y = 2, CHUNK_X = 5
+
+   integer :: ncid, varid, retval
+   integer :: y_dimid, x_dimid
+   integer :: dimids(NDIMS)
+   integer :: chunksizes(NDIMS), chunks_in(NDIMS)
+   integer :: ndims_in, nvars_in
+   integer :: len_y, len_x
+   integer :: i, j, errors
+   real :: data_out(NX, NY), data_in(NX, NY)
+   real :: expected_val
+
+   ! Generate a simple 2D temperature field.
+   do j = 1, NY
+      do i = 1, NX
+         data_out(i, j) = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+      end do
+   end do
+
+   ! Create a local NcZarr dataset.
+   retval = nf90_create(FILE_URL, NF90_CLOBBER + NF90_NETCDF4, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_def_dim(ncid, "x", NX, x_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_def_dim(ncid, "y", NY, y_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   dimids(1) = x_dimid
+   dimids(2) = y_dimid
+   retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Set chunk sizes (Fortran order: x first, y second).
+   chunksizes(1) = CHUNK_X
+   chunksizes(2) = CHUNK_Y
+   retval = nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, chunksizes)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_att(ncid, varid, "units", "K")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "long_name", "Temperature")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "_FillValue", -999.0)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_enddef(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_var(ncid, varid, data_out)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Created ", FILE_URL, " with chunks [", CHUNK_Y, ",", CHUNK_X, "]"
+
+   ! Reopen and verify chunking metadata.
+   retval = nf90_open(FILE_URL, NF90_NOWRITE, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire(ncid, ndims_in, nvars_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_dimension(ncid, y_dimid, len=len_y)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_inquire_dimension(ncid, x_dimid, len=len_x)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Dataset:", ndims_in, "dims,", nvars_in, "vars, y=", len_y, ", x=", len_x
+
+   retval = nf90_inq_varid(ncid, "temperature", varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_variable(ncid, varid, chunksizes=chunks_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Chunking: chunks=[", chunks_in(2), ",", chunks_in(1), "]"
+
+   if (chunks_in(1) /= CHUNK_X .or. chunks_in(2) /= CHUNK_Y) then
+      print *, "*** FAILED: chunk metadata mismatch"
+      stop 2
+   end if
+
+   retval = nf90_get_var(ncid, varid, data_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Verify data.
+   errors = 0
+   do j = 1, NY
+      do i = 1, NX
+         expected_val = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+         if (data_in(i, j) /= expected_val) then
+            print *, "Mismatch at", i, j, ": got", data_in(i, j), ", expected", expected_val
+            errors = errors + 1
+         end if
+      end do
+   end do
+
+   if (errors > 0) then
+      print *, "*** FAILED:", errors, "data validation errors"
+      stop 2
+   end if
+
+   print *, "Read", NX * NY, "values, all correct. Done."
+
+contains
+   subroutine handle_err(status)
+      integer, intent(in) :: status
+      print *, "Error: ", trim(nf90_strerror(status))
+      stop 2
+   end subroutine handle_err
+
+end program f_nczarr_chunking

--- a/examples/nczarr/f_nczarr_compression.f90
+++ b/examples/nczarr/f_nczarr_compression.f90
@@ -1,0 +1,178 @@
+!> @file f_nczarr_compression.f90
+!! @brief Demonstrate deflate+shuffle compression in a local NcZarr dataset (Fortran).
+!!
+!! Fortran equivalent of nczarr_compression.c. Creates a 4x5 temperature array
+!! with explicit chunking [2, 5] (y, x) and deflate level 4 + shuffle in a
+!! local NcZarr store, verifies compression metadata after reopening, and
+!! validates data values.
+!!
+!! **Learning Objectives:**
+!! - Apply deflate compression and shuffle filter from Fortran
+!! - Follow the recommended workflow: set chunks first, then compression
+!! - Query compression metadata after reopen
+!! - Verify that decompression is transparent
+!!
+!! **Key Concepts:**
+!! - Set chunk shape before compression (recommended workflow)
+!! - nf90_def_var_deflate(ncid, varid, shuffle, deflate, deflate_level)
+!!   enables shuffle and deflate filters
+!! - Compression is transparent: nf90_get_var returns original values
+!! - Same API works for NetCDF-4/HDF5 and NcZarr
+!!
+!! **Related Examples:**
+!! - nczarr_compression.c - C equivalent
+!! - f_nczarr_chunking.f90 - Chunking without compression
+!! - f_nczarr_simple.f90 - Basic NcZarr Fortran example
+!!
+!! **Compilation:**
+!! @code
+!! gfortran -o f_nczarr_compression f_nczarr_compression.f90 -lnetcdff -lnetcdf
+!! @endcode
+!!
+!! **Usage:**
+!! @code
+!! ./f_nczarr_compression
+!! ncdump 'file://f_nczarr_compression.zarr#mode=nczarr'
+!! @endcode
+!!
+!! **Expected Output:**
+!! Creates the directory f_nczarr_compression.zarr containing:
+!! - 2 dimensions: y(4), x(5)
+!! - 1 variable: temperature(y, x) of type NF90_FLOAT, chunked [2, 5],
+!!   with shuffle + deflate level 4
+!! - Attributes: units="K", long_name="Temperature", _FillValue=-999.0
+!! - A 4x5 temperature data grid stored compressed in 2 chunks
+!!
+!! @author Edward Hartnett, Intelligent Data Design, Inc.
+!! @date 2026-06-26
+
+program f_nczarr_compression
+   use netcdf
+   implicit none
+
+   character(len=*), parameter :: FILE_URL = "file://f_nczarr_compression.zarr#mode=nczarr"
+   integer, parameter :: NX = 5, NY = 4
+   integer, parameter :: NDIMS = 2
+   integer, parameter :: CHUNK_Y = 2, CHUNK_X = 5
+   integer, parameter :: DEFLATE_LEVEL = 4
+
+   integer :: ncid, varid, retval
+   integer :: y_dimid, x_dimid
+   integer :: dimids(NDIMS)
+   integer :: chunksizes(NDIMS)
+   integer :: ndims_in, nvars_in
+   integer :: shuffle_in, deflate_in, deflate_level_in
+   integer :: len_y, len_x
+   integer :: i, j, errors
+   real :: data_out(NX, NY), data_in(NX, NY)
+   real :: expected_val
+
+   ! Generate a simple 2D temperature field.
+   do j = 1, NY
+      do i = 1, NX
+         data_out(i, j) = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+      end do
+   end do
+
+   ! Create a local NcZarr dataset.
+   retval = nf90_create(FILE_URL, NF90_CLOBBER + NF90_NETCDF4, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_def_dim(ncid, "x", NX, x_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_def_dim(ncid, "y", NY, y_dimid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   dimids(1) = x_dimid
+   dimids(2) = y_dimid
+   retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Step 1: Set chunk shape (required before compression).
+   chunksizes(1) = CHUNK_X
+   chunksizes(2) = CHUNK_Y
+   retval = nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, chunksizes)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Step 2: Enable shuffle + deflate level 4.
+   retval = nf90_def_var_deflate(ncid, varid, 1, 1, DEFLATE_LEVEL)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_att(ncid, varid, "units", "K")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "long_name", "Temperature")
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_put_att(ncid, varid, "_FillValue", -999.0)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_enddef(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_put_var(ncid, varid, data_out)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Created ", FILE_URL, " with deflate=", DEFLATE_LEVEL, ", shuffle=on"
+
+   ! Reopen and verify compression metadata.
+   retval = nf90_open(FILE_URL, NF90_NOWRITE, ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire(ncid, ndims_in, nvars_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inquire_dimension(ncid, y_dimid, len=len_y)
+   if (retval /= nf90_noerr) call handle_err(retval)
+   retval = nf90_inquire_dimension(ncid, x_dimid, len=len_x)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Dataset:", ndims_in, "dims,", nvars_in, "vars, y=", len_y, ", x=", len_x
+
+   retval = nf90_inq_varid(ncid, "temperature", varid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_inq_var_deflate(ncid, varid, shuffle_in, deflate_in, deflate_level_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   print *, "Compression: shuffle=", shuffle_in, ", deflate=", deflate_in, ", level=", deflate_level_in
+
+   if (shuffle_in /= 1 .or. deflate_in /= 1 .or. deflate_level_in /= DEFLATE_LEVEL) then
+      print *, "*** FAILED: compression metadata mismatch"
+      stop 2
+   end if
+
+   retval = nf90_get_var(ncid, varid, data_in)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   retval = nf90_close(ncid)
+   if (retval /= nf90_noerr) call handle_err(retval)
+
+   ! Verify data.
+   errors = 0
+   do j = 1, NY
+      do i = 1, NX
+         expected_val = 280.0 + real(j - 1) * 2.0 + real(i - 1) * 0.5
+         if (data_in(i, j) /= expected_val) then
+            print *, "Mismatch at", i, j, ": got", data_in(i, j), ", expected", expected_val
+            errors = errors + 1
+         end if
+      end do
+   end do
+
+   if (errors > 0) then
+      print *, "*** FAILED:", errors, "data validation errors"
+      stop 2
+   end if
+
+   print *, "Read", NX * NY, "values, all correct. Done."
+
+contains
+   subroutine handle_err(status)
+      integer, intent(in) :: status
+      print *, "Error: ", trim(nf90_strerror(status))
+      stop 2
+   end subroutine handle_err
+
+end program f_nczarr_compression

--- a/examples/nczarr/nczarr_chunking.c
+++ b/examples/nczarr/nczarr_chunking.c
@@ -1,0 +1,168 @@
+/**
+ * @file nczarr_chunking.c
+ * @brief Demonstrate chunked storage in a local NcZarr dataset.
+ *
+ * This example extends nczarr_simple.c by adding explicit chunk shape
+ * selection. Chunking controls how a variable's data is split into
+ * separate storage units (chunks) in the underlying Zarr directory tree.
+ * Each chunk becomes a separate file on disk (or object in cloud storage),
+ * so the chunk shape directly affects I/O access patterns.
+ *
+ * The program creates the same 4x5 temperature grid used in nczarr_simple.c
+ * but specifies a 2x5 (y x x) chunk shape using nc_def_var_chunking().
+ * This splits the 4-row array into two 2-row chunks. After writing, the
+ * program reopens the dataset and verifies the chunk metadata via
+ * nc_inq_var_chunking(), then reads and validates all data values.
+ *
+ * **Learning Objectives:**
+ * - Set explicit chunk shape for a variable in a NcZarr dataset
+ * - Query chunk metadata (storage type and chunk dimensions) after reopen
+ * - Understand that the same nc_def_var_chunking() / nc_inq_var_chunking()
+ *   APIs used for NetCDF-4/HDF5 work identically with NcZarr
+ * - Observe that each chunk maps to a separate file in the Zarr store
+ *
+ * **Key Concepts:**
+ * - **NC_CHUNKED**: Storage mode that splits data into fixed-size chunks
+ * - **nc_def_var_chunking()**: Sets the chunk shape (must be called in
+ *   define mode, before nc_enddef)
+ * - **nc_inq_var_chunking()**: Returns storage type and chunk dimensions
+ * - **Chunk alignment**: Best practice is to choose chunk dimensions that
+ *   evenly divide the variable dimensions
+ *
+ * **Related Examples:**
+ * - nczarr_simple.c - Basic NcZarr create/read/write (default chunking)
+ * - nczarr_compression.c - Adding compression on top of chunking
+ * - chunking_performance.c - Comparing access patterns with different
+ *   chunk shapes (performance example)
+ *
+ * **Compilation:**
+ * @code
+ * gcc -o nczarr_chunking nczarr_chunking.c -lnetcdf
+ * @endcode
+ *
+ * **Usage:**
+ * @code
+ * ./nczarr_chunking
+ * ncdump 'file://nczarr_chunking.zarr#mode=nczarr'
+ * @endcode
+ *
+ * **Expected Output:**
+ * Creates the directory nczarr_chunking.zarr containing:
+ * - 2 dimensions: y(4), x(5)
+ * - 1 variable: temperature(y, x) of type NC_FLOAT with chunks [2, 5]
+ * - Attributes: units="K", long_name="Temperature", _FillValue=-999.f
+ * - A 4x5 temperature data grid stored in 2 chunks of 2x5 each
+ *
+ * @author Edward Hartnett, Intelligent Data Design, Inc.
+ * @date 2026-06-26
+ */
+
+#include <netcdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FILE_URL "file://nczarr_chunking.zarr#mode=nczarr"
+#define NY 4
+#define NX 5
+#define NDIMS 2
+#define CHUNK_Y 2
+#define CHUNK_X 5
+
+#define ERR(e) do { \
+    if (e) { \
+        fprintf(stderr, "Error: %s at line %d\n", nc_strerror(e), __LINE__); \
+        return 1; \
+    } \
+} while(0)
+
+int main(void)
+{
+    int ncid, dimids[NDIMS], varid, retval;
+    int ndims_in, nvars_in, storage_in;
+    size_t i, j;
+    size_t ylen, xlen, chunksizes[NDIMS], chunks_in[NDIMS];
+    float fill_value = -999.0f;
+    float data[NY][NX], data_in[NY][NX];
+
+    /* Generate a simple 2D temperature field. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            data[j][i] = 280.0f + (float)j * 2.0f + (float)i * 0.5f;
+
+    /* Create a local NcZarr dataset with explicit chunking. */
+    if ((retval = nc_create(FILE_URL, NC_CLOBBER | NC_NETCDF4, &ncid)))
+        ERR(retval);
+
+    if ((retval = nc_def_dim(ncid, "y", NY, &dimids[0])))
+        ERR(retval);
+    if ((retval = nc_def_dim(ncid, "x", NX, &dimids[1])))
+        ERR(retval);
+
+    if ((retval = nc_def_var(ncid, "temperature", NC_FLOAT, NDIMS, dimids, &varid)))
+        ERR(retval);
+
+    /* Set chunk sizes: 2 rows x 5 columns per chunk. */
+    chunksizes[0] = CHUNK_Y;
+    chunksizes[1] = CHUNK_X;
+    if ((retval = nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksizes)))
+        ERR(retval);
+
+    if ((retval = nc_put_att_text(ncid, varid, "units", 1, "K")))
+        ERR(retval);
+    if ((retval = nc_put_att_text(ncid, varid, "long_name", 11, "Temperature")))
+        ERR(retval);
+    if ((retval = nc_put_att_float(ncid, varid, "_FillValue", NC_FLOAT, 1, &fill_value)))
+        ERR(retval);
+
+    if ((retval = nc_enddef(ncid)))
+        ERR(retval);
+    if ((retval = nc_put_var_float(ncid, varid, &data[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    printf("Created %s with chunks [%d, %d]\n", FILE_URL, CHUNK_Y, CHUNK_X);
+
+    /* Reopen and verify chunking metadata. */
+    if ((retval = nc_open(FILE_URL, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq(ncid, &ndims_in, &nvars_in, NULL, NULL)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 0, &ylen)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 1, &xlen)))
+        ERR(retval);
+
+    printf("Dataset: %d dims, %d vars, y=%zu, x=%zu\n", ndims_in, nvars_in, ylen, xlen);
+
+    if ((retval = nc_inq_varid(ncid, "temperature", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var_chunking(ncid, varid, &storage_in, chunks_in)))
+        ERR(retval);
+
+    printf("Chunking: storage=%s, chunks=[%zu, %zu]\n",
+           storage_in == NC_CHUNKED ? "chunked" : "contiguous",
+           chunks_in[0], chunks_in[1]);
+
+    if (storage_in != NC_CHUNKED || chunks_in[0] != CHUNK_Y || chunks_in[1] != CHUNK_X) {
+        fprintf(stderr, "Chunk metadata mismatch\n");
+        return 1;
+    }
+
+    if ((retval = nc_get_var_float(ncid, varid, &data_in[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    /* Verify data. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            if (data_in[j][i] != data[j][i]) {
+                fprintf(stderr, "Mismatch at %zu,%zu: got %f, expected %f\n",
+                        j, i, data_in[j][i], data[j][i]);
+                return 1;
+            }
+
+    printf("Read %d values, all correct. Done.\n", NY * NX);
+    return 0;
+}

--- a/examples/nczarr/nczarr_compression.c
+++ b/examples/nczarr/nczarr_compression.c
@@ -1,0 +1,178 @@
+/**
+ * @file nczarr_compression.c
+ * @brief Demonstrate deflate+shuffle compression in a local NcZarr dataset.
+ *
+ * This example extends nczarr_chunking.c by adding compression filters on
+ * top of explicit chunking. The recommended workflow for compressed storage
+ * is: (1) set the chunk shape with nc_def_var_chunking(), then (2) enable
+ * compression with nc_def_var_deflate(). Both steps must occur in define
+ * mode before nc_enddef().
+ *
+ * The program creates the same 4x5 temperature grid with 2x5 chunks, then
+ * applies the shuffle filter and deflate (zlib) compression at level 4.
+ * After writing, it reopens the dataset and verifies the compression
+ * metadata via nc_inq_var_deflate(), then reads and validates all data
+ * values. Decompression is fully transparent — nc_get_var_float() returns
+ * the original data without any extra API calls.
+ *
+ * **Learning Objectives:**
+ * - Apply deflate compression and the shuffle filter to a NcZarr variable
+ * - Understand the recommended order: set chunks first, then compression
+ * - Query compression metadata (shuffle, deflate, level) after reopen
+ * - Verify that decompression is transparent through the netCDF API
+ *
+ * **Key Concepts:**
+ * - **nc_def_var_deflate(ncid, varid, shuffle, deflate, level)**:
+ *   - shuffle=1: enables the shuffle filter (reorders bytes for better
+ *     compression of typed data)
+ *   - deflate=1: enables deflate (zlib) compression
+ *   - level=0..9: compression level (0=none, 9=max; 4 is a balanced choice)
+ * - **Chunk + compress workflow**: Compression requires chunked storage;
+ *   always set chunk shape explicitly for predictable behavior
+ * - **nc_inq_var_deflate()**: Returns current shuffle, deflate, and level
+ *
+ * **Related Examples:**
+ * - nczarr_chunking.c - Chunking without compression
+ * - nczarr_simple.c - Basic NcZarr create/read/write
+ * - compression_performance.c - Comparing compression levels and filters
+ *   (performance example)
+ *
+ * **Compilation:**
+ * @code
+ * gcc -o nczarr_compression nczarr_compression.c -lnetcdf
+ * @endcode
+ *
+ * **Usage:**
+ * @code
+ * ./nczarr_compression
+ * ncdump 'file://nczarr_compression.zarr#mode=nczarr'
+ * @endcode
+ *
+ * **Expected Output:**
+ * Creates the directory nczarr_compression.zarr containing:
+ * - 2 dimensions: y(4), x(5)
+ * - 1 variable: temperature(y, x) of type NC_FLOAT, chunked [2, 5],
+ *   with shuffle + deflate level 4
+ * - Attributes: units="K", long_name="Temperature", _FillValue=-999.f
+ * - A 4x5 temperature data grid stored compressed in 2 chunks
+ *
+ * @author Edward Hartnett, Intelligent Data Design, Inc.
+ * @date 2026-06-26
+ */
+
+#include <netcdf.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define FILE_URL "file://nczarr_compression.zarr#mode=nczarr"
+#define NY 4
+#define NX 5
+#define NDIMS 2
+#define CHUNK_Y 2
+#define CHUNK_X 5
+#define DEFLATE_LEVEL 4
+
+#define ERR(e) do { \
+    if (e) { \
+        fprintf(stderr, "Error: %s at line %d\n", nc_strerror(e), __LINE__); \
+        return 1; \
+    } \
+} while(0)
+
+int main(void)
+{
+    int ncid, dimids[NDIMS], varid, retval;
+    int ndims_in, nvars_in;
+    int shuffle_in, deflate_in, deflate_level_in;
+    size_t i, j;
+    size_t ylen, xlen, chunksizes[NDIMS];
+    float fill_value = -999.0f;
+    float data[NY][NX], data_in[NY][NX];
+
+    /* Generate a simple 2D temperature field. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            data[j][i] = 280.0f + (float)j * 2.0f + (float)i * 0.5f;
+
+    /* Create a local NcZarr dataset with chunking and compression. */
+    if ((retval = nc_create(FILE_URL, NC_CLOBBER | NC_NETCDF4, &ncid)))
+        ERR(retval);
+
+    if ((retval = nc_def_dim(ncid, "y", NY, &dimids[0])))
+        ERR(retval);
+    if ((retval = nc_def_dim(ncid, "x", NX, &dimids[1])))
+        ERR(retval);
+
+    if ((retval = nc_def_var(ncid, "temperature", NC_FLOAT, NDIMS, dimids, &varid)))
+        ERR(retval);
+
+    /* Step 1: Set chunk shape — required before compression. */
+    chunksizes[0] = CHUNK_Y;
+    chunksizes[1] = CHUNK_X;
+    if ((retval = nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksizes)))
+        ERR(retval);
+
+    /* Step 2: Enable shuffle filter and deflate compression (level 4). */
+    if ((retval = nc_def_var_deflate(ncid, varid, 1, 1, DEFLATE_LEVEL)))
+        ERR(retval);
+
+    if ((retval = nc_put_att_text(ncid, varid, "units", 1, "K")))
+        ERR(retval);
+    if ((retval = nc_put_att_text(ncid, varid, "long_name", 11, "Temperature")))
+        ERR(retval);
+    if ((retval = nc_put_att_float(ncid, varid, "_FillValue", NC_FLOAT, 1, &fill_value)))
+        ERR(retval);
+
+    if ((retval = nc_enddef(ncid)))
+        ERR(retval);
+    if ((retval = nc_put_var_float(ncid, varid, &data[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    printf("Created %s with deflate=%d, shuffle=on\n", FILE_URL, DEFLATE_LEVEL);
+
+    /* Reopen and verify compression metadata. */
+    if ((retval = nc_open(FILE_URL, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq(ncid, &ndims_in, &nvars_in, NULL, NULL)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 0, &ylen)))
+        ERR(retval);
+    if ((retval = nc_inq_dimlen(ncid, 1, &xlen)))
+        ERR(retval);
+
+    printf("Dataset: %d dims, %d vars, y=%zu, x=%zu\n", ndims_in, nvars_in, ylen, xlen);
+
+    if ((retval = nc_inq_varid(ncid, "temperature", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var_deflate(ncid, varid, &shuffle_in, &deflate_in, &deflate_level_in)))
+        ERR(retval);
+
+    printf("Compression: shuffle=%s, deflate=%s, level=%d\n",
+           shuffle_in ? "on" : "off",
+           deflate_in ? "on" : "off",
+           deflate_level_in);
+
+    if (!shuffle_in || !deflate_in || deflate_level_in != DEFLATE_LEVEL) {
+        fprintf(stderr, "Compression metadata mismatch\n");
+        return 1;
+    }
+
+    if ((retval = nc_get_var_float(ncid, varid, &data_in[0][0])))
+        ERR(retval);
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    /* Verify data. */
+    for (j = 0; j < NY; j++)
+        for (i = 0; i < NX; i++)
+            if (data_in[j][i] != data[j][i]) {
+                fprintf(stderr, "Mismatch at %zu,%zu: got %f, expected %f\n",
+                        j, i, data_in[j][i], data[j][i]);
+                return 1;
+            }
+
+    printf("Read %d values, all correct. Done.\n", NY * NX);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Add four NcZarr examples demonstrating explicit chunk shape selection and deflate+shuffle compression, in both C and Fortran.

## New Examples

| File | Language | Demonstrates |
|------|----------|-------------|
| `nczarr_chunking.c` | C | `nc_def_var_chunking()` — 2×5 chunk shape on 4×5 grid |
| `nczarr_compression.c` | C | `nc_def_var_deflate()` — shuffle + deflate level 4 |
| `f_nczarr_chunking.f90` | Fortran | `nf90_def_var_chunking()` — column-major chunk ordering |
| `f_nczarr_compression.f90` | Fortran | `nf90_def_var_deflate()` — shuffle + deflate with explicit chunking |

All examples use the same 4×5 `temperature(y, x)` dataset as sprints 1–2, write to distinct Zarr stores, and include internal metadata verification and data validation.

## Key APIs Demonstrated

- `nc_def_var_chunking()` / `nf90_def_var_chunking()` — set explicit chunk shape
- `nc_def_var_deflate()` / `nf90_def_var_deflate()` — enable shuffle + deflate compression
- `nc_inq_var_chunking()` / `nc_inq_var_deflate()` — verify metadata after reopen
- Recommended workflow: set chunk shape before applying compression

## Build System

- **CMake**: 4 new executables + CTest entries; Fortran gated on `ENABLE_FORTRAN AND NetCDF_Fortran_FOUND`
- **Autotools**: 4 new `check_PROGRAMS` and `TESTS` entries; Fortran gated on `ENABLE_FORTRAN`
- `clean-local` updated for 6 Zarr directory stores
- `.gitignore` updated for new binaries and Zarr output dirs

## Test Results

- **Autotools**: 7/7 PASS
- **CMake**: 8/8 PASS

## Other Changes

- `docs/roadmap.md` — Sprint 3 entry expanded with plan reference
- `docs/prd.md` — Sprint 3 examples documented in NcZarr section
- `docs/plan/v1.11.0-sprint3-nczarr-advanced.md` — detailed sprint plan
- `README.md` — Example Programs section updated to include NcZarr, Performance, and Parallel I/O categories
