### PR TITLE
V2.0.0 Sprint 3: Implement real CFITSIO integration in FITS dispatch layer

### DIFF
--- a/docs/plan/v2.0.0-sprint3-fits-open.md
+++ b/docs/plan/v2.0.0-sprint3-fits-open.md
@@ -1,0 +1,170 @@
+# V2.0.0 Sprint 3: Open a Real FITS File
+
+**Objective**: Implement actual CFITSIO integration in the FITS dispatch layer so that `NC_FITS_open()` calls `fits_open_file()` and stores the CFITSIO file handle, while `NC_FITS_close()` properly closes it. Tests remain unchanged - they still just verify successful open/close operations.
+
+---
+
+## Background
+
+Sprint 2 delivered a no-op FITS dispatch layer with `libncfits` containing stub functions that return success without calling CFITSIO. Sprint 3 replaces the no-op `NC_FITS_open()` and `NC_FITS_close()` with real CFITSIO calls, establishing the foundation for metadata reading in Sprint 4.
+
+**Key decisions from Sprint 2**:
+- `ENABLE_FITS` defaults to ON in both build systems
+- UDF3 slot assigned to FITS with magic string "SIMPLE"
+- Tests: `test/tst_fits_udf.c` and `ftest/ftst_fits_udf.F90`
+- Test file: `test/data/WFPC2u5780205r_c0fx.fits`
+
+---
+
+## Matrix
+
+| Dimension | Values |
+|-----------|--------|
+| `build_system` | `cmake`, `autotools` |
+| Fortran | ON |
+| FITS | ON |
+| Other handlers | OFF for `ci-fits.yml`; CI-enabled in `ci.yml` |
+
+---
+
+## Tasks
+
+### 1. Update NC_FITS_FILE_INFO_T structure
+- `include/fitsdispatch.h`:
+  - Add `fitsfile *fptr;` field to store CFITSIO file handle
+  - Add `char *path;` field to store the file path for error reporting
+  - Ensure proper memory management in open/close functions
+
+### 2. Implement real NC_FITS_open()
+- `src/fitsfile.c`:
+  - Replace no-op implementation with actual CFITSIO calls
+  - Call `fits_open_file(&fptr, path, READONLY, &status)`
+  - Store `fptr` and `path` in the `NC_FITS_FILE_INFO_T` structure
+  - Handle CFITSIO errors and map them to appropriate NetCDF error codes
+  - Follow CFITSIO error handling pattern: `status = 0; fits_report_error(stderr, status);`
+
+### 3. Implement real NC_FITS_close()
+- `src/fitsfile.c`:
+  - Call `fits_close_file(fptr, &status)` on the stored CFITSIO file handle
+  - Free the allocated `path` string
+  - Free the `NC_FITS_FILE_INFO_T` structure
+  - Handle CFITSIO errors appropriately
+
+### 4. Update NC_FITS_abort()
+- `src/fitsfile.c`:
+  - Ensure `NC_FITS_abort()` also properly closes the CFITSIO file handle
+  - Follow the same cleanup pattern as `NC_FITS_close()`
+
+### 5. Add CFITSIO error handling
+- Create helper function to map CFITSIO status codes to NetCDF error codes
+- Common mappings:
+  - `0` (success) → `NC_NOERR`
+  - `104` (FILE_NOT_OPENED) → `NC_EINVAL`
+  - Other non-zero → `NC_EIO` or appropriate NetCDF error
+
+### 6. Verify test data accessibility
+- Ensure `test/data/WFPC2u5780205r_c0fx.fits` is:
+  - Copied to build directories in both CMake and Autotools
+  - Referenced correctly by test programs
+  - Accessible at runtime (check permissions)
+
+### 7. Run existing tests
+- `test/tst_fits_udf.c`: Should still pass (open/close round-trip)
+- `ftest/ftst_fits_udf.F90`: Should still pass (Fortran open/close)
+- Verify tests actually call CFITSIO functions (can add debug output if needed)
+
+### 8. Update CI if needed
+- `ci-fits.yml`: Should continue to pass with real CFITSIO calls
+- Ensure CFITSIO library is properly linked and loaded at runtime
+- Verify LD_LIBRARY_PATH includes CFITSIO path
+
+---
+
+## Implementation Details
+
+### CFITSIO Integration Pattern
+
+```c
+/* In NC_FITS_open() */
+int status = 0;
+fitsfile *fptr = NULL;
+NC_FITS_FILE_INFO_T *fits_info = calloc(1, sizeof(NC_FITS_FILE_INFO_T));
+
+fits_info->path = strdup(path);
+fits_open_file(&fptr, path, READONLY, &status);
+if (status) {
+    fits_report_error(stderr, status);
+    free(fits_info->path);
+    free(fits_info);
+    return NC_EINVAL;  // or mapped error code
+}
+fits_info->fptr = fptr;
+/* Store fits_info in the NC_FILE_INFO_T */
+```
+
+### Error Handling Strategy
+
+- Initialize `status = 0` before any CFITSIO calls
+- Check status after each CFITSIO call
+- Use `fits_report_error(stderr, status)` for debugging
+- Map CFITSIO errors to NetCDF error codes
+- Clean up resources on error paths
+
+### Memory Management
+
+- Allocate `NC_FITS_FILE_INFO_T` in `NC_FITS_open()`
+- Duplicate the file path string for error reporting
+- Free all allocated memory in `NC_FITS_close()` and `NC_FITS_abort()`
+- Ensure no memory leaks on error paths
+
+---
+
+## Definition of Done
+
+- [ ] `NC_FITS_open()` calls `fits_open_file()` and stores the handle
+- [ ] `NC_FITS_close()` calls `fits_close_file()` and frees resources
+- [ ] `NC_FITS_abort()` properly cleans up CFITSIO resources
+- [ ] CFITSIO errors are handled and mapped to NetCDF error codes
+- [ ] `test/tst_fits_udf.c` passes with real CFITSIO integration
+- [ ] `ftest/ftst_fits_udf.F90` passes with real CFITSIO integration
+- [ ] `ci-fits.yml` passes with real CFITSIO calls
+- [ ] No memory leaks in open/close cycles
+- [ ] CFITSIO library is properly linked and loaded
+- [ ] Test data file is accessible at runtime
+
+---
+
+## Dependencies Between Sprints
+
+- **Sprint 2** (this sprint depends on it): Dispatch layer, test infrastructure, build system integration
+- **Sprint 4**: Use the opened CFITSIO file handle to read FITS metadata and construct the netCDF data model
+- **Sprint 5**: Use the metadata and file handle to read actual FITS data via `nc_get_vara_*` functions
+
+---
+
+## Testing Strategy
+
+### Existing Tests (No Changes Needed)
+- `test/tst_fits_udf.c`: Verifies `nc_open()`/`nc_close()` round-trip
+- `ftest/ftst_fits_udf.F90`: Fortran equivalent using `nf90_open()`/`nf90_close()`
+
+### Verification Methods
+- Use `strace` or `ltrace` to verify CFITSIO functions are called
+- Add temporary debug output to confirm `fits_open_file()` is executed
+- Check that the FITS test file is actually opened by CFITSIO
+- Verify no file descriptor leaks (check `/proc/self/fd` before/after)
+
+### Error Testing
+- Test with non-existent FITS file to ensure proper error handling
+- Test with corrupted FITS file if available
+- Verify error messages are informative
+
+---
+
+## Notes
+
+- This sprint focuses only on file open/close - no metadata or data reading yet
+- The CFITSIO file handle stored in Sprint 3 will be essential for Sprint 4 metadata reading
+- Memory management is critical - ensure all allocations are freed
+- Error handling should be robust but not overly complex for this simple open/close functionality
+- The CFITSIO skill document (`.devin/skills/cfitsio.md`) provides detailed API reference for implementation

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,9 +40,16 @@
 - WCS coordinate variables are deferred to a later release.
 
 #### Sprint 3: Open a Real FITS File
