### PR TITLE
FITS reader: implement NC_FITS_get_vara() for image and table data (Sprint 5)

### DIFF
--- a/docs/plan/v2.0.0-sprint5-fits-data.md
+++ b/docs/plan/v2.0.0-sprint5-fits-data.md
@@ -1,0 +1,280 @@
+# V2.0.0 Sprint 5: Read the FITS Data
+
+**Objective**: Implement `NC_FITS_get_vara()` so that `nc_get_vara_*` and
+`nf90_get_var` calls return real pixel and column data from a FITS file. By
+the end of this sprint the FITS reader is fully functional.
+
+**Prerequisite**: Sprint 4b (extension HDU metadata) complete.
+
+---
+
+## Background
+
+Sprints 4a/4b built the complete netCDF-4 in-memory inventory for all HDUs.
+`NC_FITS_VAR_INFO_T` (stored in `var->format_var_info`) carries:
+- `hdu_num` — 1-based HDU number
+- `col_num` — 1-based column number for table variables; 0 for image variables
+
+The `NC_FITS_get_vara()` function in `src/fitsfile.c` is currently a no-op stub
+(returns `NC_NOERR` without reading anything). This sprint replaces it with real
+CFITSIO calls.
+
+**Test file**: `test/data/WFPC2u5780205r_c0fx.fits`
+
+| HDU | Type      | netCDF mapping                        |
+|-----|-----------|---------------------------------------|
+| 1   | IMAGE_HDU | root group, var `image` [4,200,200] NC_FLOAT |
+| 2   | ASCII_TBL | child group `u5780205r_cvt_c0h_tab`, 49 vars, 4 rows |
+
+---
+
+## FITS ↔ netCDF coordinate mapping
+
+### Image variables
+
+FITS stores pixels in **column-major (Fortran) order**: `NAXIS1` varies fastest.
+netCDF uses **row-major (C) order**: last dimension varies fastest.
+
+The metadata inventory reversed the axes so:
+- netCDF `dim_0` (size 4) = FITS `NAXIS3`
+- netCDF `dim_1` (size 200) = FITS `NAXIS2`
+- netCDF `dim_2` (size 200) = FITS `NAXIS1`
+
+When converting `start[d]` / `count[d]` (0-based, netCDF order) to CFITSIO
+`fpixel[]` / `lpixel[]` (1-based, FITS order), reverse the dimension index:
+
+```c
+int ndims = var->ndims;   /* e.g. 3 */
+for (int d = 0; d < ndims; d++) {
+    int fd = ndims - 1 - d;          /* FITS dim index */
+    fpixel[fd] = (long)(start[d] + 1);
+    lpixel[fd] = (long)(start[d] + count[d]);
+    inc[fd]    = 1L;
+}
+fits_movabs_hdu(fptr, hdu_num, NULL, &status);
+fits_read_subset(fptr, cfitsio_type, fpixel, lpixel, inc,
+                 NULL, buf, &anynul, &status);
+```
+
+### Table column variables
+
+Rows map directly; no reversal needed:
+
+```c
+long firstrow  = (long)(start[0] + 1);   /* 1-based */
+long firstelem = (ndims > 1) ? (long)(start[1] + 1) : 1L;
+long nelements = (long)count[0] * ((ndims > 1) ? (long)count[1] : 1L);
+fits_movabs_hdu(fptr, hdu_num, NULL, &status);
+fits_read_col(fptr, cfitsio_type, col_num,
+              firstrow, firstelem, nelements,
+              NULL, buf, &anynul, &status);
+```
+
+For string columns (`xtype == NC_CHAR`) the buffer is a flat `char` array of
+size `count[0] * count[1]`. CFITSIO's `TSTRING` type expects `char **`; build
+a temporary array of `char *` pointing into the flat buffer.
+
+---
+
+## memtype → CFITSIO datatype mapping
+
+```c
+static int
+nc_type_to_cfitsio_type(nc_type memtype, int *cfitsio_type)
+{
+    switch (memtype) {
+    case NC_BYTE:   *cfitsio_type = TSBYTE;    break;
+    case NC_UBYTE:  *cfitsio_type = TBYTE;     break;
+    case NC_SHORT:  *cfitsio_type = TSHORT;    break;
+    case NC_USHORT: *cfitsio_type = TUSHORT;   break;
+    case NC_INT:    *cfitsio_type = TINT;      break;
+    case NC_UINT:   *cfitsio_type = TUINT;     break;
+    case NC_INT64:  *cfitsio_type = TLONGLONG; break;
+    case NC_UINT64: *cfitsio_type = TULONGLONG;break;
+    case NC_FLOAT:  *cfitsio_type = TFLOAT;    break;
+    case NC_DOUBLE: *cfitsio_type = TDOUBLE;   break;
+    case NC_CHAR:   *cfitsio_type = TSTRING;   break;
+    default:        return NC_EBADTYPE;
+    }
+    return NC_NOERR;
+}
+```
+
+CFITSIO applies `BSCALE`/`BZERO` and `TSCALn`/`TZEROn` automatically when
+reading into `TFLOAT` or `TDOUBLE`. No extra scaling step is needed.
+
+---
+
+## Tasks
+
+### 1. Add `nc_type_to_cfitsio_type()` helper
+
+`src/fitsfile.c` — static function inside `#ifdef HAVE_FITS`, placed near the
+other type-mapping helpers (`fits_bitpix_to_nc_type`, `fits_typecode_to_nc_type`).
+
+### 2. Implement image read path in `NC_FITS_get_vara()`
+
+Replace the no-op stub body (lines 1177–1183 of `src/fitsfile.c`) with:
+
+1. Retrieve `NC_FILE_INFO_T *h5` and `NC_GRP_INFO_T *grp` via
+   `nc4_find_grp_h5_var(ncid, varid, &h5, &grp, &var)` (or the two-step
+   `nc4_find_grp_h5` + `ncindexlookup`).
+2. Cast `var->format_var_info` to `NC_FITS_VAR_INFO_T *fits_var`.
+3. Get `fits_file` from `h5->format_file_info`.
+4. Call `nc_type_to_cfitsio_type(memtype, &cfitsio_type)`.
+5. `fits_movabs_hdu(fptr, fits_var->hdu_num, NULL, &status)`.
+6. **Image branch** (`fits_var->col_num == 0`):
+   - Build `fpixel[]`, `lpixel[]`, `inc[]` arrays by reversing `start`/`count`.
+   - Call `fits_read_subset(fptr, cfitsio_type, fpixel, lpixel, inc, NULL, value, &anynul, &status)`.
+7. **Table branch** (`fits_var->col_num > 0`): see task 3.
+8. Map nonzero `status` via `map_fitsio_error(status)` and return.
+
+### 3. Implement table column read path in `NC_FITS_get_vara()`
+
+In the table branch:
+- `firstrow  = start[0] + 1`
+- `firstelem = (var->ndims > 1) ? start[1] + 1 : 1`
+- `nelements = count[0] * (var->ndims > 1 ? count[1] : 1)`
+- For non-string columns: `fits_read_col(fptr, cfitsio_type, col_num, firstrow, firstelem, nelements, NULL, value, &anynul, &status)`.
+- For string columns (`var->type_info->hdr.id == NC_CHAR`):
+  - Allocate `char **ptrs` of `count[0]` pointers, each pointing `width` bytes
+    apart into the flat `value` buffer. (`width` is not stored in `NC_FITS_VAR_INFO_T`
+    — either re-query via `fits_get_coltype()` or store `width` in the struct.)
+  - Call `fits_read_col(fptr, TSTRING, col_num, firstrow, 1, count[0], NULL, ptrs, &anynul, &status)`.
+  - Free `ptrs`.
+
+> **Decision**: Store `col_width` in `NC_FITS_VAR_INFO_T` to avoid re-querying
+> at read time. Add `int col_width` field to the struct in `include/fitsdispatch.h`
+> and populate it in `fits_read_table_hdu()`.
+
+### 4. Add `col_width` to `NC_FITS_VAR_INFO_T`
+
+`include/fitsdispatch.h` — add field:
+
+```c
+typedef struct NC_FITS_VAR_INFO
+{
+    int hdu_num;    /**< 1-based HDU number in the FITS file */
+    int col_num;    /**< 1-based column number; 0 = image variable */
+    int col_width;  /**< bytes per string element (TSTRING columns only) */
+} NC_FITS_VAR_INFO_T;
+```
+
+`src/fitsfile.c` `fits_read_table_hdu()` — set `var_info->col_width = (int)width`
+for string columns (already has `width` from `fits_get_coltype()`); leave 0 for
+numeric columns.
+
+### 5. Determine known pixel values from the test file
+
+Before writing test assertions, extract reference values:
+
+```bash
+# Print first few pixels of the primary image (HDU 1, NC_FLOAT, shape [4,200,200])
+python3 -c "
+from astropy.io import fits
+import numpy as np
+hdu = fits.open('test/data/WFPC2u5780205r_c0fx.fits')
+d = hdu[0].data   # shape (4, 200, 200) after astropy reverses axes
+print('image[0,0,0:4] =', d[0,0,0:4])
+print('image[0,0,0]   =', d[0,0,0])
+hdu.close()
+"
+
+# Print first few values of CRVAL1 column (col 1 in HDU 2, NC_DOUBLE)
+python3 -c "
+from astropy.io import fits
+hdu = fits.open('test/data/WFPC2u5780205r_c0fx.fits')
+print('CRVAL1 =', hdu[1].data['CRVAL1'])
+hdu.close()
+"
+```
+
+Run these commands and record the values before implementing the test assertions.
+
+### 6. Update `test/tst_fits_udf.c`
+
+After the existing Sprint 4b group assertions, add a **Sprint 5** section:
+
+```c
+/* ---- Sprint 5: read image data ---- */
+{
+    float pixels[4];        /* 4 pixels along dim_2 (NAXIS1 direction) */
+    size_t start[3] = {0, 0, 0};
+    size_t count[3] = {1, 1, 4};
+    if ((retval = nc_get_vara_float(ncid, 0, start, count, pixels)))
+        ERR(retval);
+    /* Compare against known values (fill in after step 5) */
+    if (pixels[0] < -1e10 || pixels[0] > 1e10)
+    { fprintf(stderr, "image[0,0,0] out of range: %g\n", pixels[0]); return 1; }
+    printf("PASS: image pixels[0,0,0:4] = %g %g %g %g\n",
+           pixels[0], pixels[1], pixels[2], pixels[3]);
+}
+
+/* ---- Sprint 5: read table column data ---- */
+{
+    double crval1[4];
+    size_t start1[1] = {0};
+    size_t count1[1] = {4};
+    if ((retval = nc_get_vara_double(grpid, 0, start1, count1, crval1)))
+        ERR(retval);
+    printf("PASS: CRVAL1 = %g %g %g %g\n",
+           crval1[0], crval1[1], crval1[2], crval1[3]);
+    /* Add exact-value assertions after step 5 */
+}
+```
+
+Replace the range-check placeholder and the comment with exact assertions once
+the reference values from step 5 are known.
+
+### 7. Update `ftest/ftst_fits_udf.F90`
+
+After the existing Sprint 4b group assertions, add:
+
+```fortran
+! --- Sprint 5: read image data ---
+block
+  real :: pixels(4)
+  integer :: s5(3), c5(3)
+  integer :: varid5
+  s5 = (/ 1, 1, 1 /)   ! Fortran 1-based start
+  c5 = (/ 1, 1, 4 /)
+  retval = nf90_inq_varid(ncid, "image", varid5)
+  if (retval /= nf90_noerr) then
+     print *, "Error finding image var: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  retval = nf90_get_var(ncid, varid5, pixels, start=s5, count=c5)
+  if (retval /= nf90_noerr) then
+     print *, "Error reading image pixels: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  print *, "PASS: image pixels(1,1,1:4) =", pixels
+end block
+```
+
+> Note: `nf90_get_var` with `start`/`count` uses 1-based Fortran indices.
+> The Fortran interface reverses dimension order relative to C, so `start=(1,1,1)`
+> with `count=(1,1,4)` reads 4 values along the fastest-varying netCDF dimension
+> (`dim_2`, size 200).
+
+---
+
+## Definition of Done
+
+- [ ] `nc_type_to_cfitsio_type()` covers all netCDF numeric types and NC_CHAR
+- [ ] `NC_FITS_VAR_INFO_T` has `col_width` field; `fits_read_table_hdu()` populates it
+- [ ] `NC_FITS_get_vara()` image path: `fits_read_subset()` with reversed dims
+- [ ] `NC_FITS_get_vara()` table path: `fits_read_col()` for numeric and string columns
+- [ ] C test reads `image[0,0,0:4]` and asserts exact float values
+- [ ] C test reads all 4 rows of `CRVAL1` and asserts exact double values
+- [ ] Fortran test reads `image` pixels without error and prints them
+- [ ] CMake and Autotools builds clean; `make check` / `ctest` 0 FAIL
+- [ ] `ci-fits.yml` passes on both cmake and autotools matrix jobs
+
+---
+
+## Dependencies
+
+- **Sprint 4b** (prerequisite): `NC_FITS_VAR_INFO_T` with `hdu_num`/`col_num`
+  populated for all variables; `fits_file->fptr` open and valid
+- **Sprint 6** (follows): Doxygen and README updates for the completed FITS reader

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,9 +71,28 @@
 - By the end of this sprint, all FITS metadata will have been converted to the netCDF model.
 
 #### Sprint 5: Read the FITS Data
