### PR TITLE
v2.0.0 Sprint 4a: Read primary HDU metadata

### DIFF
--- a/docs/plan/v2.0.0-sprint4a-fits-primary-metadata.md
+++ b/docs/plan/v2.0.0-sprint4a-fits-primary-metadata.md
@@ -1,0 +1,236 @@
+# V2.0.0 Sprint 4a: Read Primary HDU Metadata
+
+**Objective**: Read the primary HDU of a FITS file and populate the netCDF-4
+in-memory model with its dimensions, variable, and attributes. `nc_inq*` functions
+must return correct results for the primary HDU of `WFPC2u5780205r_c0fx.fits`.
+Extension HDUs are deferred to Sprint 4b.
+
+---
+
+## Background
+
+Sprint 3 delivered a real `NC_FITS_open()` / `NC_FITS_close()` that calls CFITSIO
+but reads no metadata. Sprint 4a adds the metadata inventory for the primary HDU
+only, following the same pattern used in `cdffile.c` (`nc4_dim_list_add`,
+`nc4_var_list_add_full`, `nc4_att_list_add`).
+
+**Test file structure** (`WFPC2u5780205r_c0fx.fits`):
+- **HDU 1** (primary): `IMAGE_HDU`, `BITPIX=-32` (NC_FLOAT), `NAXIS=3`,
+  `NAXIS1=200, NAXIS2=200, NAXIS3=4`, 262 header keywords
+- **HDU 2** (extension): `ASCII_TBL`, extname=`u5780205r_cvt.c0h.tab`,
+  4 rows × 49 cols, 353 header keywords — deferred to Sprint 4b
+
+**netCDF mapping for primary HDU**:
+- FITS column-major `[NAXIS1=200, NAXIS2=200, NAXIS3=4]` → reversed to netCDF
+  row-major `[4, 200, 200]`
+- Dimension names: `dim_0` (size 4), `dim_1` (size 200), `dim_2` (size 200)
+- Variable name: `image` (primary HDU has no EXTNAME); type `NC_FLOAT`
+- All 262 primary header keywords → root group global attributes
+
+---
+
+## Matrix
+
+| Dimension      | Values                        |
+|----------------|-------------------------------|
+| `build_system` | `cmake`, `autotools`          |
+| Fortran        | ON                            |
+| FITS           | ON                            |
+
+---
+
+## Tasks
+
+### 1. Expand `NC_FITS_FILE_INFO_T`
+
+`include/fitsdispatch.h`:
+- Add `int num_hdus` field (total HDU count, filled during open).
+- No per-HDU struct is needed at this sprint; the `fptr` already stored in
+  Sprint 3 is sufficient since `NC_FITS_get_vara` will `fits_movabs_hdu` on
+  demand. For now, the variable's `format_var_info` stores the 1-based HDU
+  index.
+
+Add a per-variable info struct for FITS:
+
+```c
+/** Per-variable FITS info: which HDU and (for tables) which column. */
+typedef struct NC_FITS_VAR_INFO
+{
+    int hdu_num;    /**< 1-based HDU number in the FITS file */
+    int col_num;    /**< 1-based column number (0 = image variable) */
+} NC_FITS_VAR_INFO_T;
+```
+
+### 2. Add `fits_bitpix_to_nc_type()` helper
+
+`src/fitsfile.c` — static function:
+
+```c
+static int
+fits_bitpix_to_nc_type(int bitpix, nc_type *xtypep, size_t *type_sizep,
+                       char *type_name, int *endiannessp)
+```
+
+| BITPIX | nc_type    | size | name    | endianness         |
+|--------|------------|------|---------|--------------------|
+| 8      | NC_UBYTE   | 1    | "ubyte" | NC_ENDIAN_NATIVE   |
+| 16     | NC_SHORT   | 2    | "short" | NC_ENDIAN_BIG      |
+| 32     | NC_INT     | 4    | "int"   | NC_ENDIAN_BIG      |
+| 64     | NC_INT64   | 8    | "int64" | NC_ENDIAN_BIG      |
+| -32    | NC_FLOAT   | 4    | "float" | NC_ENDIAN_BIG      |
+| -64    | NC_DOUBLE  | 8    | "double"| NC_ENDIAN_BIG      |
+| other  | return `NC_EBADTYPE` | | | |
+
+FITS stores integers big-endian; floats are IEEE big-endian.
+
+### 3. Add `fits_read_primary_atts()` helper
+
+`src/fitsfile.c` — static function that reads all header keyword cards from the
+current HDU and stores them as netCDF attributes on a given group:
+
+```c
+static int
+fits_read_primary_atts(fitsfile *fptr, NC_GRP_INFO_T *grp)
+```
+
+- Call `fits_get_hdrspace(fptr, &nkeys, NULL, &status)`.
+- Loop `k = 1..nkeys`: call `fits_read_record(fptr, k, card, &status)`.
+- Parse each 80-character card:
+  - Skip structural keywords that are not useful as attributes:
+    `SIMPLE`, `EXTEND`, `END`, `XTENSION`, `BITPIX`, `NAXIS`, `NAXISn`.
+  - Use `fits_parse_value(card, value, comment, &status)` to split keyword /
+    value / comment (or simply store all non-structural cards as `NC_CHAR`
+    attributes using the raw value string, trimming trailing spaces).
+  - For simplicity in Sprint 4a: store every non-structural keyword as a
+    `NC_CHAR` attribute. The attribute name is the keyword (first 8 chars,
+    trimmed); the value is the value string (trimmed).
+  - Handle duplicates (`COMMENT`, `HISTORY`): append to an existing `NC_CHAR`
+    attribute by separator `\n`, or store as indexed names
+    (`COMMENT_0`, `COMMENT_1`, …).
+- Call `nc4_att_list_add(grp->att, name, &att)`, then set `att->nc_typeid =
+  NC_CHAR`, `att->len = strlen(value)`, `att->data = strdup(value)`.
+
+### 4. Add `fits_read_primary_hdu()` helper
+
+`src/fitsfile.c` — static function:
+
+```c
+static int
+fits_read_primary_hdu(NC_FILE_INFO_T *h5)
+```
+
+Steps:
+1. Move to HDU 1: `fits_movabs_hdu(fptr, 1, &hdutype, &status)`.
+2. Call `fits_get_img_param(fptr, NC_MAX_VAR_DIMS, &bitpix, &naxis, naxes,
+   &status)`.
+3. If `naxis == 0`: no image data — skip variable/dim creation, but still read
+   attributes (step 6).
+4. Map `bitpix` via `fits_bitpix_to_nc_type()`.
+5. Create `naxis` dimensions in reverse order (FITS index `naxis-1-d` →
+   netCDF dimension `d`):
+   - Name: `dim_0`, `dim_1`, …, `dim_{naxis-1}`
+   - Size: `naxes[naxis-1-d]`
+   - Call `nc4_dim_list_add(h5->root_grp, name, size, -1, &dim)`.
+   - Collect `dimids[]` array.
+6. Allocate `NC_FITS_VAR_INFO_T` with `hdu_num = 1`, `col_num = 0`.
+7. Call `nc4_var_list_add_full(h5->root_grp, "image", naxis, xtype,
+   endianness, type_size, type_name, NULL, 1, NULL, var_fits_info, &var)`.
+8. Set `var->dimids[d] = dimids[d]` for `d = 0..naxis-1`.
+9. Call `fits_read_primary_atts(fptr, h5->root_grp)`.
+
+### 5. Call `fits_read_primary_hdu()` from `NC_FITS_open()`
+
+`src/fitsfile.c` — after the successful `fits_open_file()` call and storing
+`fits_file->fptr`, add:
+
+```c
+if ((retval = fits_read_primary_hdu(h5)))
+{
+    fits_close_file(fits_file->fptr, &fits_status);
+    free(fits_file->path);
+    free(fits_file);
+    return retval;
+}
+```
+
+Also store `fits_file->num_hdus` using:
+```c
+fits_get_num_hdus(fits_file->fptr, &fits_file->num_hdus, &fits_status);
+```
+(call this before `fits_read_primary_hdu`, before moving HDUs).
+
+### 6. Update `test/tst_fits_udf.c`
+
+Replace the existing open/close-only test with assertions against known values
+for the primary HDU of `WFPC2u5780205r_c0fx.fits`:
+
+```
+nc_inq(ncid, &ndims, &nvars, &ngatts, &unlimdimid)
+  → ndims=3, nvars=1, ngatts>=10, unlimdimid=-1
+
+nc_inq_dim(ncid, 0, name, &len) → dim_0, len=4
+nc_inq_dim(ncid, 1, name, &len) → dim_1, len=200
+nc_inq_dim(ncid, 2, name, &len) → dim_2, len=200
+
+nc_inq_var(ncid, 0, name, &xtype, &ndims, dimids, &natts)
+  → name="image", xtype=NC_FLOAT, ndims=3
+
+nc_inq_att(ncid, NC_GLOBAL, "BSCALE", &xtype, &len) → NC_CHAR
+nc_inq_att(ncid, NC_GLOBAL, "BZERO",  &xtype, &len) → NC_CHAR
+nc_inq_att(ncid, NC_GLOBAL, "ORIGIN", &xtype, &len) → NC_CHAR
+```
+
+Keep `PASS:` print lines for each check.
+
+---
+
+## Implementation Notes
+
+### Keyword parsing approach (Sprint 4a)
+
+All keyword values stored as `NC_CHAR` is simple and safe. It avoids the
+complexity of typed attribute mapping (which requires parsing FITS value
+strings). Sprint 4b or a follow-on sprint can add typed mapping for known
+standard keywords (`BSCALE`, `BZERO`, etc.).
+
+### Structural keywords to skip
+
+Do not create attributes for these — they describe structure already captured
+in dims/vars:
+`SIMPLE`, `BITPIX`, `NAXIS`, `NAXIS1`…`NAXIS9`, `EXTEND`, `XTENSION`, `END`,
+`PCOUNT`, `GCOUNT`.
+
+### `COMMENT` / `HISTORY` handling
+
+FITS files can have many `COMMENT` and `HISTORY` cards. Concatenate all
+`COMMENT` cards into one `NC_CHAR` attribute named `COMMENT` (newline-separated),
+and similarly for `HISTORY`. This avoids creating dozens of duplicate-named
+attributes.
+
+### Dimension naming
+
+Use `dim_0`, `dim_1`, `dim_2` for the primary HDU. These are the reversed
+FITS axes: `dim_0` corresponds to `NAXIS3=4`, `dim_1` to `NAXIS2=200`,
+`dim_2` to `NAXIS1=200`.
+
+---
+
+## Definition of Done
+
+- [ ] `NC_FITS_FILE_INFO_T` has `num_hdus` field; `NC_FITS_VAR_INFO_T` struct defined
+- [ ] `fits_bitpix_to_nc_type()` covers all six BITPIX values
+- [ ] `fits_read_primary_atts()` stores all non-structural keywords as `NC_CHAR` attributes
+- [ ] `fits_read_primary_hdu()` creates 3 dims, 1 variable in root group for the test file
+- [ ] `NC_FITS_open()` calls `fits_read_primary_hdu()` after opening
+- [ ] `test/tst_fits_udf.c` asserts dims, variable name/type, and selected global attributes
+- [ ] `ftest/ftst_fits_udf.F90` asserts at minimum `ndims=3`, `nvars=1` via `nf90_inquire`
+- [ ] CMake and Autotools builds pass `ci-fits.yml`
+- [ ] No memory leaks on open/close of primary HDU metadata
+
+---
+
+## Dependencies
+
+- **Sprint 3** (prerequisite): real `fits_open_file()` / `fits_close_file()` in place
+- **Sprint 4b** (follows): extension HDU child groups, table column variables
+- **Sprint 5** (follows): `NC_FITS_get_vara()` uses `hdu_num` stored in `NC_FITS_VAR_INFO_T`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,12 +51,24 @@
 
 **Status**: In progress - need to implement actual CFITSIO integration in the dispatch layer.
 