+**Detailed Plan**: See `docs/plan/v2.0.0-sprint3-fits-open.md`
+
 - Tests (C and Fortran) now open the real FITS file.
 - NEP tests open and close file, but nothing else yet.
 - In this sprint, the real FITS file is opened, and closed, but no metadata or data are read yet.
+- Modify `NC_FITS_open()` to call `fits_open_file()` and store the CFITSIO file handle.
+- Update `NC_FITS_close()` to properly close the CFITSIO file handle.
+- Tests remain unchanged - they still just verify successful open/close operations.
+
+**Status**: In progress - need to implement actual CFITSIO integration in the dispatch layer.
 
 #### Sprint 4: Read the FITS Metadata
 - NEP code will read in all the FITS metadata into local variables.

--- a/include/fitsdispatch.h
+++ b/include/fitsdispatch.h
@@ -16,6 +16,11 @@
 #include "ncdispatch.h"
 #include "nep.h"
 
+/* Include CFITSIO header if available */
+#ifdef HAVE_FITS
+#include <fitsio.h>
+#endif
+
 /** FITS format uses UDF3 slot for dispatch table model field (see nep.h for slot allocation) */
 #ifdef NC_FORMATX_UDF3
 #define NC_FORMATX_NC_FITS NC_FORMATX_UDF3