-- NEP C and Fortran tests read data from FITS file, and confirm it is correct by comparing agains stored values for some subset of the data.
-- NetCDF vara functions are used to read subsets of FITS data.
+**Detailed Plan**: See `docs/plan/v2.0.0-sprint5-fits-data.md`
+
+- Implement `NC_FITS_get_vara()` to read actual pixel/column data via CFITSIO.
+- For image variables (`col_num == 0`): convert netCDF 0-based `start[]/count[]` to
+  FITS 1-based `fpixel[]/lpixel[]` with reversed dimension order, then call
+  `fits_read_subset()`.
+- For table column variables (`col_num > 0`): call `fits_read_col()` using
+  `start[0]+1` as `firstrow` and `count[0]` as `nelements`; for 2D variables
+  (vector or string columns) use `start[1]+1` as `firstelem`.
+- Map netCDF `memtype` to the appropriate CFITSIO datatype constant.
+- C test updated to read a small subset of the primary image and verify pixel values
+  against known data, and to read one scalar column from the extension table.
+- Fortran test updated to read a row of the `image` variable and verify at least one value.
 - By the end of this sprint, the FITS reader will be fully functional.
+
+**Clarified decisions:**
+- Image data: use `fits_read_subset()` with dimension order reversal.
+- Table data: use `fits_read_col()`; string columns read via `TSTRING` into a flat
+  `char` buffer.
+- CFITSIO performs `BSCALE`/`BZERO` and `TSCALn`/`TZEROn` scaling automatically when
+  reading into floating-point types; no extra scaling step needed.
+- Known pixel values extracted from the test file before implementation to anchor the test.
 
 #### Sprint 6: Documentation and More Tests
 - Can we add more testing?

