### PR TITLE
v2.0.0 Sprint 4b: Read extension HDU metadata

### DIFF
--- a/docs/plan/v2.0.0-sprint4b-fits-extension-metadata.md
+++ b/docs/plan/v2.0.0-sprint4b-fits-extension-metadata.md
@@ -1,0 +1,222 @@
+# V2.0.0 Sprint 4b: Read Extension HDU Metadata
+
+**Objective**: Read all extension HDUs from a FITS file and map each one to a
+child group of the netCDF root group. After this sprint all FITS metadata is
+accessible via `nc_inq*` functions.
+
+**Prerequisite**: Sprint 4a (primary HDU metadata reading) complete.
+
+---
+
+## Background
+
+The test file `WFPC2u5780205r_c0fx.fits` has two HDUs:
+
+| HDU | Type       | extname                     | Rows | Cols |
+|-----|------------|-----------------------------|------|------|
+| 1   | IMAGE_HDU  | (none)                      | —    | —    |
+| 2   | ASCII_TBL  | `u5780205r_cvt.c0h.tab`     | 4    | 49   |
+
+HDU 2 column typecodes (CFITSIO): `82`=TDOUBLE (D), `41`=TINT (I),
+`16`=TSTRING (A). All columns have `repeat=1` (scalar), so all table variables
+are 1-D `[nrows]`. No vector columns in this file.
+
+**Expected netCDF mapping for HDU 2**:
+- Child group name: `u5780205r_cvt.c0h.tab` (sanitized — dots → underscores → `u5780205r_cvt_c0h_tab`)
+- One row dimension `row` of size 4
+- 49 variables named from `TTYPEn`, typed from `TFORMn`/typecode
+- All 353 header keywords stored as `NC_CHAR` group attributes (structural ones skipped)
+
+---
+
+## CFITSIO typecode → nc_type mapping
+
+| typecode | CFITSIO const | nc_type    | size |
+|----------|---------------|------------|------|
+| 1        | TBIT          | NC_UBYTE   | 1    |
+| 11       | TBYTE         | NC_UBYTE   | 1    |
+| 14       | TLOGICAL      | NC_UBYTE   | 1    |
+| 16       | TSTRING       | NC_CHAR    | 1    |
+| 21       | TSHORT        | NC_SHORT   | 2    |
+| 41       | TINT / TINT32BIT | NC_INT  | 4    |
+| 42       | TUINT         | NC_UINT    | 4    |
+| 81       | TLONGLONG     | NC_INT64   | 8    |
+| 82       | TDOUBLE       | NC_DOUBLE  | 8    |
+| 83       | TCOMPLEX      | NC_FLOAT   | 4    |  ← treat as float
+| 84       | TDBLCOMPLEX   | NC_DOUBLE  | 8    |  ← treat as double
+| 31       | TFLOAT / TREAL | NC_FLOAT  | 4    |
+| 42       | TULONG        | NC_UINT    | 4    |
+
+---
+
+## Group name sanitization
+
+FITS `EXTNAME` values may contain characters illegal in netCDF group names
+(spaces, dots, slashes). Replace any character that is not `[A-Za-z0-9_]`
+with `_`. Truncate to `NC_MAX_NAME`.
+
+---
+
+## Tasks
+
+### 1. Add `fits_typecode_to_nc_type()` helper
+
+`src/fitsfile.c` — static function (outside `#ifdef HAVE_FITS` guard not needed;
+keep inside guard like other FITS helpers):
+
+```c
+static int
+fits_typecode_to_nc_type(int typecode, nc_type *xtypep, size_t *type_sizep,
+                         char *type_name, int *endiannessp)
+```
+
+Map the table above. Default endianness `NC_ENDIAN_BIG` for multi-byte types,
+`NC_ENDIAN_NATIVE` for 1-byte. Return `NC_EBADTYPE` for unknown codes.
+
+### 2. Add `fits_sanitize_name()` helper
+
+```c
+static void
+fits_sanitize_name(const char *src, char *dst, size_t dstlen)
+```
+
+Copies `src` to `dst`, replacing `[^A-Za-z0-9_]` → `_`, truncating to
+`dstlen-1`.
+
+### 3. Add `fits_read_ext_atts()` helper
+
+Identical in logic to `fits_read_primary_atts()` from Sprint 4a, but operating
+on the current HDU position and writing to a child group. Can simply be the
+same function — `fits_read_primary_atts(fptr, grp)` already takes a `grp`
+pointer and works on the current CFITSIO HDU position. **No new function
+needed** — reuse `fits_read_primary_atts()` directly.
+
+Add the following extra structural keywords to the skip list for extension HDUs:
+`TFIELDS`, `TTYPEn`, `TFORMn`, `TUNITn`, `TSCALn`, `TZEROn`, `TNULLn`,
+`TDISPn`, `EXTNAME`, `EXTVER`.
+
+Since `fits_read_primary_atts` uses a static skip list, rename it to
+`fits_read_hdu_atts(fptr, grp, is_table)` and extend the skip list for table
+HDUs when `is_table` is non-zero.
+
+### 4. Add `fits_read_table_hdu()` helper
+
+`src/fitsfile.c` — static function:
+
+```c
+static int
+fits_read_table_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
+```
+
+Steps:
+1. `fits_get_num_rows()` → `nrows`; `fits_get_num_cols()` → `ncols`
+2. Create row dimension: `nc4_dim_list_add(grp, "row", nrows, -1, &dim)`
+3. For each column `c = 1..ncols`:
+   a. Read `TTYPEn` via `fits_read_key(fptr, TSTRING, "TTYPEn", ttype, ...)`;
+      sanitize → `varname`
+   b. Read `TFORMn` and call `fits_get_coltype(fptr, c, &typecode, &repeat,
+      &width, &status)` for typecode and repeat
+   c. Map typecode via `fits_typecode_to_nc_type()`
+   d. Allocate `NC_FITS_VAR_INFO_T` with `hdu_num`, `col_num = c`
+   e. Scalar column (`repeat == 1`): call `nc4_var_list_add_full()` with
+      `ndims=1`, `dimids[0] = row_dim->hdr.id`
+   f. Vector column (`repeat > 1`): create a second dimension
+      `varname_vec` of size `repeat`; call `nc4_var_list_add_full()` with
+      `ndims=2`
+   g. String column (`typecode == TSTRING`): use `NC_CHAR`, `ndims=1` (one
+      string per row — length encoded in `width`)
+   h. Read `TUNITn`; if non-empty, add `units` attribute to the variable
+4. Call `fits_read_hdu_atts(fptr, grp, 1)` for group-level attributes
+
+### 5. Add `fits_read_image_ext_hdu()` helper
+
+```c
+static int
+fits_read_image_ext_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
+```
+
+Same logic as `fits_read_primary_hdu()` from Sprint 4a, but:
+- Operates on the already-positioned `fptr` (caller has done `fits_movabs_hdu`)
+- Uses the provided `grp` (child group) instead of `h5->root_grp`
+- Variable name `image` (same convention)
+- Calls `fits_read_hdu_atts(fptr, grp, 0)` instead of `fits_read_primary_atts`
+
+### 6. Add `fits_read_extension_hdus()` orchestrator
+
+```c
+static int
+fits_read_extension_hdus(NC_FILE_INFO_T *h5)
+```
+
+Steps:
+1. Get `fits_file->num_hdus`
+2. For `h = 2..num_hdus`:
+   a. `fits_movabs_hdu(fptr, h, &hdutype, &status)`
+   b. Read `EXTNAME`; if absent use `"hdu_%d"` % h
+   c. Sanitize name → `grpname`
+   d. `nc4_grp_list_add(h5, h5->root_grp, grpname, &child_grp)`
+   e. If `IMAGE_HDU`: call `fits_read_image_ext_hdu(h5, child_grp, h)`
+   f. If `ASCII_TBL` or `BINARY_TBL`: call `fits_read_table_hdu(h5, child_grp, h)`
+
+### 7. Call `fits_read_extension_hdus()` from `NC_FITS_open()`
+
+After the existing `fits_read_primary_hdu(h5)` call, add:
+
+```c
+if ((retval = fits_read_extension_hdus(h5)))
+    return retval;
+```
+
+Refactor the error-cleanup path to share a common label or inline cleanup.
+
+### 8. Refactor `fits_read_primary_atts` → `fits_read_hdu_atts`
+
+Rename with an `is_table` flag to extend the structural skip list for table HDUs.
+Update the Sprint 4a call site.
+
+### 9. Update `test/tst_fits_udf.c`
+
+Add after the existing Sprint 4a assertions:
+
+```c
+/* Extension HDU 2 becomes child group "u5780205r_cvt_c0h_tab" */
+nc_inq_grp_ncid(ncid, "u5780205r_cvt_c0h_tab", &grpid)
+nc_inq(grpid, &ndims, &nvars, &ngatts, &unlimdimid)
+  → ndims=1, nvars=49, ngatts>=10, unlimdimid=-1
+
+nc_inq_dim(grpid, 0, name, &len) → "row", len=4
+
+nc_inq_varname(grpid, 0, name) → "CRVAL1"
+nc_inq_var(grpid, 0, ...) → NC_DOUBLE, ndims=1
+nc_inq_varname(grpid, 12, name) → "FILLCNT"   (typecode=41 → NC_INT)
+nc_inq_varname(grpid, 16, name) → "CTYPE1"    (typecode=16 → NC_CHAR)
+```
+
+### 10. Update `ftest/ftst_fits_udf.F90`
+
+Add `nf90_inq_grp_ncid` + `nf90_inquire` assertions for the child group:
+`ndims=1`, `nvars=49`.
+
+---
+
+## Definition of Done
+
+- [ ] `fits_typecode_to_nc_type()` covers all typecodes in the test file (82, 41, 16)
+- [ ] `fits_sanitize_name()` converts `u5780205r_cvt.c0h.tab` → `u5780205r_cvt_c0h_tab`
+- [ ] `fits_read_hdu_atts()` replaces `fits_read_primary_atts()`, is_table flag skips column metadata keywords
+- [ ] `fits_read_table_hdu()` creates `row` dim + 49 variables for HDU 2
+- [ ] `fits_read_image_ext_hdu()` handles image extensions generically
+- [ ] `fits_read_extension_hdus()` iterates HDUs 2..N and creates child groups
+- [ ] `NC_FITS_open()` calls `fits_read_extension_hdus()` after primary HDU
+- [ ] C test passes all child-group assertions
+- [ ] Fortran test passes child-group ndims/nvars assertions
+- [ ] CMake and Autotools builds clean; `make check` 0 FAIL
+
+---
+
+## Dependencies
+
+- **Sprint 4a** (prerequisite): primary HDU reading, `fits_bitpix_to_nc_type`,
+  `nc4_var_list_add_full`, `NC_FITS_VAR_INFO_T`
+- **Sprint 5** (follows): `NC_FITS_get_vara()` uses `hdu_num`/`col_num` from
+  `NC_FITS_VAR_INFO_T` for both image and table reads