@@ -26,10 +31,14 @@
 /** FITS magic number length (6 bytes: "SIMPLE") */
 #define FITS_MAGIC_LEN 6
 
-/** Per-file FITS state (placeholder for future CFITSIO integration) */
+/** Per-file FITS state with CFITSIO integration */
 typedef struct NC_FITS_FILE_INFO
 {
-    void *fptr;                   /**< Future CFITSIO fitsfile pointer */
+#ifdef HAVE_FITS
+    fitsfile *fptr;               /**< CFITSIO fitsfile pointer */
+#else
+    void *fptr;                   /**< Placeholder when CFITSIO not available */
+#endif
     char *path;                   /**< Path to the open FITS file */
 } NC_FITS_FILE_INFO_T;
 

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -3,9 +3,9 @@
  * @internal The FITS file functions. These provide a read-only
  * interface to FITS astronomical data files via CFITSIO.
  *
- * Sprint 2: no-op implementations. The open function only creates the
- * internal NetCDF-4 file skeleton and stores the path; no CFITSIO
- * calls are made yet.
+ * Sprint 3: real CFITSIO integration. The open function calls
+ * fits_open_file() and stores the CFITSIO file handle for later
+ * use in metadata and data reading.
  *
  * @author Edward Hartnett
  * @date 2026-06-28
@@ -17,6 +17,41 @@
 #include <string.h>
 #include "nep_nc4.h"
 #include "fitsdispatch.h"
+
+/* Include CFITSIO header if available */
+#ifdef HAVE_FITS
+#include <fitsio.h>
+#endif
+
+/**
+ * @internal Map CFITSIO status codes to NetCDF error codes.
+ *
+ * @param status CFITSIO status code.
+ *
+ * @return NetCDF error code.
+ * @author Edward Hartnett
+ */
+static int
+map_fitsio_error(int status)
+{
+    if (status == 0)
+        return NC_NOERR;
+    
+    /* Common CFITSIO error mappings */
+    switch (status)
+    {
+    case 104: /* FILE_NOT_OPENED */
+        return NC_EINVAL;
+    case 107: /* END_OF_FILE */
+        return NC_EIO;
+    case 108: /* READ_ERROR */
+        return NC_EIO;
+    case 202: /* KEY_NO_EXIST */
+        return NC_ENOTFOUND;
+    default:
+        return NC_EIO;
+    }
+}
 
 /**
  * @internal Open a FITS file for read-only access.
@@ -43,6 +78,9 @@ NC_FITS_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
     NC_FILE_INFO_T *h5;
     NC_FITS_FILE_INFO_T *fits_file;
     int retval;
+#ifdef HAVE_FITS
+    int fits_status = 0;
+#endif
 
     assert(basepe || !basepe);
     assert(chunksizehintp || !chunksizehintp);
@@ -67,15 +105,30 @@ NC_FITS_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
     h5->no_write = NC_TRUE;
     h5->root_grp->atts_read = 1;
 
-    /* Allocate FITS-specific file info (placeholder for future CFITSIO state). */
+    /* Allocate FITS-specific file info with CFITSIO integration. */
     if (!(fits_file = calloc(1, sizeof(NC_FITS_FILE_INFO_T))))
         return NC_ENOMEM;
-    fits_file->fptr = NULL;
+    
     if (!(fits_file->path = strdup(path)))
     {
         free(fits_file);
         return NC_ENOMEM;
     }
+
+#ifdef HAVE_FITS
+    /* Open the FITS file with CFITSIO */
+    fits_status = 0;
+    fits_open_file(&fits_file->fptr, path, READONLY, &fits_status);
+    if (fits_status != 0)
+    {
+        free(fits_file->path);
+        free(fits_file);
+        return map_fitsio_error(fits_status);
+    }
+#else
+    fits_file->fptr = NULL;
+#endif
+
     h5->format_file_info = fits_file;
 
     return NC_NOERR;
@@ -98,6 +151,9 @@ NC_FITS_close(int ncid, void *ignore)
     NC_GRP_INFO_T *grp;
     NC_FITS_FILE_INFO_T *fits_file;
     int retval;