--- a/ftest/ftst_fits_udf.F90
+++ b/ftest/ftst_fits_udf.F90
@@ -1,8 +1,7 @@
 !> @file
 !!
 !! This is a test program for the NEP FITS User Defined Format (UDF)
-!! handler. It opens and closes a real FITS file through the netCDF
-!! Fortran API, relying on the generated .ncrc for UDF autoload.
+!! handler. Sprints 4a/4b: metadata checks. Sprint 5: data reads.
 !!
 !! @author Edward Hartnett
 !! @date 2026-06-28
@@ -29,6 +28,11 @@ program ftst_fits_udf
   integer :: grpid, grpid2
   character(len=NF90_MAX_NAME) :: dimname
   integer :: dimlen
+  integer :: image_varid, crval1_varid, fillcnt_varid
+  real    :: pixels(4)
+  double precision :: crval1(4)
+  integer :: fillcnt(4)
+  integer :: s3(3), c3(3), s1(1), c1(1)
 
   ! Ensure the FITS UDF handler is registered (also covers builds where
   ! .ncrc autoload is not active).
@@ -126,6 +130,73 @@ program ftst_fits_udf
      stop 1
   endif
   print *, "PASS: group row dim len=", dimlen
+
+  ! --- Sprint 5: read image data ---
+  ! Read image[0,0,0:4] (4 pixels along fastest dim_2 / NAXIS1).
+  ! Fortran nf90_get_var uses 1-based indices; dim order same as C here
+  ! because netCDF Fortran reverses vs C, but we match with reversed start/count.
+  retval = nf90_inq_varid(ncid, "image", image_varid)
+  if (retval /= nf90_noerr) then
+     print *, "Error finding image var: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  ! netCDF Fortran dim order is reversed vs C: dim 1 = C dim_2 (size 200),
+  ! dim 2 = C dim_1 (size 200), dim 3 = C dim_0 (size 4).
+  ! start=(1,1,1) count=(4,1,1) reads 4 pixels along NAXIS1.
+  s3 = (/ 1, 1, 1 /)
+  c3 = (/ 4, 1, 1 /)
+  retval = nf90_get_var(ncid, image_varid, pixels, start=s3, count=c3)
+  if (retval /= nf90_noerr) then
+     print *, "Error reading image pixels: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  ! Expected: pixels(1)~-1.5443, pixels(2)~0.9169
+  if (abs(pixels(1) - (-1.5442986)) > 1e-5) then
+     print *, "image pixel(1): expected ~-1.5443, got ", pixels(1)
+     stop 1
+  endif
+  if (abs(pixels(2) - 0.9169310) > 1e-5) then
+     print *, "image pixel(2): expected ~0.9169, got ", pixels(2)
+     stop 1
+  endif
+  print *, "PASS: image pixels(1:4) =", pixels
+
+  ! --- Sprint 5: read table column CRVAL1 (NC_DOUBLE, 4 rows) ---
+  retval = nf90_inq_varid(grpid, "CRVAL1", crval1_varid)
+  if (retval /= nf90_noerr) then
+     print *, "Error finding CRVAL1 var: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  s1 = (/ 1 /)
+  c1 = (/ 4 /)
+  retval = nf90_get_var(grpid, crval1_varid, crval1, start=s1, count=c1)
+  if (retval /= nf90_noerr) then
+     print *, "Error reading CRVAL1: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  ! Expected row 0: ~182.631, row 1: ~182.626
+  if (abs(crval1(1) - 182.63118863080002d0) > 1d-6) then
+     print *, "CRVAL1(1): expected ~182.631, got ", crval1(1)
+     stop 1
+  endif
+  print *, "PASS: CRVAL1 =", crval1
+
+  ! --- Sprint 5: read table column FILLCNT (NC_INT, 4 rows) ---
+  retval = nf90_inq_varid(grpid, "FILLCNT", fillcnt_varid)
+  if (retval /= nf90_noerr) then
+     print *, "Error finding FILLCNT var: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  retval = nf90_get_var(grpid, fillcnt_varid, fillcnt, start=s1, count=c1)
+  if (retval /= nf90_noerr) then
+     print *, "Error reading FILLCNT: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  if (fillcnt(1) /= 0 .or. fillcnt(2) /= 0 .or. fillcnt(3) /= 0 .or. fillcnt(4) /= 0) then
+     print *, "FILLCNT: expected all zeros, got", fillcnt
+     stop 1
+  endif
+  print *, "PASS: FILLCNT =", fillcnt
 
   ! Close the file.
   retval = nf90_close(ncid)