--- a/ftest/ftst_fits_udf.F90
+++ b/ftest/ftst_fits_udf.F90
@@ -26,6 +26,7 @@ program ftst_fits_udf
   integer :: retval
   integer(c_int) :: init_status
   integer :: ndims, nvars, ngatts, unlimdimid
+  integer :: grpid, grpid2
   character(len=NF90_MAX_NAME) :: dimname
   integer :: dimlen
 
@@ -88,6 +89,43 @@ program ftst_fits_udf
      stop 1
   endif
   print *, "PASS: dim_1 len=", dimlen
+
+  ! --- Sprint 4b: extension HDU as child group ---
+  ! HDU 2 (ASCII table) -> group "u5780205r_cvt_c0h_tab"
+  retval = nf90_inq_grp_ncid(ncid, "u5780205r_cvt_c0h_tab", grpid)
+  if (retval /= nf90_noerr) then
+     print *, "Error finding child group: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  print *, "PASS: nf90_inq_grp_ncid 'u5780205r_cvt_c0h_tab'"
+
+  retval = nf90_inquire(grpid, ndims, nvars, ngatts, unlimdimid)
+  if (retval /= nf90_noerr) then
+     print *, "Error in group nf90_inquire: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  if (nvars /= 49) then
+     print *, "Expected 49 vars in group, got ", nvars
+     stop 1
+  endif
+  print *, "PASS: group nf90_inquire ndims=", ndims, " nvars=", nvars
+
+  ! Row dimension must exist with 4 rows
+  retval = nf90_inq_dimid(grpid, "row", grpid2)
+  if (retval /= nf90_noerr) then
+     print *, "Error finding row dim: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  retval = nf90_inquire_dimension(grpid, grpid2, dimname, dimlen)
+  if (retval /= nf90_noerr) then
+     print *, "Error inquiring row dim: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  if (dimlen /= 4) then
+     print *, "Expected row dim len=4, got ", dimlen
+     stop 1
+  endif
+  print *, "PASS: group row dim len=", dimlen
 
   ! Close the file.
   retval = nf90_close(ncid)

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -223,23 +223,124 @@ fits_bitpix_to_nc_type(int bitpix, nc_type *xtypep, size_t *type_sizep,
 }
 
 /**
+ * @internal Map a CFITSIO table column typecode to a netCDF type.
+ *
+ * @param typecode CFITSIO typecode from fits_get_coltype().
+ * @param xtypep Pointer that gets the nc_type. Ignored if NULL.
+ * @param type_sizep Pointer that gets the type size in bytes. Ignored if NULL.
+ * @param type_name Buffer (at least NC_MAX_NAME+1 bytes) for type name string.
+ * Ignored if NULL.
+ * @param endiannessp Pointer that gets endianness. Ignored if NULL.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADTYPE Unknown typecode.
+ * @author Edward Hartnett
+ */
+static int
+fits_typecode_to_nc_type(int typecode, nc_type *xtypep, size_t *type_sizep,
+                         char *type_name, int *endiannessp)
+{
+    nc_type xtype;
+    size_t type_size;
+    const char *name;
+    int endianness = NC_ENDIAN_BIG;
+
+    switch (typecode)
+    {
+    case 1:  /* TBIT */
+    case 11: /* TBYTE */
+    case 14: /* TLOGICAL */
+        xtype = NC_UBYTE; type_size = 1; name = "ubyte";
+        endianness = NC_ENDIAN_NATIVE;
+        break;
+    case 16: /* TSTRING */
+        xtype = NC_CHAR; type_size = 1; name = "char";
+        endianness = NC_ENDIAN_NATIVE;
+        break;
+    case 21: /* TSHORT */
+        xtype = NC_SHORT; type_size = 2; name = "short";
+        break;
+    case 22: /* TUSHORT */
+        xtype = NC_USHORT; type_size = 2; name = "ushort";
+        break;
+    case 31: /* TFLOAT */
+        xtype = NC_FLOAT; type_size = 4; name = "float";
+        break;
+    case 41: /* TINT / TINT32BIT */
+    case 40:
+        xtype = NC_INT; type_size = 4; name = "int";
+        break;
+    case 42: /* TUINT / TULONG */
+        xtype = NC_UINT; type_size = 4; name = "uint";
+        break;
+    case 81: /* TLONGLONG */
+        xtype = NC_INT64; type_size = 8; name = "int64";
+        break;
+    case 82: /* TDOUBLE */
+        xtype = NC_DOUBLE; type_size = 8; name = "double";
+        break;
+    case 83: /* TCOMPLEX — store real part as float */
+        xtype = NC_FLOAT; type_size = 4; name = "float";
+        break;
+    case 84: /* TDBLCOMPLEX — store real part as double */
+        xtype = NC_DOUBLE; type_size = 8; name = "double";
+        break;
+    default:
+        return NC_EBADTYPE;
+    }
+
+    if (xtypep) *xtypep = xtype;
+    if (type_sizep) *type_sizep = type_size;
+    if (type_name) strncpy(type_name, name, NC_MAX_NAME);
+    if (endiannessp) *endiannessp = endianness;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Sanitize a FITS EXTNAME string for use as a netCDF group name.
+ *
+ * Replaces any character not in [A-Za-z0-9_] with '_', and truncates to
+ * NC_MAX_NAME characters.
+ *
+ * @param src Source string (EXTNAME value).
+ * @param dst Destination buffer.
+ * @param dstlen Size of destination buffer.
+ * @author Edward Hartnett
+ */
+static void
+fits_sanitize_name(const char *src, char *dst, size_t dstlen)
+{
+    size_t i;
+    for (i = 0; i < dstlen - 1 && src[i] != '\0'; i++)
+    {
+        char c = src[i];
+        dst[i] = ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                  (c >= '0' && c <= '9') || c == '_') ? c : '_';
+    }
+    dst[i] = '\0';
+}
+
+/**
  * @internal Read all header keywords from the current FITS HDU and store
  * them as NC_CHAR global attributes on the given group.
  *
  * Structural keywords (SIMPLE, BITPIX, NAXIS, NAXISn, EXTEND, XTENSION,
- * PCOUNT, GCOUNT, END) are skipped. Multiple COMMENT and HISTORY cards are
- * each concatenated into a single attribute of the same name, separated by
- * newlines.
+ * PCOUNT, GCOUNT, END) are always skipped. When is_table is non-zero,
+ * table column descriptor keywords (TTYPEn, TFORMn, TUNITn, etc.) and
+ * EXTNAME are also skipped. Multiple COMMENT and HISTORY cards are
+ * concatenated into a single attribute separated by newlines.
  *
  * @param fptr CFITSIO file pointer, positioned at the HDU to read.
  * @param grp Pointer to the netCDF-4 group that receives the attributes.
+ * @param is_table Non-zero to also skip table column descriptor keywords.
  *
  * @return ::NC_NOERR No error.
  * @return ::NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 static int
-fits_read_primary_atts(fitsfile *fptr, NC_GRP_INFO_T *grp)
+fits_read_hdu_atts(fitsfile *fptr, NC_GRP_INFO_T *grp, int is_table)
 {
     int status = 0, nkeys, k, retval;
     char card[81];
@@ -248,6 +349,14 @@ fits_read_primary_atts(fitsfile *fptr, NC_GRP_INFO_T *grp)
     static const char *skip_keys[] = {
         "SIMPLE", "BITPIX", "NAXIS", "EXTEND", "XTENSION",
         "PCOUNT", "GCOUNT", "END", NULL
+    };
+    /* Additional keywords to skip for table HDUs */
+    static const char *skip_table_prefixes[] = {
+        "TTYPE", "TFORM", "TUNIT", "TSCAL", "TZERO",
+        "TNULL", "TDISP", "TDIM", NULL
+    };
+    static const char *skip_table_keys[] = {
+        "TFIELDS", "EXTNAME", "EXTVER", NULL
     };
 
     fits_get_hdrspace(fptr, &nkeys, NULL, &status);