-#### Sprint 4: Read the FITS Metadata
-- NEP code will read in all the FITS metadata into local variables.
-- Metadata will be used to construct netcdf data model objects.
-- The main FITS HDU will be in the root group. Additional ADUs will be child groups of the root group.
-- nc_inq* functions will now return correct results for the file. Tests are updated to confirm all file metadata is as expected for this test file.
-- By the end of this sprint, FITS metadata will have been converted to the netCDF model.
+#### Sprint 4a: Read Primary HDU Metadata
+**Detailed Plan**: See `docs/plan/v2.0.0-sprint4a-fits-primary-metadata.md`
+
+- Read all header keywords from the primary HDU and store them as global netCDF attributes on the root group.
+- For the primary HDU image (if `NAXIS > 0`): create netCDF dimensions (reversed order from FITS) and a netCDF variable in the root group.
+- Map `BITPIX` to the correct `nc_type`; map standard keywords (`BUNIT`→`units`, `BZERO`→`add_offset`, `BSCALE`→`scale_factor`, `BLANK`→`_FillValue`) to netCDF attributes.
+- `nc_inq*` functions now return correct results for the primary HDU. C test is updated to confirm primary HDU dims, variable, and attributes for the test FITS file.
+- No extension HDUs in this sprint.
+
+#### Sprint 4b: Read Extension HDU Metadata
+**Detailed Plan**: See `docs/plan/v2.0.0-sprint4b-fits-extension-metadata.md`
+
+- Each extension HDU becomes a child group of the root group, named from `EXTNAME` (or `hdu_N` if absent).
+- Image extension HDUs: same dim/variable/attribute mapping as 4a, applied to the child group.
+- Binary and ASCII table HDUs: create a row dimension (`NAXIS2`), one netCDF variable per column (named from `TTYPEn`), with `TUNITn`→`units` attributes. Vector columns become 2D variables.
+- All HDU header keywords stored as group-level attributes.
+- C and Fortran tests updated to verify extension group names, dims, variables, and attributes for the test FITS file.
+- By the end of this sprint, all FITS metadata will have been converted to the netCDF model.
 
 #### Sprint 5: Read the FITS Data
 - NEP C and Fortran tests read data from FITS file, and confirm it is correct by comparing agains stored values for some subset of the data.