--- a/include/fitsdispatch.h
+++ b/include/fitsdispatch.h
@@ -36,6 +36,7 @@ typedef struct NC_FITS_VAR_INFO
 {
     int hdu_num;    /**< 1-based HDU number in the FITS file */
     int col_num;    /**< 1-based column number; 0 = image variable */
+    int col_width;  /**< bytes per string element (TSTRING columns only; 0 otherwise) */
 } NC_FITS_VAR_INFO_T;
 
 /** Per-file FITS state with CFITSIO integration */

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -770,6 +770,7 @@ fits_read_table_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
             NC_DIM_INFO_T *str_dim;
             char sdimname[NC_MAX_NAME + 1];
 
+            var_info->col_width = (int)width;
             strncpy(sdimname, varname, NC_MAX_NAME - 4);
             sdimname[NC_MAX_NAME - 4] = '\0';
             strncat(sdimname, "_len", 5);
@@ -1155,30 +1156,166 @@ NC_FITS_inq_format_extended(int ncid, int *formatp, int *modep)
     return NC_NOERR;
 }
 
+#ifdef HAVE_FITS
+/**
+ * @internal Map a netCDF memory type to the corresponding CFITSIO datatype
+ * constant for use with fits_read_pix(), fits_read_subset(), fits_read_col().
+ *
+ * @param memtype netCDF type.
+ * @param cfitsio_type Pointer that receives the CFITSIO type constant.
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADTYPE Unknown type.
+ * @author Edward Hartnett
+ */
+static int
+nc_type_to_cfitsio_type(nc_type memtype, int *cfitsio_type)
+{
+    switch (memtype)
+    {
+    case NC_BYTE:   *cfitsio_type = TSBYTE;     break;
+    case NC_UBYTE:  *cfitsio_type = TBYTE;      break;
+    case NC_SHORT:  *cfitsio_type = TSHORT;     break;
+    case NC_USHORT: *cfitsio_type = TUSHORT;    break;
+    case NC_INT:    *cfitsio_type = TINT;       break;
+    case NC_UINT:   *cfitsio_type = TUINT;      break;
+    case NC_INT64:  *cfitsio_type = TLONGLONG;  break;
+    case NC_UINT64: *cfitsio_type = TULONGLONG; break;
+    case NC_FLOAT:  *cfitsio_type = TFLOAT;     break;
+    case NC_DOUBLE: *cfitsio_type = TDOUBLE;    break;
+    case NC_CHAR:   *cfitsio_type = TSTRING;    break;
+    default:        return NC_EBADTYPE;
+    }
+    return NC_NOERR;
+}
+#endif /* HAVE_FITS */
+
 /**
  * @internal Read a hyperslab of data from a FITS variable.
  *
- * Sprint 2: no-op. No variables are defined yet.
+ * For image variables (col_num == 0): converts 0-based netCDF start/count to
+ * 1-based FITS fpixel/lpixel with reversed dimension order, then calls
+ * fits_read_subset().
+ *
+ * For table column variables (col_num > 0): calls fits_read_col() using
+ * start[0]+1 as firstrow. For 2D variables (vector or string columns),
+ * start[1]+1 is used as firstelem.
+ *
+ * CFITSIO applies BSCALE/BZERO and TSCALn/TZEROn scaling automatically when
+ * reading into floating-point types.
  *
  * @param ncid NetCDF ID.
  * @param varid Variable ID.
- * @param start Start indices.
+ * @param start Start indices (0-based).
  * @param count Counts.
- * @param value Buffer.
- * @param memtype Memory type.
+ * @param value Output buffer.
+ * @param memtype Memory type requested by caller.
  *
  * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid or varid.
+ * @return ::NC_EINVAL Invalid parameters.
+ * @return ::NC_EIO CFITSIO read error.
  * @author Edward Hartnett
  */
 int
 NC_FITS_get_vara(int ncid, int varid, const size_t *start, const size_t *count,
                  void *value, nc_type memtype)
 {
-    (void)ncid;
-    (void)varid;
-    (void)start;
-    (void)count;
-    (void)value;
-    (void)memtype;
+#ifdef HAVE_FITS
+    NC_FILE_INFO_T *h5;
+    NC_GRP_INFO_T *grp;
+    NC_VAR_INFO_T *var;
+    NC_FITS_FILE_INFO_T *fits_file;
+    NC_FITS_VAR_INFO_T *fits_var;
+    int cfitsio_type;
+    int fits_status = 0;
+    int anynul;
+    int retval;
+
+    if (!start || !count || !value)
+        return NC_EINVAL;
+
+    if ((retval = nc4_find_grp_h5_var(ncid, varid, &h5, &grp, &var)))
+        return retval;
+    if (!var || !var->format_var_info)
+        return NC_EBADID;
+
+    fits_file = (NC_FITS_FILE_INFO_T *)h5->format_file_info;
+    fits_var  = (NC_FITS_VAR_INFO_T *)var->format_var_info;
+
+    /* Use variable's own type if caller did not specify */
+    if (memtype == NC_NAT)
+        memtype = (nc_type)var->type_info->hdr.id;
+
+    if ((retval = nc_type_to_cfitsio_type(memtype, &cfitsio_type)))
+        return retval;
+
+    fits_status = 0;
+    fits_movabs_hdu(fits_file->fptr, fits_var->hdu_num, NULL, &fits_status);
+    if (fits_status)
+        return map_fitsio_error(fits_status);
+
+    if (fits_var->col_num == 0)
+    {
+        /* Image variable: reverse dimension order for FITS column-major layout */
+        int ndims = var->ndims;
+        long fpixel[NC_MAX_VAR_DIMS];
+        long lpixel[NC_MAX_VAR_DIMS];
+        long inc[NC_MAX_VAR_DIMS];
+        int d;
+
+        for (d = 0; d < ndims; d++)
+        {
+            int fd = ndims - 1 - d;   /* FITS dimension index (reversed) */
+            fpixel[fd] = (long)(start[d] + 1);
+            lpixel[fd] = (long)(start[d] + count[d]);
+            inc[fd]    = 1L;
+        }
+
+        fits_read_subset(fits_file->fptr, cfitsio_type, fpixel, lpixel, inc,
+                         NULL, value, &anynul, &fits_status);
+        if (fits_status)
+            return map_fitsio_error(fits_status);
+    }
+    else
+    {
+        /* Table column variable */
+        long firstrow  = (long)(start[0] + 1);
+        long firstelem = (var->ndims > 1) ? (long)(start[1] + 1) : 1L;
+        long nelements = (long)count[0] * ((var->ndims > 1) ? (long)count[1] : 1L);
+
+        if (memtype == NC_CHAR && fits_var->col_width > 0)
+        {
+            /* String column: CFITSIO needs char** pointing into flat buffer */
+            long nrows = (long)count[0];
+            int w = fits_var->col_width;
+            char **ptrs = (char **)malloc((size_t)nrows * sizeof(char *));
+            long r;
+
+            if (!ptrs)
+                return NC_ENOMEM;
+            for (r = 0; r < nrows; r++)
+                ptrs[r] = (char *)value + r * w;
+
+            fits_read_col(fits_file->fptr, TSTRING, fits_var->col_num,
+                          firstrow, 1L, nrows,
+                          NULL, ptrs, &anynul, &fits_status);
+            free(ptrs);
+        }
+        else
+        {
+            fits_read_col(fits_file->fptr, cfitsio_type, fits_var->col_num,
+                          firstrow, firstelem, nelements,
+                          NULL, value, &anynul, &fits_status);
+        }
+
+        if (fits_status)
+            return map_fitsio_error(fits_status);
+    }
+
     return NC_NOERR;
+#else
+    (void)ncid; (void)varid; (void)start; (void)count; (void)value; (void)memtype;
+    return NC_ENOTBUILT;
+#endif
 }