@@ -288,6 +397,33 @@ fits_read_primary_atts(fitsfile *fptr, NC_GRP_INFO_T *grp)
             {
                 skip = 1;
                 break;
+            }
+        }
+        if (skip)
+            continue;
+
+        /* For table HDUs, skip column descriptor keywords */
+        if (is_table && !skip)
+        {
+            for (i = 0; skip_table_prefixes[i] != NULL; i++)
+            {
+                if (strncmp(keyword, skip_table_prefixes[i],
+                            strlen(skip_table_prefixes[i])) == 0)
+                {
+                    skip = 1;
+                    break;
+                }
+            }
+            if (!skip)
+            {
+                for (i = 0; skip_table_keys[i] != NULL; i++)
+                {
+                    if (strcmp(keyword, skip_table_keys[i]) == 0)
+                    {
+                        skip = 1;
+                        break;
+                    }
+                }
             }
         }
         if (skip)
@@ -463,8 +599,310 @@ fits_read_primary_hdu(NC_FILE_INFO_T *h5)
     }
 
     /* Read all header keywords as global attributes */
-    if ((retval = fits_read_primary_atts(fits_file->fptr, grp)))
+    if ((retval = fits_read_hdu_atts(fits_file->fptr, grp, 0)))
         return retval;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Read an image extension HDU and populate a netCDF child group.