--- a/ftest/ftst_fits_udf.F90
+++ b/ftest/ftst_fits_udf.F90
@@ -25,6 +25,9 @@ program ftst_fits_udf
   integer :: ncid
   integer :: retval
   integer(c_int) :: init_status
+  integer :: ndims, nvars, ngatts, unlimdimid
+  character(len=NF90_MAX_NAME) :: dimname
+  integer :: dimlen
 
   ! Ensure the FITS UDF handler is registered (also covers builds where
   ! .ncrc autoload is not active).
@@ -40,7 +43,51 @@ program ftst_fits_udf
      print *, "Error opening FITS file: ", trim(nf90_strerror(retval))
      stop 1
   endif
-  print *, "PASS: nf90_open FITS file"
+  print *, "PASS: nf90_open"
+
+  ! Check primary HDU metadata: 3 dims, 1 var, no unlimited dim.
+  retval = nf90_inquire(ncid, ndims, nvars, ngatts, unlimdimid)
+  if (retval /= nf90_noerr) then
+     print *, "Error in nf90_inquire: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  if (ndims /= 3) then
+     print *, "Expected 3 dims, got ", ndims
+     stop 1
+  endif
+  if (nvars /= 1) then
+     print *, "Expected 1 var, got ", nvars
+     stop 1
+  endif
+  if (unlimdimid /= -1) then
+     print *, "Expected no unlimited dim, got ", unlimdimid
+     stop 1
+  endif
+  print *, "PASS: nf90_inquire ndims=", ndims, " nvars=", nvars
+
+  ! Check dim_0 = 4 (reversed NAXIS3).
+  retval = nf90_inquire_dimension(ncid, 1, dimname, dimlen)
+  if (retval /= nf90_noerr) then
+     print *, "Error inquiring dim 1: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  if (trim(dimname) /= "dim_0" .or. dimlen /= 4) then
+     print *, "dim_0: expected name='dim_0' len=4, got '", trim(dimname), "' len=", dimlen
+     stop 1
+  endif
+  print *, "PASS: dim_0 len=", dimlen
+
+  ! Check dim_1 = 200.
+  retval = nf90_inquire_dimension(ncid, 2, dimname, dimlen)
+  if (retval /= nf90_noerr) then
+     print *, "Error inquiring dim 2: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  if (dimlen /= 200) then
+     print *, "dim_1: expected len=200, got ", dimlen
+     stop 1
+  endif
+  print *, "PASS: dim_1 len=", dimlen
 
   ! Close the file.
   retval = nf90_close(ncid)