--- a/test/tst_fits_udf.c
+++ b/test/tst_fits_udf.c
@@ -2,13 +2,14 @@
  * @file tst_fits_udf.c
  * @brief Test for FITS User Defined Format (UDF) handler.
  *
- * Sprint 4a: validates that the primary HDU of a real FITS file is correctly
- * mapped to the netCDF-4 in-memory model — dimensions, variable, and global
- * attributes are all accessible via nc_inq* functions.
+ * Sprint 4a: validates primary HDU metadata (dims, variable, attributes).
+ * Sprint 4b: validates extension HDU child group (49 table vars, row dim).
+ * Sprint 5: validates data reads — image pixels and table column values.
  *
  * Test file: WFPC2u5780205r_c0fx.fits
  *   Primary HDU: BITPIX=-32 (NC_FLOAT), NAXIS=3, NAXIS1=200 NAXIS2=200 NAXIS3=4
  *   Expected netCDF mapping: 3 dims (4,200,200), 1 var "image" (NC_FLOAT)
+ *   HDU 2: ASCII table, 4 rows x 49 cols -> group "u5780205r_cvt_c0h_tab"
  *
  * @author Edward Hartnett
  * @date 2026-06-28
@@ -21,6 +22,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include <netcdf.h>
 #include "fitsdispatch.h"
 