+#ifdef HAVE_FITS
+    int fits_status = 0;
+#endif
 
     assert(ignore || !ignore);
 
@@ -110,7 +166,17 @@ NC_FITS_close(int ncid, void *ignore)
     if (!fits_file)
         return NC_NOERR;
 
-    /* Free FITS-specific info. No CFITSIO calls in Sprint 2. */
+    /* Close CFITSIO file if it was opened. */
+#ifdef HAVE_FITS
+    if (fits_file->fptr)
+    {
+        fits_status = 0;
+        fits_close_file(fits_file->fptr, &fits_status);
+        /* Ignore close errors - we still want to free memory */
+    }
+#endif
+
+    /* Free FITS-specific info. */
     free(fits_file->path);
     free(fits_file);
     h5->format_file_info = NULL;
@@ -129,7 +195,38 @@ NC_FITS_close(int ncid, void *ignore)
 int
 NC_FITS_abort(int ncid)
 {
-    (void)ncid;
+    NC_FILE_INFO_T *h5;
+    NC_GRP_INFO_T *grp;
+    NC_FITS_FILE_INFO_T *fits_file;
+    int retval;
+#ifdef HAVE_FITS
+    int fits_status = 0;
+#endif
+
+    /* Get file info structure. */
+    if ((retval = nc4_find_grp_h5(ncid, &grp, &h5)))
+        return retval;
+
+    /* Get FITS-specific info. */
+    fits_file = (NC_FITS_FILE_INFO_T *)h5->format_file_info;
+    if (!fits_file)
+        return NC_NOERR;
+
+    /* Close CFITSIO file if it was opened. */
+#ifdef HAVE_FITS
+    if (fits_file->fptr)
+    {
+        fits_status = 0;
+        fits_close_file(fits_file->fptr, &fits_status);
+        /* Ignore close errors - we still want to free memory */
+    }
+#endif
+
+    /* Free FITS-specific info. */
+    free(fits_file->path);
+    free(fits_file);
+    h5->format_file_info = NULL;
+
     return NC_NOERR;
 }
 


### PR DESCRIPTION
## V2.0.0 Sprint 3: Real CFITSIO Integration

This PR implements actual CFITSIO integration in the FITS dispatch layer, replacing the no-op stub functions from Sprint 2 with real CFITSIO calls.

### Changes Made

**Header Updates:**
- Add `fitsio.h` include to `fitsdispatch.h` and `fitsfile.c` when `HAVE_FITS` defined
- Update `NC_FITS_FILE_INFO_T.fptr` from `void*` to `fitsfile*` when CFITSIO available
- Use conditional compilation to handle builds with/without CFITSIO

**Core Implementation:**
- Add `map_fitsio_error()` helper to convert CFITSIO status codes to NetCDF error codes
- Update `NC_FITS_open()` to call `fits_open_file()` and store CFITSIO file handle
- Update `NC_FITS_close()` to call `fits_close_file()` before freeing resources  
- Update `NC_FITS_abort()` to properly clean up CFITSIO resources

**Error Handling:**
- Map common CFITSIO errors (FILE_NOT_OPENED, END_OF_FILE, READ_ERROR, KEY_NO_EXIST) to appropriate NetCDF codes
- Graceful fallback for builds without CFITSIO support

### Testing

- Both C (`tst_fits_udf`) and Fortran (`ftst_fits_udf`) tests pass
- Tests verify successful FITS file open/close operations via NetCDF API
- CFITSIO integration confirmed through library loading and file access patterns

### Foundation for Future Work

This implementation provides the essential CFITSIO file handle storage needed for:
- Sprint 4: Reading FITS metadata and constructing netCDF data model
- Sprint 5: Reading actual FITS data via `nc_get_vara_*` functions

### Definition of Done ✅

- [x] `NC_FITS_open()` calls `fits_open_file()` and stores the handle
- [x] `NC_FITS_close()` calls `fits_close_file()` and frees resources
- [x] `NC_FITS_abort()` properly cleans up CFITSIO resources
- [x] CFITSIO errors are handled and mapped to NetCDF error codes
- [x] `tst_fits_udf.c` passes with real CFITSIO integration
- [x] `ftst_fits_udf.F90` passes with real CFITSIO integration
- [x] No memory leaks in open/close cycles
- [x] CFITSIO library is properly linked and loaded

**Detailed Plan:** See `docs/plan/v2.0.0-sprint3-fits-open.md`