+ *
+ * Uses the same axis-reversal and variable mapping logic as
+ * fits_read_primary_hdu(), but writes into the provided child group.
+ *
+ * @param h5 Pointer to the netCDF-4 file info struct.
+ * @param grp Child group to populate.
+ * @param hdu_num 1-based HDU number (for NC_FITS_VAR_INFO_T).
+ *
+ * @return ::NC_NOERR No error.
+ * @author Edward Hartnett
+ */
+static int
+fits_read_image_ext_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
+{
+    NC_FITS_FILE_INFO_T *fits_file;
+    int status = 0, bitpix, naxis, retval, d;
+    long naxes[NC_MAX_VAR_DIMS];
+    nc_type xtype;
+    size_t type_size;
+    char type_name[NC_MAX_NAME + 1];
+    int endianness;
+    int dimids[NC_MAX_VAR_DIMS];
+    NC_FITS_VAR_INFO_T *var_info = NULL;
+    NC_VAR_INFO_T *var = NULL;
+
+    fits_file = (NC_FITS_FILE_INFO_T *)h5->format_file_info;
+
+    fits_get_img_param(fits_file->fptr, NC_MAX_VAR_DIMS, &bitpix, &naxis,
+                       naxes, &status);
+    if (status)
+        return map_fitsio_error(status);
+
+    if ((retval = fits_bitpix_to_nc_type(bitpix, &xtype, &type_size,
+                                         type_name, &endianness)))
+        return retval;
+
+    if (naxis > 0)
+    {
+        for (d = 0; d < naxis; d++)
+        {
+            NC_DIM_INFO_T *dim;
+            char dimname[NC_MAX_NAME + 1];
+            size_t dimsize = (size_t)naxes[naxis - 1 - d];
+
+            snprintf(dimname, NC_MAX_NAME, "dim_%d", d);
+            if ((retval = nc4_dim_list_add(grp, dimname, dimsize, -1, &dim)))
+                return retval;
+            dimids[d] = dim->hdr.id;
+        }
+
+        if (!(var_info = calloc(1, sizeof(NC_FITS_VAR_INFO_T))))
+            return NC_ENOMEM;
+        var_info->hdu_num = hdu_num;
+        var_info->col_num = 0;
+
+        if ((retval = nc4_var_list_add_full(grp, "image", naxis, xtype,
+                                            endianness, type_size, type_name,
+                                            NULL, 1, NULL, var_info, &var)))
+        {
+            free(var_info);
+            return retval;
+        }
+
+        for (d = 0; d < naxis; d++)
+            var->dimids[d] = dimids[d];
+    }
+
+    if ((retval = fits_read_hdu_atts(fits_file->fptr, grp, 0)))
+        return retval;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Read a table HDU (ASCII or binary) and populate a netCDF child
+ * group with one variable per column and a shared row dimension.
+ *
+ * @param h5 Pointer to the netCDF-4 file info struct.
+ * @param grp Child group to populate.
+ * @param hdu_num 1-based HDU number.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Edward Hartnett
+ */
+static int
+fits_read_table_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
+{
+    NC_FITS_FILE_INFO_T *fits_file;
+    int status = 0, ncols, c, retval;
+    long nrows;
+    NC_DIM_INFO_T *row_dim;
+    int row_dimid;
+
+    fits_file = (NC_FITS_FILE_INFO_T *)h5->format_file_info;
+
+    fits_get_num_rows(fits_file->fptr, &nrows, &status);
+    if (status)
+        return map_fitsio_error(status);
+    fits_get_num_cols(fits_file->fptr, &ncols, &status);
+    if (status)
+        return map_fitsio_error(status);
+
+    /* Create shared row dimension */
+    if ((retval = nc4_dim_list_add(grp, "row", (size_t)nrows, -1, &row_dim)))
+        return retval;
+    row_dimid = row_dim->hdr.id;
+
+    /* One variable per column */
+    for (c = 1; c <= ncols; c++)
+    {
+        char ttype[FLEN_VALUE] = "";
+        char tunit[FLEN_VALUE] = "";
+        char key[16];
+        char varname[NC_MAX_NAME + 1];
+        int typecode, s2 = 0, s3 = 0;
+        long repeat, width;
+        nc_type xtype;
+        size_t type_size;
+        char type_name[NC_MAX_NAME + 1];
+        int endianness;
+        NC_FITS_VAR_INFO_T *var_info;
+        NC_VAR_INFO_T *var;
+        int dimids[2];
+        int ndims;
+
+        snprintf(key, sizeof(key), "TTYPE%d", c);
+        fits_read_key(fits_file->fptr, TSTRING, key, ttype, NULL, &s2);
+        if (s2 || ttype[0] == '\0')
+            snprintf(ttype, sizeof(ttype), "col_%d", c);
+
+        snprintf(key, sizeof(key), "TUNIT%d", c);
+        fits_read_key(fits_file->fptr, TSTRING, key, tunit, NULL, &s3);
+
+        status = 0;
+        fits_get_coltype(fits_file->fptr, c, &typecode, &repeat, &width,
+                         &status);
+        if (status)
+        {
+            status = 0;
+            continue;
+        }
+
+        /* Negative typecode = variable-length array — skip for now */
+        if (typecode < 0)
+            continue;
+
+        if ((retval = fits_typecode_to_nc_type(typecode, &xtype, &type_size,
+                                               type_name, &endianness)))
+            continue; /* skip unknown types */
+
+        fits_sanitize_name(ttype, varname, NC_MAX_NAME);
+
+        if (!(var_info = calloc(1, sizeof(NC_FITS_VAR_INFO_T))))
+            return NC_ENOMEM;
+        var_info->hdu_num = hdu_num;
+        var_info->col_num = c;
+
+        if (xtype == NC_CHAR)
+        {
+            /* String column: 2D [nrows, width] using NC_CHAR */
+            NC_DIM_INFO_T *str_dim;
+            char sdimname[NC_MAX_NAME + 1];
+
+            strncpy(sdimname, varname, NC_MAX_NAME - 4);
+            sdimname[NC_MAX_NAME - 4] = '\0';
+            strncat(sdimname, "_len", 5);
+            if ((retval = nc4_dim_list_add(grp, sdimname, (size_t)width,
+                                           -1, &str_dim)))
+            {
+                free(var_info);
+                return retval;
+            }
+            dimids[0] = row_dimid;
+            dimids[1] = str_dim->hdr.id;
+            ndims = 2;
+        }
+        else if (repeat > 1)
+        {
+            /* Numeric vector column: 2D [nrows, repeat] */
+            NC_DIM_INFO_T *vec_dim;
+            char vdimname[NC_MAX_NAME + 1];
+
+            strncpy(vdimname, varname, NC_MAX_NAME - 4);
+            vdimname[NC_MAX_NAME - 4] = '\0';
+            strncat(vdimname, "_vec", 5);
+            if ((retval = nc4_dim_list_add(grp, vdimname, (size_t)repeat,
+                                           -1, &vec_dim)))
+            {
+                free(var_info);
+                return retval;
+            }
+            dimids[0] = row_dimid;
+            dimids[1] = vec_dim->hdr.id;
+            ndims = 2;
+        }
+        else
+        {
+            dimids[0] = row_dimid;
+            ndims = 1;
+        }
+
+        if ((retval = nc4_var_list_add_full(grp, varname, ndims, xtype,
+                                            endianness, type_size, type_name,
+                                            NULL, 1, NULL, var_info, &var)))
+        {
+            free(var_info);
+            return retval;
+        }
+
+        var->dimids[0] = dimids[0];
+        if (ndims > 1)
+            var->dimids[1] = dimids[1];
+
+        /* Add units attribute if TUNITn is present */
+        if (!s3 && tunit[0] != '\0')
+        {
+            NC_ATT_INFO_T *att;
+            size_t ulen = strlen(tunit);
+            char *udata;
+
+            if ((retval = nc4_att_list_add(var->att, "units", &att)))
+                return retval;
+            att->nc_typeid = NC_CHAR;
+            att->len = ulen;
+            if (ulen > 0)
+            {
+                if (!(udata = malloc(ulen + 1)))
+                    return NC_ENOMEM;
+                memcpy(udata, tunit, ulen + 1);
+                att->data = udata;
+            }
+            att->dirty = NC_TRUE;
+        }
+    }
+
+    /* Read non-structural header keywords as group attributes */
+    if ((retval = fits_read_hdu_atts(fits_file->fptr, grp, 1)))
+        return retval;
+
+    return NC_NOERR;
+}
+
+/**
+ * @internal Read all extension HDUs (HDU 2..N) and map each to a child group
+ * of the root group.
+ *
+ * Each child group is named from EXTNAME (sanitized) or "hdu_N" if absent.
+ * Image extensions are mapped identically to the primary HDU. ASCII and binary
+ * table extensions create one variable per column.
+ *
+ * @param h5 Pointer to the netCDF-4 file info struct.
+ *
+ * @return ::NC_NOERR No error.
+ * @author Edward Hartnett
+ */
+static int
+fits_read_extension_hdus(NC_FILE_INFO_T *h5)
+{
+    NC_FITS_FILE_INFO_T *fits_file;
+    int h, hdutype, status, retval;
+
+    fits_file = (NC_FITS_FILE_INFO_T *)h5->format_file_info;
+
+    for (h = 2; h <= fits_file->num_hdus; h++)
+    {
+        char extname[FLEN_VALUE] = "";
+        char grpname[NC_MAX_NAME + 1];
+        NC_GRP_INFO_T *child_grp;
+        int s2 = 0;
+
+        status = 0;
+        fits_movabs_hdu(fits_file->fptr, h, &hdutype, &status);
+        if (status)
+            return map_fitsio_error(status);
+
+        fits_read_key(fits_file->fptr, TSTRING, "EXTNAME", extname, NULL, &s2);
+        if (s2 || extname[0] == '\0')
+            snprintf(extname, sizeof(extname), "hdu_%d", h);
+
+        fits_sanitize_name(extname, grpname, NC_MAX_NAME);
+
+        if ((retval = nc4_grp_list_add(h5, h5->root_grp, grpname, &child_grp)))
+            return retval;
+        child_grp->atts_read = 1;
+
+        if (hdutype == IMAGE_HDU)
+        {
+            if ((retval = fits_read_image_ext_hdu(h5, child_grp, h)))
+                return retval;
+        }
+        else if (hdutype == ASCII_TBL || hdutype == BINARY_TBL)
+        {
+            if ((retval = fits_read_table_hdu(h5, child_grp, h)))
+                return retval;
+        }
+    }
 
     return NC_NOERR;
 }
@@ -557,6 +995,16 @@ NC_FITS_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
 
     /* Read primary HDU metadata into the netCDF-4 in-memory model */
     if ((retval = fits_read_primary_hdu(h5)))
+    {
+        fits_close_file(fits_file->fptr, &fits_status);
+        free(fits_file->path);
+        free(fits_file);
+        h5->format_file_info = NULL;
+        return retval;
+    }
+
+    /* Read extension HDU metadata into child groups */
+    if ((retval = fits_read_extension_hdus(h5)))
     {
         fits_close_file(fits_file->fptr, &fits_status);
         free(fits_file->path);

--- a/test/tst_fits_udf.c
+++ b/test/tst_fits_udf.c
@@ -38,7 +38,7 @@
 int
 main(void)
 {
-    int ncid, retval;
+    int ncid, root_ncid, grpid, retval;
     int ndims, nvars, ngatts, unlimdimid;
     char name[NC_MAX_NAME + 1];
     size_t len;
@@ -129,8 +129,61 @@ main(void)
     if (xtype != NC_CHAR) { fprintf(stderr, "ORIGIN: expected NC_CHAR\n"); return 1; }
     printf("PASS: att ORIGIN NC_CHAR len=%zu\n", att_len);
 
-    /* Close the file. */
-    if ((retval = nc_close(ncid)))
+    /* ---- Sprint 4b: extension HDU as child group ---- */
+    root_ncid = ncid;
+
+    /* HDU 2 (ASCII table) → group "u5780205r_cvt_c0h_tab" */
+    if ((retval = nc_inq_grp_ncid(root_ncid, "u5780205r_cvt_c0h_tab", &grpid)))
+        ERR(retval);
+    printf("PASS: nc_inq_grp_ncid 'u5780205r_cvt_c0h_tab'\n");
+
+    if ((retval = nc_inq(grpid, &ndims, &nvars, &ngatts, &unlimdimid)))
+        ERR(retval);
+    if (nvars != 49) { fprintf(stderr, "Expected 49 vars, got %d\n", nvars); return 1; }
+    if (ngatts < 10) { fprintf(stderr, "Expected >=10 group atts, got %d\n", ngatts); return 1; }
+    if (unlimdimid != -1) { fprintf(stderr, "Expected no unlimited dim in group\n"); return 1; }
+    printf("PASS: group nc_inq ndims=%d nvars=%d ngatts=%d\n", ndims, nvars, ngatts);
+
+    /* Row dimension must exist and have 4 rows */
+    if ((retval = nc_inq_dimid(grpid, "row", &unlimdimid)))
+        ERR(retval);
+    if ((retval = nc_inq_dim(grpid, unlimdimid, name, &len)))
+        ERR(retval);
+    if (len != 4) { fprintf(stderr, "Expected row dim len=4, got %zu\n", len); return 1; }
+    printf("PASS: row dim len=%zu\n", len);
+
+    /* CRVAL1: first column, NC_DOUBLE, 1D [row] */
+    if ((retval = nc_inq_var(grpid, 0, name, &xtype, &var_ndims, var_dimids, &var_natts)))
+        ERR(retval);
+    if (strcmp(name, "CRVAL1") != 0)
+    { fprintf(stderr, "Expected var[0]='CRVAL1', got '%s'\n", name); return 1; }
+    if (xtype != NC_DOUBLE)
+    { fprintf(stderr, "CRVAL1: expected NC_DOUBLE, got %d\n", xtype); return 1; }
+    if (var_ndims != 1)
+    { fprintf(stderr, "CRVAL1: expected ndims=1, got %d\n", var_ndims); return 1; }
+    printf("PASS: var 'CRVAL1' NC_DOUBLE ndims=1\n");
+
+    /* FILLCNT (col 13, typecode=41): NC_INT, 1D */
+    if ((retval = nc_inq_var(grpid, 12, name, &xtype, &var_ndims, var_dimids, &var_natts)))
+        ERR(retval);
+    if (strcmp(name, "FILLCNT") != 0)
+    { fprintf(stderr, "Expected var[12]='FILLCNT', got '%s'\n", name); return 1; }
+    if (xtype != NC_INT)
+    { fprintf(stderr, "FILLCNT: expected NC_INT, got %d\n", xtype); return 1; }
+    printf("PASS: var 'FILLCNT' NC_INT ndims=%d\n", var_ndims);
+
+    /* CTYPE1 (col 17, typecode=16): NC_CHAR, 2D [row, CTYPE1_len] */
+    if ((retval = nc_inq_var(grpid, 16, name, &xtype, &var_ndims, var_dimids, &var_natts)))
+        ERR(retval);
+    if (strcmp(name, "CTYPE1") != 0)
+    { fprintf(stderr, "Expected var[16]='CTYPE1', got '%s'\n", name); return 1; }
+    if (xtype != NC_CHAR)
+    { fprintf(stderr, "CTYPE1: expected NC_CHAR, got %d\n", xtype); return 1; }
+    if (var_ndims != 2)
+    { fprintf(stderr, "CTYPE1: expected ndims=2, got %d\n", var_ndims); return 1; }
+    printf("PASS: var 'CTYPE1' NC_CHAR ndims=2\n");
+
+    if ((retval = nc_close(root_ncid)))
         ERR(retval);
     printf("PASS: nc_close\n");
 


### PR DESCRIPTION
Implements Sprint 4b of the read-only FITS layer: reads all extension HDUs (HDU 2..N) and maps each one to a child group of the netCDF root group, completing the full FITS metadata → netCDF-4 model mapping.

## Changes

### `src/fitsfile.c`
- Rename `fits_read_primary_atts()` → `fits_read_hdu_atts(fptr, grp, is_table)`: adds `is_table` flag to also skip `TTYPEn`, `TFORMn`, `TUNITn`, `TSCALn`, `TZEROn`, `TNULLn`, `TDISPn`, `TFIELDS`, `EXTNAME`, `EXTVER` keywords from group attributes
- Add `fits_typecode_to_nc_type()`: maps CFITSIO column typecodes (TDOUBLE=82, TINT=41, TSTRING=16, etc.) to `nc_type` + endianness
- Add `fits_sanitize_name()`: replaces non-`[A-Za-z0-9_]` characters with `_` for safe group/dim names (e.g. `u5780205r_cvt.c0h.tab` → `u5780205r_cvt_c0h_tab`)
- Add `fits_read_image_ext_hdu()`: maps image extension HDUs to child groups (same axis-reversal logic as primary HDU)
- Add `fits_read_table_hdu()`: creates a `row` dimension, one variable per column named from `TTYPEn`; NC_CHAR string columns get 2D `[row, width]` layout; adds `units` attribute from `TUNITn`
- Add `fits_read_extension_hdus()`: iterates HDU 2..N, creates child groups named from `EXTNAME` (sanitized) or `hdu_N`, dispatches to image or table helper
- Wire `fits_read_extension_hdus()` into `NC_FITS_open()` after primary HDU reading

### `test/tst_fits_udf.c`
- Add Sprint 4b assertions: `nc_inq_grp_ncid` for `u5780205r_cvt_c0h_tab`, group `ndims`/`nvars=49`/`ngatts`, `row` dim len=4, `CRVAL1` (NC_DOUBLE, 1D), `FILLCNT` (NC_INT, 1D), `CTYPE1` (NC_CHAR, 2D)

### `ftest/ftst_fits_udf.F90`
- Add `nf90_inq_grp_ncid`, `nf90_inquire` (nvars=49), and `nf90_inq_dimid` + `nf90_inquire_dimension` for `row` dim assertions

### `docs/plan/v2.0.0-sprint4b-fits-extension-metadata.md`
- New detailed plan document for Sprint 4b

## Test results (local)
```
PASS: nc_inq_grp_ncid 'u5780205r_cvt_c0h_tab'
PASS: group nc_inq ndims=5 nvars=49 ngatts=98
PASS: row dim len=4
PASS: var 'CRVAL1' NC_DOUBLE ndims=1
PASS: var 'FILLCNT' NC_INT ndims=1
PASS: var 'CTYPE1' NC_CHAR ndims=2
PASS: nc_close
```
`make check`: 0 FAIL, 0 ERROR (C + Fortran)