@@ -182,6 +184,70 @@ main(void)
     if (var_ndims != 2)
     { fprintf(stderr, "CTYPE1: expected ndims=2, got %d\n", var_ndims); return 1; }
     printf("PASS: var 'CTYPE1' NC_CHAR ndims=2\n");
+
+    /* ---- Sprint 5: read image data ---- */
+    {
+        /* Read 4 consecutive pixels along dim_2 (NAXIS1) from image[0,0,0:4].
+         * Known values extracted from raw FITS bytes (BSCALE=1, BZERO=0). */
+        float pixels[4];
+        size_t img_start[3] = {0, 0, 0};
+        size_t img_count[3] = {1, 1, 4};
+        int image_varid;
+
+        if ((retval = nc_inq_varid(root_ncid, "image", &image_varid)))
+            ERR(retval);
+        if ((retval = nc_get_vara_float(root_ncid, image_varid,
+                                        img_start, img_count, pixels)))
+            ERR(retval);
+        /* Expected: pixel[0]=-1.5442986, [1]=0.9169310, [2]=-0.0955117, [3]=0.8646135 */
+        if (fabsf(pixels[0] - (-1.5442986f)) > 1e-5f)
+        { fprintf(stderr, "image[0,0,0]: expected ~-1.5443, got %g\n", pixels[0]); return 1; }
+        if (fabsf(pixels[1] - 0.9169310f) > 1e-5f)
+        { fprintf(stderr, "image[0,0,1]: expected ~0.9169, got %g\n", pixels[1]); return 1; }
+        printf("PASS: image pixels[0,0,0:4] = %g %g %g %g\n",
+               pixels[0], pixels[1], pixels[2], pixels[3]);
+    }
+
+    /* ---- Sprint 5: read table column CRVAL1 (NC_DOUBLE, 4 rows) ---- */
+    {
+        double crval1[4];
+        size_t tbl_start[1] = {0};
+        size_t tbl_count[1] = {4};
+        int crval1_varid;
+
+        if ((retval = nc_inq_varid(grpid, "CRVAL1", &crval1_varid)))
+            ERR(retval);
+        if ((retval = nc_get_vara_double(grpid, crval1_varid,
+                                          tbl_start, tbl_count, crval1)))
+            ERR(retval);
+        /* Expected row 0: ~182.63118863, row 1: ~182.62552336 */
+        if (fabs(crval1[0] - 182.63118863080002) > 1e-6)
+        { fprintf(stderr, "CRVAL1[0]: expected ~182.631, got %g\n", crval1[0]); return 1; }
+        if (fabs(crval1[1] - 182.62552336340000) > 1e-6)
+        { fprintf(stderr, "CRVAL1[1]: expected ~182.626, got %g\n", crval1[1]); return 1; }
+        printf("PASS: CRVAL1 = %g %g %g %g\n",
+               crval1[0], crval1[1], crval1[2], crval1[3]);
+    }
+
+    /* ---- Sprint 5: read table column FILLCNT (NC_INT, 4 rows) ---- */
+    {
+        int fillcnt[4];
+        size_t tbl_start[1] = {0};
+        size_t tbl_count[1] = {4};
+        int fillcnt_varid;
+
+        if ((retval = nc_inq_varid(grpid, "FILLCNT", &fillcnt_varid)))
+            ERR(retval);
+        if ((retval = nc_get_vara_int(grpid, fillcnt_varid,
+                                       tbl_start, tbl_count, fillcnt)))
+            ERR(retval);
+        /* All four rows have FILLCNT=0 */
+        if (fillcnt[0] != 0 || fillcnt[1] != 0 || fillcnt[2] != 0 || fillcnt[3] != 0)
+        { fprintf(stderr, "FILLCNT: expected all zeros, got %d %d %d %d\n",
+                  fillcnt[0], fillcnt[1], fillcnt[2], fillcnt[3]); return 1; }
+        printf("PASS: FILLCNT = %d %d %d %d\n",
+               fillcnt[0], fillcnt[1], fillcnt[2], fillcnt[3]);
+    }
 
     if ((retval = nc_close(root_ncid)))
         ERR(retval);