@@ -48,6 +95,6 @@ program ftst_fits_udf
      print *, "Error closing FITS file: ", trim(nf90_strerror(retval))
      stop 1
   endif
-  print *, "PASS: nf90_close FITS file"
+  print *, "PASS: nf90_close"
 
 end program ftst_fits_udf

--- a/include/fitsdispatch.h
+++ b/include/fitsdispatch.h
@@ -31,6 +31,13 @@
 /** FITS magic number length (6 bytes: "SIMPLE") */
 #define FITS_MAGIC_LEN 6
 
+/** Per-variable FITS info: which HDU and (for tables) which column. */
+typedef struct NC_FITS_VAR_INFO
+{
+    int hdu_num;    /**< 1-based HDU number in the FITS file */
+    int col_num;    /**< 1-based column number; 0 = image variable */
+} NC_FITS_VAR_INFO_T;
+
 /** Per-file FITS state with CFITSIO integration */
 typedef struct NC_FITS_FILE_INFO
 {
@@ -40,6 +47,7 @@ typedef struct NC_FITS_FILE_INFO
     void *fptr;                   /**< Placeholder when CFITSIO not available */
 #endif
     char *path;                   /**< Path to the open FITS file */
+    int num_hdus;                 /**< Total number of HDUs in the file */
 } NC_FITS_FILE_INFO_T;
 
 #if defined(__cplusplus)

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -53,6 +53,423 @@ map_fitsio_error(int status)
     }
 }
 