### PR DESCRIPTION
## Summary

Implements `NC_FITS_get_vara()` in `src/fitsfile.c`, completing the FITS reader so that `nc_get_vara_*` and `nf90_get_var` calls return real pixel and column data from a FITS file.

## Changes

### `include/fitsdispatch.h`
- Added `col_width` field to `NC_FITS_VAR_INFO_T` — stores the byte width of string (TSTRING) columns so the read path can build the `char**` pointer array CFITSIO requires.

### `src/fitsfile.c`
- **`nc_type_to_cfitsio_type()`** — new static helper mapping all netCDF types (`NC_BYTE`…`NC_CHAR`) to CFITSIO datatype constants (`TSBYTE`…`TSTRING`).
- **`fits_read_table_hdu()`** — populates `var_info->col_width` for `NC_CHAR` columns.
- **`NC_FITS_get_vara()`** — replaces no-op stub with two read paths:
  - **Image variables** (`col_num == 0`): reverses 0-based netCDF `start[]/count[]` to 1-based FITS `fpixel[]/lpixel[]` (column-major ↔ row-major), then calls `fits_read_subset()`.
  - **Table columns** (`col_num > 0`): calls `fits_read_col()` directly; string columns use a temporary `char**` array pointing into the caller's flat buffer.
  - CFITSIO handles `BSCALE`/`BZERO` and `TSCALn`/`TZEROn` scaling automatically — no extra step needed.

### `test/tst_fits_udf.c`
Three new Sprint 5 assertions against `WFPC2u5780205r_c0fx.fits`:
- Image pixels `[0,0,0:4]` verified against known float values extracted from raw FITS bytes.
- `CRVAL1` (4 NC_DOUBLE rows from the ASCII table extension) checked to `1e-6` tolerance.
- `FILLCNT` (4 NC_INT rows) verified all zero.

### `ftest/ftst_fits_udf.F90`
Matching Fortran reads using `nf90_get_var` with `start`/`count`; same pixel and column assertions.

## Test results

```
PASS: image pixels[0,0,0:4] = -1.5443 0.916931 -0.0955117 0.864613
PASS: CRVAL1 = 182.631 182.626 182.652 182.65
PASS: FILLCNT = 0 0 0 0
```

Both `make check` (Autotools) pass with 0 FAIL / 0 ERROR. The FITS reader is now fully functional.