+extern int nc4_var_list_add(NC_GRP_INFO_T *grp, const char *name, int ndims,
+                            NC_VAR_INFO_T **var);
+
+/**
+ * @internal Set the type of a netCDF-4 variable.
+ *
+ * @param xtype A netcdf type.
+ * @param endianness The endianness of the data.
+ * @param type_size The size in bytes of one element of this type.
+ * @param type_name A name for the type.
+ * @param typep Pointer to a pointer that gets the TYPE_INFO_T struct.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Ed Hartnett
+ */
+static int
+nc4_set_var_type(nc_type xtype, int endianness, size_t type_size,
+                 char *type_name, NC_TYPE_INFO_T **typep)
+{
+    NC_TYPE_INFO_T *type;
+
+    assert(typep);
+
+    if (!(type = calloc(1, sizeof(NC_TYPE_INFO_T))))
+        return NC_ENOMEM;
+    if (!(type->hdr.name = strdup(type_name)))
+    {
+        free(type);
+        return NC_ENOMEM;
+    }
+    type->hdr.sort = NCTYP;
+
+    if (xtype == NC_FLOAT)
+        type->nc_type_class = NC_FLOAT;
+    else if (xtype == NC_DOUBLE)
+        type->nc_type_class = NC_DOUBLE;
+    else if (xtype == NC_CHAR)
+        type->nc_type_class = NC_STRING;
+    else
+        type->nc_type_class = NC_INT;
+
+    type->endianness = endianness;
+    type->size = type_size;
+    type->hdr.id = (size_t)xtype;
+
+    *typep = type;
+    return NC_NOERR;
+}
+
+/**
+ * @internal Create a new variable and insert it into relevant lists.
+ *
+ * @param grp The containing group.
+ * @param name The variable name.
+ * @param ndims The rank.
+ * @param xtype The netCDF data type.
+ * @param endianness Byte order.
+ * @param type_size Size in bytes of one element.
+ * @param type_name Human-readable type name.
+ * @param fill_value Optional fill value (may be NULL).
+ * @param contiguous Non-zero for contiguous storage.
+ * @param chunksizes Optional chunk sizes (may be NULL).
+ * @param format_var_info Format-specific per-variable metadata.
+ * @param var Output: pointer to the new variable.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_ENOMEM Out of memory.
+ * @author Ed Hartnett
+ */
+static int
+nc4_var_list_add_full(NC_GRP_INFO_T *grp, const char *name, int ndims,
+                      nc_type xtype, int endianness, size_t type_size,
+                      char *type_name, void *fill_value, int contiguous,
+                      size_t *chunksizes, void *format_var_info,
+                      NC_VAR_INFO_T **var)
+{
+    int d, retval;
+
+    if ((retval = nc4_var_list_add(grp, name, ndims, var)))
+        return retval;
+    (*var)->created = NC_TRUE;
+    (*var)->written_to = NC_TRUE;
+    (*var)->format_var_info = format_var_info;
+    (*var)->atts_read = 1;
+
+    if ((retval = nc4_set_var_type(xtype, endianness, type_size, type_name,
+                                   &(*var)->type_info)))
+        return retval;
+
+    (*var)->endianness = (*var)->type_info->endianness;
+    (*var)->type_info->rc++;
+
+    if (fill_value)
+    {
+        if (!((*var)->fill_value = malloc(type_size)))
+            return NC_ENOMEM;
+        memcpy((*var)->fill_value, fill_value, type_size);
+    }
+
+    (*var)->storage = contiguous ? NC_CONTIGUOUS : NC_CHUNKED;
+
+    if (chunksizes)
+    {
+        if (!((*var)->chunksizes = malloc(ndims * sizeof(size_t))))
+            return NC_ENOMEM;
+        for (d = 0; d < ndims; d++)
+            (*var)->chunksizes[d] = chunksizes[d];
+    }
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Map FITS BITPIX value to a netCDF type and associated metadata.
+ *
+ * @param bitpix FITS BITPIX value.
+ * @param xtypep Pointer that gets the nc_type. Ignored if NULL.
+ * @param type_sizep Pointer that gets the type size in bytes. Ignored if NULL.
+ * @param type_name Buffer (at least NC_MAX_NAME+1 bytes) that gets the type
+ * name string. Ignored if NULL.
+ * @param endiannessp Pointer that gets the endianness. Ignored if NULL.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADTYPE Unknown BITPIX value.
+ * @author Edward Hartnett
+ */
+#ifdef HAVE_FITS
+static int
+fits_bitpix_to_nc_type(int bitpix, nc_type *xtypep, size_t *type_sizep,
+                       char *type_name, int *endiannessp)
+{
+    nc_type xtype;
+    size_t type_size;
+    const char *name;
+    int endianness = NC_ENDIAN_BIG;
+
+    switch (bitpix)
+    {
+    case 8:
+        xtype = NC_UBYTE; type_size = 1; name = "ubyte";
+        endianness = NC_ENDIAN_NATIVE;
+        break;
+    case 16:
+        xtype = NC_SHORT; type_size = 2; name = "short";
+        break;
+    case 32:
+        xtype = NC_INT; type_size = 4; name = "int";
+        break;
+    case 64:
+        xtype = NC_INT64; type_size = 8; name = "int64";
+        break;
+    case -32:
+        xtype = NC_FLOAT; type_size = 4; name = "float";
+        break;
+    case -64:
+        xtype = NC_DOUBLE; type_size = 8; name = "double";
+        break;
+    default:
+        return NC_EBADTYPE;
+    }
+
+    if (xtypep) *xtypep = xtype;
+    if (type_sizep) *type_sizep = type_size;
+    if (type_name) strncpy(type_name, name, NC_MAX_NAME);
+    if (endiannessp) *endiannessp = endianness;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Read all header keywords from the current FITS HDU and store
+ * them as NC_CHAR global attributes on the given group.
+ *
+ * Structural keywords (SIMPLE, BITPIX, NAXIS, NAXISn, EXTEND, XTENSION,
+ * PCOUNT, GCOUNT, END) are skipped. Multiple COMMENT and HISTORY cards are
+ * each concatenated into a single attribute of the same name, separated by
+ * newlines.
+ *
+ * @param fptr CFITSIO file pointer, positioned at the HDU to read.
+ * @param grp Pointer to the netCDF-4 group that receives the attributes.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_ENOMEM Out of memory.
+ * @author Edward Hartnett
+ */
+static int
+fits_read_primary_atts(fitsfile *fptr, NC_GRP_INFO_T *grp)
+{
+    int status = 0, nkeys, k, retval;
+    char card[81];
+
+    /* Structural keywords that map to netCDF structure, not attributes */
+    static const char *skip_keys[] = {
+        "SIMPLE", "BITPIX", "NAXIS", "EXTEND", "XTENSION",
+        "PCOUNT", "GCOUNT", "END", NULL
+    };
+
+    fits_get_hdrspace(fptr, &nkeys, NULL, &status);
+    if (status)
+        return map_fitsio_error(status);
+
+    for (k = 1; k <= nkeys; k++)
+    {
+        char keyword[9] = "";   /* 8-char keyword + null */
+        char value[71] = "";    /* FLEN_VALUE */
+        char comment[73] = "";  /* FLEN_COMMENT */
+        int skip = 0;
+        int i;
+
+        status = 0;
+        fits_read_record(fptr, k, card, &status);
+        if (status)
+            continue;
+
+        /* Extract keyword (first 8 chars, trimmed) */
+        strncpy(keyword, card, 8);
+        keyword[8] = '\0';
+        /* Right-trim spaces */
+        for (i = 7; i >= 0 && keyword[i] == ' '; i--)
+            keyword[i] = '\0';
+
+        if (keyword[0] == '\0')
+            continue;
+
+        /* Skip NAXISn (NAXIS1..NAXIS9) */
+        if (strncmp(keyword, "NAXIS", 5) == 0)
+            continue;
+
+        /* Skip known structural keywords */
+        for (i = 0; skip_keys[i] != NULL; i++)
+        {
+            if (strcmp(keyword, skip_keys[i]) == 0)
+            {
+                skip = 1;
+                break;
+            }
+        }
+        if (skip)
+            continue;
+
+        /* Parse value and comment from card */
+        {
+            int ps = 0;
+            fits_parse_value(card, value, comment, &ps);
+            if (ps)
+            {
+                /* Blank/comment card: value is empty; use rest of card */
+                strncpy(value, card + 8, 70);
+                value[70] = '\0';
+            }
+        }
+
+        /* Right-trim value */
+        {
+            int vlen = (int)strlen(value);
+            while (vlen > 0 && (value[vlen-1] == ' ' || value[vlen-1] == '\''))
+                value[--vlen] = '\0';
+            /* Strip leading quote if present */
+            if (value[0] == '\'')
+                memmove(value, value + 1, strlen(value));
+        }
+
+        /* COMMENT and HISTORY: append to existing attribute if present */
+        if (strcmp(keyword, "COMMENT") == 0 || strcmp(keyword, "HISTORY") == 0)
+        {
+            NC_ATT_INFO_T *existing = NULL;
+            size_t att_idx;
+
+            for (att_idx = 0; att_idx < ncindexsize(grp->att); att_idx++)
+            {
+                NC_ATT_INFO_T *a = (NC_ATT_INFO_T *)ncindexith(grp->att, att_idx);
+                if (a && strcmp(a->hdr.name, keyword) == 0)
+                {
+                    existing = a;
+                    break;
+                }
+            }
+
+            if (existing)
+            {
+                /* Append newline + new value to existing data */
+                size_t old_len = existing->len;
+                size_t add_len = strlen(value);
+                char *new_data = malloc(old_len + 1 + add_len + 1);
+                if (!new_data)
+                    return NC_ENOMEM;
+                memcpy(new_data, existing->data, old_len);
+                new_data[old_len] = '\n';
+                memcpy(new_data + old_len + 1, value, add_len);
+                new_data[old_len + 1 + add_len] = '\0';
+                free(existing->data);
+                existing->data = new_data;
+                existing->len = old_len + 1 + add_len;
+                continue;
+            }
+        }
+
+        /* Add new attribute */
+        {
+            NC_ATT_INFO_T *att = NULL;
+            size_t vlen = strlen(value);
+            char *data = NULL;
+
+            if ((retval = nc4_att_list_add(grp->att, keyword, &att)))
+                return retval;
+
+            att->nc_typeid = NC_CHAR;
+            att->len = vlen;
+            if (vlen > 0)
+            {
+                if (!(data = malloc(vlen + 1)))
+                    return NC_ENOMEM;
+                memcpy(data, value, vlen + 1);
+            }
+            att->data = data;
+            att->dirty = NC_TRUE;
+        }
+    }
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Read the primary HDU of a FITS file and populate the
+ * netCDF-4 in-memory model with its dimensions, variable, and attributes.
+ *
+ * The primary HDU image is mapped to the root group as:
+ *  - FITS column-major axes reversed to netCDF row-major: dim_0 = NAXIS_N,
+ *    ..., dim_{N-1} = NAXIS1
+ *  - Variable named "image", type derived from BITPIX
+ *  - All non-structural header keywords stored as NC_CHAR global attributes
+ *
+ * @param h5 Pointer to the netCDF-4 file info struct.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_ENOMEM Out of memory.
+ * @author Edward Hartnett
+ */
+static int
+fits_read_primary_hdu(NC_FILE_INFO_T *h5)
+{
+    NC_FITS_FILE_INFO_T *fits_file;
+    NC_GRP_INFO_T *grp;
+    int status = 0, hdutype, bitpix, naxis, retval, d;
+    long naxes[NC_MAX_VAR_DIMS];
+    nc_type xtype;
+    size_t type_size;
+    char type_name[NC_MAX_NAME + 1];
+    int endianness;
+    int dimids[NC_MAX_VAR_DIMS];
+    NC_FITS_VAR_INFO_T *var_info = NULL;
+    NC_VAR_INFO_T *var = NULL;
+
+    fits_file = (NC_FITS_FILE_INFO_T *)h5->format_file_info;
+    grp = h5->root_grp;
+
+    /* Position at primary HDU */
+    fits_movabs_hdu(fits_file->fptr, 1, &hdutype, &status);
+    if (status)
+        return map_fitsio_error(status);
+
+    /* Get image parameters */
+    fits_get_img_param(fits_file->fptr, NC_MAX_VAR_DIMS, &bitpix, &naxis,
+                       naxes, &status);
+    if (status)
+        return map_fitsio_error(status);
+
+    /* Map BITPIX to netCDF type */
+    if ((retval = fits_bitpix_to_nc_type(bitpix, &xtype, &type_size,
+                                         type_name, &endianness)))
+        return retval;
+
+    if (naxis > 0)
+    {
+        /* Create dimensions in reversed order (FITS col-major → netCDF row-major).
+           FITS naxes[0]=NAXIS1 (fastest), naxes[naxis-1]=NAXISn (slowest).
+           netCDF dim_0 = naxes[naxis-1] (slowest = outermost). */
+        for (d = 0; d < naxis; d++)
+        {
+            NC_DIM_INFO_T *dim;
+            char dimname[NC_MAX_NAME + 1];
+            size_t dimsize = (size_t)naxes[naxis - 1 - d];
+
+            snprintf(dimname, NC_MAX_NAME, "dim_%d", d);
+            if ((retval = nc4_dim_list_add(grp, dimname, dimsize, -1, &dim)))
+                return retval;
+            dimids[d] = dim->hdr.id;
+        }
+
+        /* Allocate per-variable FITS info */
+        if (!(var_info = calloc(1, sizeof(NC_FITS_VAR_INFO_T))))
+            return NC_ENOMEM;
+        var_info->hdu_num = 1;
+        var_info->col_num = 0;
+
+        /* Add variable to root group */
+        if ((retval = nc4_var_list_add_full(grp, "image", naxis, xtype,
+                                            endianness, type_size, type_name,
+                                            NULL, 1, NULL, var_info, &var)))
+        {
+            free(var_info);
+            return retval;
+        }
+
+        /* Assign dimension IDs */
+        for (d = 0; d < naxis; d++)
+            var->dimids[d] = dimids[d];
+    }
+
+    /* Read all header keywords as global attributes */
+    if ((retval = fits_read_primary_atts(fits_file->fptr, grp)))
+        return retval;
+
+    return NC_NOERR;
+}
+#endif /* HAVE_FITS */
+
 /**
  * @internal Open a FITS file for read-only access.
  *
@@ -125,11 +542,32 @@ NC_FITS_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
         free(fits_file);
         return map_fitsio_error(fits_status);
     }
-#else
-    fits_file->fptr = NULL;
-#endif
+
+    /* Get total HDU count */
+    fits_get_num_hdus(fits_file->fptr, &fits_file->num_hdus, &fits_status);
+    if (fits_status != 0)
+    {
+        fits_close_file(fits_file->fptr, &fits_status);
+        free(fits_file->path);
+        free(fits_file);
+        return map_fitsio_error(fits_status);
+    }
 
     h5->format_file_info = fits_file;
+
+    /* Read primary HDU metadata into the netCDF-4 in-memory model */
+    if ((retval = fits_read_primary_hdu(h5)))
+    {
+        fits_close_file(fits_file->fptr, &fits_status);
+        free(fits_file->path);
+        free(fits_file);
+        h5->format_file_info = NULL;
+        return retval;
+    }
+#else
+    fits_file->fptr = NULL;
+    h5->format_file_info = fits_file;
+#endif
 
     return NC_NOERR;
 }

--- a/test/tst_fits_udf.c
+++ b/test/tst_fits_udf.c
@@ -2,11 +2,13 @@
  * @file tst_fits_udf.c
  * @brief Test for FITS User Defined Format (UDF) handler.
  *
- * Validates that a FITS file can be opened and closed through the
- * standard NetCDF API using the FITS UDF handler, without reading
- * any CFITSIO metadata.
+ * Sprint 4a: validates that the primary HDU of a real FITS file is correctly
+ * mapped to the netCDF-4 in-memory model — dimensions, variable, and global
+ * attributes are all accessible via nc_inq* functions.
  *
- * This test covers v2.0.0 Sprint 2.
+ * Test file: WFPC2u5780205r_c0fx.fits
+ *   Primary HDU: BITPIX=-32 (NC_FLOAT), NAXIS=3, NAXIS1=200 NAXIS2=200 NAXIS3=4
+ *   Expected netCDF mapping: 3 dims (4,200,200), 1 var "image" (NC_FLOAT)
  *
  * @author Edward Hartnett
  * @date 2026-06-28
@@ -18,6 +20,7 @@
 #ifdef HAVE_FITS
 
 #include <stdio.h>
+#include <string.h>
 #include <netcdf.h>
 #include "fitsdispatch.h"
 
@@ -35,23 +38,101 @@
 int
 main(void)
 {
-    int ncid;
-    int retval;
+    int ncid, retval;
+    int ndims, nvars, ngatts, unlimdimid;
+    char name[NC_MAX_NAME + 1];
+    size_t len;
+    nc_type xtype;
+    size_t att_len;
+    int var_ndims, var_dimids[NC_MAX_VAR_DIMS], var_natts;
 
-    /* Ensure the FITS UDF handler is registered (also covers builds where
-       .ncrc autoload is not active). */
+    /* Ensure the FITS UDF handler is registered. */
     if ((retval = NC_FITS_initialize()) && retval != NC_EINVAL)
         ERR(retval);
 
-    /* Open a valid FITS file read-only via .ncrc autoload. */
+    /* Open the FITS file read-only. */
     if ((retval = nc_open(FITS_TEST_FILE, NC_NOWRITE, &ncid)))
         ERR(retval);
-    printf("PASS: nc_open FITS file\n");
+    printf("PASS: nc_open\n");
+
+    /* Check top-level counts: 3 dims, 1 var, at least 10 global atts, no unlimited dim. */
+    if ((retval = nc_inq(ncid, &ndims, &nvars, &ngatts, &unlimdimid)))
+        ERR(retval);
+    if (ndims != 3) { fprintf(stderr, "Expected 3 dims, got %d\n", ndims); return 1; }
+    if (nvars != 1) { fprintf(stderr, "Expected 1 var, got %d\n", nvars); return 1; }
+    if (ngatts < 10) { fprintf(stderr, "Expected >=10 global atts, got %d\n", ngatts); return 1; }
+    if (unlimdimid != -1) { fprintf(stderr, "Expected no unlimited dim\n"); return 1; }
+    printf("PASS: nc_inq ndims=%d nvars=%d ngatts=%d unlimdimid=%d\n",
+           ndims, nvars, ngatts, unlimdimid);
+
+    /* Check dimensions: reversed FITS axes → dim_0=4, dim_1=200, dim_2=200. */
+    if ((retval = nc_inq_dim(ncid, 0, name, &len)))
+        ERR(retval);
+    if (strcmp(name, "dim_0") != 0 || len != 4)
+    {
+        fprintf(stderr, "dim_0: expected name='dim_0' len=4, got '%s' len=%zu\n", name, len);
+        return 1;
+    }
+    printf("PASS: dim_0 len=%zu\n", len);
+
+    if ((retval = nc_inq_dim(ncid, 1, name, &len)))
+        ERR(retval);
+    if (strcmp(name, "dim_1") != 0 || len != 200)
+    {
+        fprintf(stderr, "dim_1: expected name='dim_1' len=200, got '%s' len=%zu\n", name, len);
+        return 1;
+    }
+    printf("PASS: dim_1 len=%zu\n", len);
+
+    if ((retval = nc_inq_dim(ncid, 2, name, &len)))
+        ERR(retval);
+    if (strcmp(name, "dim_2") != 0 || len != 200)
+    {
+        fprintf(stderr, "dim_2: expected name='dim_2' len=200, got '%s' len=%zu\n", name, len);
+        return 1;
+    }
+    printf("PASS: dim_2 len=%zu\n", len);
+
+    /* Check variable: "image", NC_FLOAT, 3 dims. */
+    if ((retval = nc_inq_var(ncid, 0, name, &xtype, &var_ndims, var_dimids, &var_natts)))
+        ERR(retval);
+    if (strcmp(name, "image") != 0)
+    {
+        fprintf(stderr, "Expected var name 'image', got '%s'\n", name);
+        return 1;
+    }
+    if (xtype != NC_FLOAT)
+    {
+        fprintf(stderr, "Expected NC_FLOAT (%d), got %d\n", NC_FLOAT, xtype);
+        return 1;
+    }
+    if (var_ndims != 3)
+    {
+        fprintf(stderr, "Expected var ndims=3, got %d\n", var_ndims);
+        return 1;
+    }
+    printf("PASS: var 'image' xtype=%d ndims=%d\n", xtype, var_ndims);
+
+    /* Check selected global attributes are present as NC_CHAR. */
+    if ((retval = nc_inq_att(ncid, NC_GLOBAL, "BSCALE", &xtype, &att_len)))
+        ERR(retval);
+    if (xtype != NC_CHAR) { fprintf(stderr, "BSCALE: expected NC_CHAR\n"); return 1; }
+    printf("PASS: att BSCALE NC_CHAR len=%zu\n", att_len);
+
+    if ((retval = nc_inq_att(ncid, NC_GLOBAL, "BZERO", &xtype, &att_len)))
+        ERR(retval);
+    if (xtype != NC_CHAR) { fprintf(stderr, "BZERO: expected NC_CHAR\n"); return 1; }
+    printf("PASS: att BZERO NC_CHAR len=%zu\n", att_len);
+
+    if ((retval = nc_inq_att(ncid, NC_GLOBAL, "ORIGIN", &xtype, &att_len)))
+        ERR(retval);
+    if (xtype != NC_CHAR) { fprintf(stderr, "ORIGIN: expected NC_CHAR\n"); return 1; }
+    printf("PASS: att ORIGIN NC_CHAR len=%zu\n", att_len);
 
     /* Close the file. */
     if ((retval = nc_close(ncid)))
         ERR(retval);
-    printf("PASS: nc_close FITS file\n");
+    printf("PASS: nc_close\n");
 
     return 0;
 }


### PR DESCRIPTION
Implements Sprint 4a of the read-only FITS layer: reads the primary HDU of a FITS file and populates the netCDF-4 in-memory model with its dimensions, variable, and global attributes.

## Changes

### `include/fitsdispatch.h`
- Add `NC_FITS_VAR_INFO_T` struct (`hdu_num`, `col_num`) for per-variable HDU tracking
- Add `num_hdus` field to `NC_FITS_FILE_INFO_T`

### `src/fitsfile.c`
- Add `nc4_set_var_type()` and `nc4_var_list_add_full()` static helpers (same pattern as `geotifffile.c`)
- Add `fits_bitpix_to_nc_type()`: maps all 6 BITPIX values to `nc_type` + endianness
- Add `fits_read_primary_atts()`: reads all non-structural header keywords as `NC_CHAR` global attributes; concatenates `COMMENT`/`HISTORY` cards
- Add `fits_read_primary_hdu()`: creates reversed FITS axes as netCDF dimensions and an `image` variable; calls `fits_read_primary_atts()`
- Wire `fits_read_primary_hdu()` into `NC_FITS_open()`

### `test/tst_fits_udf.c`
- Replace open/close-only test with full `nc_inq*` assertions: 3 dims (4, 200, 200), 1 `NC_FLOAT` variable `image`, and selected global attributes (`BSCALE`, `BZERO`, `ORIGIN`)

### `ftest/ftst_fits_udf.F90`
- Add `nf90_inquire` and `nf90_inquire_dimension` assertions for `ndims=3`, `nvars=1`, `dim_0=4`, `dim_1=200`

### `docs/roadmap.md`
- Split original Sprint 4 into Sprint 4a (primary HDU) and Sprint 4b (extension HDUs as child groups)

### `docs/plan/v2.0.0-sprint4a-fits-primary-metadata.md`
- New detailed plan document for Sprint 4a

## Test results (local)
```
PASS: nc_open
PASS: nc_inq ndims=3 nvars=1 ngatts=173 unlimdimid=-1
PASS: dim_0 len=4
PASS: dim_1 len=200
PASS: dim_2 len=200
PASS: var 'image' xtype=5 ndims=3
PASS: att BSCALE NC_CHAR len=5
PASS: att BZERO NC_CHAR len=5
PASS: att ORIGIN NC_CHAR len=41
PASS: nc_close
```