### PR TITLE
Add Sprint 6 FITS reader documentation and additional test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ NEP extends NetCDF-4 with powerful new capabilities for scientific data workflow
 - **NASA CDF File Reader**: Access Common Data Format files directly through the familiar NetCDF API - no conversion needed
 - **GeoTIFF File Reader**: Read GeoTIFF geospatial raster files through the NetCDF API with CF-1.8 compliant CRS metadata
 - **GRIB2 File Reader**: Read GRIB2 meteorological and oceanographic data files (NWP model output, wave forecasts) through the NetCDF API
+- **FITS File Reader**: Read NASA/ESA FITS astronomical image and table files (HST, Chandra, JWST) through the NetCDF API
 - **Drop-In Compatibility**: Works with existing NetCDF-4 applications without code changes
 
 ## Why NEP?
@@ -401,6 +402,76 @@ cmake -B build -DENABLE_GRIB2=OFF
 Requires NOAA NCEPLIBS-g2c (>= 2.1.0) and libjasper (>= 3.0.0). Supply the g2c install path via `G2C_PATH` or `--with-g2c` at configure time.
 
 **Note**: GRIB2 and CDF are mutually exclusive — both use UDF slot 2. Enable one or the other, not both.
+
+---
+
+### What is FITS?
+
+FITS (Flexible Image Transport System) is the standard format used by NASA, ESA, and the astronomical community to store images, spectra, and tables from telescopes and instruments such as the Hubble Space Telescope, Chandra X-ray Observatory, and the James Webb Space Telescope.
+
+**Key characteristics:**
+- Multi-HDU structure: primary image plus optional extension HDUs (image, ASCII table, binary table)
+- BITPIX keyword encodes data type (8/16/32-bit integer, 32/64-bit IEEE float)
+- Dimension order is column-major (FITS) vs. row-major (netCDF/C) — handled automatically by NEP
+- WCS (World Coordinate System) keywords stored as netCDF attributes
+
+### FITS File Reader: Astronomical Data Access
+
+**Current Features (v2.0.0):**
+- ✅ Automatic format detection — FITS files recognized by `SIMPLE` magic bytes
+- ✅ Open/close via standard `nc_open()` and `nc_close()`; `ncdump` works directly
+- ✅ Primary HDU: image variable in the root group; `BITPIX` mapped to `nc_type`
+- ✅ Standard keywords mapped to netCDF attributes: `BUNIT`→`units`, `BZERO`→`add_offset`, `BSCALE`→`scale_factor`, `BLANK`→`_FillValue`
+- ✅ All header keywords stored as global attributes
+- ✅ Extension HDUs: each becomes a child group named from `EXTNAME`
+- ✅ ASCII and binary table HDUs: row dimension + one variable per column; `TUNITn`→`units`
+- ✅ Data reading via `nc_get_vara_*`: `fits_read_subset()` for images, `fits_read_col()` for table columns
+- ✅ Dimension order reversal handled automatically (FITS column-major ↔ netCDF row-major)
+- ✅ CFITSIO applies `BSCALE`/`BZERO` and `TSCALn`/`TZEROn` scaling automatically
+
+**Usage Example:**
+
+```c
+#include <netcdf.h>
+
+int ncid, varid;
+float pixels[4];  /* 4 pixels from a [4, 200, 200] float image */
+size_t start[3] = {0, 0, 0};
+size_t count[3] = {1, 1, 4};
+
+/* Open FITS file - automatically detected */
+if ((retval = nc_open("WFPC2u5780205r_c0fx.fits", NC_NOWRITE, &ncid)))
+    ERR(retval);
+
+/* Read a hyperslab from the primary image */
+if ((retval = nc_inq_varid(ncid, "image", &varid)))
+    ERR(retval);
+if ((retval = nc_get_vara_float(ncid, varid, start, count, pixels)))
+    ERR(retval);
+
+if ((retval = nc_close(ncid)))
+    ERR(retval);
+```
+
+Or use `ncdump` directly:
+
+```bash
+ncdump -h WFPC2u5780205r_c0fx.fits
+```
+
+**Build Configuration:**
+
+FITS support is enabled by default when CFITSIO is found. To disable:
+
+```bash
+# CMake
+cmake -B build -DENABLE_FITS=OFF
+
+# Autotools
+./configure --disable-fits
+```
+
+Requires CFITSIO (>= 3.0). Supply the install path via `CFITSIO_PATH` or `--with-cfitsio` at configure time.
 
 ---
 

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -9,6 +9,7 @@ NEP (NetCDF Extension Pack) extends NetCDF-4 with high-performance compression a
 - **CDF File Reader**: Read NASA Common Data Format files through the NetCDF API
 - **GeoTIFF File Reader**: Read GeoTIFF geospatial raster files through the NetCDF API
 - **GRIB2 File Reader**: Read GRIB2 meteorological and oceanographic data files through the NetCDF API
+- **FITS File Reader**: Read NASA/ESA FITS astronomical image and table HDUs through the NetCDF API
 
 NEP provides flexible compression options and unified data access for diverse scientific data workflows.
 

--- a/docs/plan/v2.0.0-sprint6-fits-docs-tests.md
+++ b/docs/plan/v2.0.0-sprint6-fits-docs-tests.md
@@ -1,0 +1,221 @@
+# V2.0.0 Sprint 6: Documentation and More Tests
+
+**Objective**: Document the completed FITS reader in `README.md` and the Doxygen
+landing page, update the `fitsfile.c` file-level header, and add moderate additional
+test coverage exercising the second image plane, a non-zero-start hyperslab, and the
+2D string column `CTYPE1`.
+
+**Prerequisite**: Sprint 5 (data reading) complete and merged.
+
+---
+
+## Background
+
+Sprint 5 made the FITS reader fully functional. Sprint 6 ensures it is properly
+documented and that the test suite covers the key code paths not yet exercised:
+
+| Untested path | New test |
+|---|---|
+| Non-first image plane | `image[1,0,0]` → known float |
+| Non-zero start offset | `image[0,1,0:4]` → known floats |
+| 2D string column (TSTRING / `char**` path) | `CTYPE1[0:4, 0:8]` → known strings |
+
+**Test file**: `test/data/WFPC2u5780205r_c0fx.fits`
+
+---
+
+## Reference values (extracted from raw FITS bytes)
+
+| Read | Value(s) |
+|---|---|
+| `image[1,0,0]` | `0.5044580698f` |
+| `image[0,1,0:4]` | `{-0.8824396f, -1.0924211f, 0.9486601f, -0.0793435f}` |
+| `CTYPE1[0:4]` | all rows `"RA---TAN"` |
+
+---
+
+## Tasks
+
+### 1. Add FITS section to `README.md`
+
+Insert a new `### FITS File Reader` section after the existing `### GRIB2 File
+Reader` section, following the same structure:
+
+```markdown
+### FITS File Reader: Astronomical Data Access
+
+**Capability**: Read NASA/ESA FITS (Flexible Image Transport System) files through
+the NetCDF API you already know.
+
+**Benefits**:
+- No file conversion required — access image and table data directly
+- Automatic BITPIX → nc_type mapping (FITS IEEE float, integer, double)
+- Multi-HDU support: each extension HDU becomes a child group
+- Table columns (ASCII and binary) mapped to netCDF variables with units attributes
+- Dimension order reversal handled automatically (FITS column-major → netCDF row-major)
+
+**Use Cases**:
+- Hubble Space Telescope and other observatory data pipelines
+- Astronomical catalog access alongside NetCDF model output
+- Cross-format analysis combining FITS observations with NetCDF simulations
+
+**How It Works**: NEP provides a User-Defined Format (UDF) handler that
+transparently reads FITS files through standard NetCDF functions such as
+`nc_open()`, `nc_get_var()`, and `nc_get_att()`. CFITSIO handles the low-level
+I/O and scaling (`BSCALE`/`BZERO`, `TSCALn`/`TZEROn`); the handler maps the
+FITS data model (HDUs, BITPIX, TTYPEn) to the netCDF-4 group/dimension/variable
+model.
+```
+
+Place the bullet for FITS in the top-level feature list:
+
+```markdown
+- **FITS File Reader**: Read NASA/ESA FITS astronomical image and table files
+  through the NetCDF API
+```
+
+### 2. Add FITS to `docs/mainpage.md`
+
+In the format list near CDF/GeoTIFF/GRIB2, add:
+
+```markdown
+- **FITS File Reader**: Read NASA/ESA FITS astronomical image and table HDUs
+  through the NetCDF API
+```
+
+### 3. Update `@file` block in `src/fitsfile.c`
+
+Replace the current brief description (which still refers to "Sprint 3") with:
+
+```c
+/**
+ * @file fitsfile.c
+ * @brief FITS User-Defined Format (UDF) dispatch layer.
+ *
+ * Implements the NEP FITS reader, which maps NASA/ESA Flexible Image Transport
+ * System (FITS) files to the netCDF-4 data model using CFITSIO.
+ *
+ * - Primary HDU: image variable in the root group; BITPIX mapped to nc_type;
+ *   standard keywords (BUNIT, BSCALE, BZERO, BLANK) mapped to attributes.
+ * - Extension HDUs: each becomes a child group named from EXTNAME.
+ *   ASCII/binary table HDUs: row dimension + one variable per column.
+ *   Image extension HDUs: same dim/var/attribute mapping as the primary HDU.
+ * - Data reading: NC_FITS_get_vara() calls fits_read_subset() for image
+ *   variables and fits_read_col() for table columns. Dimension order is
+ *   reversed (FITS column-major ↔ netCDF row-major). CFITSIO applies
+ *   BSCALE/BZERO scaling automatically.
+ *
+ * @author Edward Hartnett
+ * @date 2026-06-29
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+```
+
+### 4. Add additional C test assertions in `test/tst_fits_udf.c`
+
+After the existing Sprint 5 block, add a **Sprint 6** section with three
+sub-sections:
+
+#### 4a. Second image plane
+
+```c
+/* ---- Sprint 6: second image plane image[1,0,0] ---- */
+{
+    float pix;
+    size_t s[3] = {1, 0, 0};
+    size_t c[3] = {1, 1, 1};
+
+    if ((retval = nc_get_vara_float(root_ncid, image_varid, s, c, &pix)))
+        ERR(retval);
+    /* Expected: 0.5044580698f */
+    if (fabsf(pix - 0.5044580698f) > 1e-5f)
+    { fprintf(stderr, "image[1,0,0]: expected ~0.5045, got %g\n", pix); return 1; }
+    printf("PASS: image[1,0,0] = %g\n", pix);
+}
+```
+
+#### 4b. Non-zero-start hyperslab
+
+```c
+/* ---- Sprint 6: non-zero-start image[0,1,0:4] ---- */
+{
+    float row1[4];
+    size_t s[3] = {0, 1, 0};
+    size_t c[3] = {1, 1, 4};
+
+    if ((retval = nc_get_vara_float(root_ncid, image_varid, s, c, row1)))
+        ERR(retval);
+    /* Expected: {-0.8824396f, -1.0924211f, 0.9486601f, -0.0793435f} */
+    if (fabsf(row1[0] - (-0.8824396f)) > 1e-5f)
+    { fprintf(stderr, "image[0,1,0]: expected ~-0.8824, got %g\n", row1[0]); return 1; }
+    printf("PASS: image[0,1,0:4] = %g %g %g %g\n",
+           row1[0], row1[1], row1[2], row1[3]);
+}
+```
+
+#### 4c. 2D string column `CTYPE1`
+
+```c
+/* ---- Sprint 6: string column CTYPE1 [4 rows x 8 chars] ---- */
+{
+    /* CTYPE1 is NC_CHAR, dims [4, 8] */
+    char ctype1[4][8];
+    int ctype1_varid;
+    size_t s[2] = {0, 0};
+    size_t c[2] = {4, 8};
+
+    if ((retval = nc_inq_varid(grpid, "CTYPE1", &ctype1_varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_text(grpid, ctype1_varid, s, c, &ctype1[0][0])))
+        ERR(retval);
+    /* All 4 rows should be "RA---TAN" */
+    if (strncmp(ctype1[0], "RA---TAN", 8) != 0)
+    { fprintf(stderr, "CTYPE1[0]: expected 'RA---TAN', got '%.8s'\n", ctype1[0]); return 1; }
+    printf("PASS: CTYPE1[0] = '%.8s'\n", ctype1[0]);
+}
+```
+
+### 5. Add additional Fortran assertions in `ftest/ftst_fits_udf.F90`
+
+After the existing Sprint 5 block, add:
+
+```fortran
+! --- Sprint 6: second image plane image[1,0,0] ---
+! Fortran dim order reversed: start=(1,1,2) count=(1,1,1) => plane index 2 (0-based=1)
+s3 = (/ 1, 1, 2 /)
+c3 = (/ 1, 1, 1 /)
+retval = nf90_get_var(ncid, image_varid, pixels(1:1), start=s3, count=c3)
+if (retval /= nf90_noerr) then
+   print *, "Error reading image[1,0,0]: ", trim(nf90_strerror(retval))
+   stop 1
+endif
+if (abs(pixels(1) - 0.5044580698) > 1e-5) then
+   print *, "image[1,0,0]: expected ~0.5045, got ", pixels(1)
+   stop 1
+endif
+print *, "PASS: image[1,0,0] =", pixels(1)
+```
+
+---
+
+## Definition of Done
+
+- [ ] `README.md` has a `### FITS File Reader` section with Capability / Benefits /
+      Use Cases / How It Works content, and FITS in the top-level feature bullet list
+- [ ] `docs/mainpage.md` lists FITS alongside CDF/GeoTIFF/GRIB2
+- [ ] `src/fitsfile.c` `@file` block reflects the fully implemented state
+- [ ] C test: `image[1,0,0]` asserted to `1e-5f` tolerance
+- [ ] C test: `image[0,1,0:4]` asserted to `1e-5f` tolerance
+- [ ] C test: `CTYPE1[0]` compared to `"RA---TAN"`
+- [ ] Fortran test: `image[1,0,0]` asserted to `1e-5` tolerance
+- [ ] `make check` passes with 0 FAIL / 0 ERROR (Autotools)
+- [ ] `ctest` passes with 0 FAIL (CMake)
+- [ ] `ci-fits.yml` passes on both cmake and autotools matrix jobs
+
+---
+
+## Dependencies
+
+- **Sprint 5** (prerequisite): `NC_FITS_get_vara()` fully implemented; C and Fortran
+  tests already exercise the primary image and two numeric table columns
+- No follow-on sprints defined for v2.0.0

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,8 +95,18 @@
 - Known pixel values extracted from the test file before implementation to anchor the test.
 
 #### Sprint 6: Documentation and More Tests
-- Can we add more testing?
-- Update the doxygen and README to include the new FITS reading capability.
+**Detailed Plan**: See `docs/plan/v2.0.0-sprint6-fits-docs-tests.md`
+
+- Add FITS reader section to `README.md` (Capability / Benefits / How It Works / Use Cases),
+  consistent with the existing CDF, GeoTIFF, and GRIB2 sections.
+- Add FITS to the format list in `docs/mainpage.md` (Doxygen landing page).
+- Update the `@file` block in `src/fitsfile.c` to reflect the fully implemented state.
+- Add moderate additional test coverage to `test/tst_fits_udf.c`:
+  - Read a second image plane (`image[1,0,0]`) and verify against the known float value.
+  - Read a non-zero-start hyperslab (`image[0,1,0:4]`) to exercise the offset path.
+  - Read all 4 rows of the 2D string column `CTYPE1` and verify the first string.
+- Add matching additional assertions to `ftest/ftst_fits_udf.F90`.
+- By the end of this sprint, the FITS reader is fully documented and tested.
 
 ### V1.11.0 NcZarr Examples
 

--- a/ftest/ftst_fits_udf.F90
+++ b/ftest/ftst_fits_udf.F90
@@ -198,6 +198,23 @@ program ftst_fits_udf
   endif
   print *, "PASS: FILLCNT =", fillcnt
 
+  ! --- Sprint 6: second image plane image[1,0,0] ---
+  ! Fortran dim order reversed: dim 3 = C dim_0 (size 4, plane index).
+  ! start=(1,1,2) count=(1,1,1) => C start={1,0,0} count={1,1,1}
+  s3 = (/ 1, 1, 2 /)
+  c3 = (/ 1, 1, 1 /)
+  retval = nf90_get_var(ncid, image_varid, pixels(1:1), start=s3, count=c3)
+  if (retval /= nf90_noerr) then
+     print *, "Error reading image[1,0,0]: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  ! Expected: ~0.5045
+  if (abs(pixels(1) - 0.5044580698) > 1e-5) then
+     print *, "image[1,0,0]: expected ~0.5045, got ", pixels(1)
+     stop 1
+  endif
+  print *, "PASS: image[1,0,0] =", pixels(1)
+
   ! Close the file.
   retval = nf90_close(ncid)
   if (retval /= nf90_noerr) then

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -1,14 +1,22 @@
 /**
- * @file
- * @internal The FITS file functions. These provide a read-only
- * interface to FITS astronomical data files via CFITSIO.
+ * @file fitsfile.c
+ * @brief FITS User-Defined Format (UDF) dispatch layer.
  *
- * Sprint 3: real CFITSIO integration. The open function calls
- * fits_open_file() and stores the CFITSIO file handle for later
- * use in metadata and data reading.
+ * Implements the NEP FITS reader, which maps NASA/ESA Flexible Image
+ * Transport System (FITS) files to the netCDF-4 data model via CFITSIO.
+ *
+ * - Primary HDU: image variable in the root group; BITPIX mapped to nc_type;
+ *   standard keywords (BUNIT, BSCALE, BZERO, BLANK) mapped to attributes.
+ * - Extension HDUs: each becomes a child group named from EXTNAME.
+ *   ASCII/binary table HDUs: row dimension + one variable per column.
+ *   Image extension HDUs: same dim/var/attribute mapping as the primary HDU.
+ * - Data reading: NC_FITS_get_vara() calls fits_read_subset() for image
+ *   variables and fits_read_col() for table columns. Dimension order is
+ *   reversed (FITS column-major <-> netCDF row-major). CFITSIO applies
+ *   BSCALE/BZERO scaling automatically.
  *
  * @author Edward Hartnett
- * @date 2026-06-28
+ * @date 2026-06-29
  * @copyright Intelligent Data Design, Inc. All rights reserved.
  */
 

--- a/test/tst_fits_udf.c
+++ b/test/tst_fits_udf.c
@@ -249,6 +249,58 @@ main(void)
                fillcnt[0], fillcnt[1], fillcnt[2], fillcnt[3]);
     }
 
+    /* ---- Sprint 6: second image plane image[1,0,0] ---- */
+    {
+        float pix;
+        size_t s[3] = {1, 0, 0};
+        size_t c[3] = {1, 1, 1};
+        int image_varid2;
+
+        if ((retval = nc_inq_varid(root_ncid, "image", &image_varid2)))
+            ERR(retval);
+        if ((retval = nc_get_vara_float(root_ncid, image_varid2, s, c, &pix)))
+            ERR(retval);
+        /* Expected: 0.5044580698f */
+        if (fabsf(pix - 0.5044580698f) > 1e-5f)
+        { fprintf(stderr, "image[1,0,0]: expected ~0.5045, got %g\n", pix); return 1; }
+        printf("PASS: image[1,0,0] = %g\n", pix);
+    }
+
+    /* ---- Sprint 6: non-zero-start hyperslab image[0,1,0:4] ---- */
+    {
+        float row1[4];
+        size_t s[3] = {0, 1, 0};
+        size_t c[3] = {1, 1, 4};
+        int image_varid3;
+
+        if ((retval = nc_inq_varid(root_ncid, "image", &image_varid3)))
+            ERR(retval);
+        if ((retval = nc_get_vara_float(root_ncid, image_varid3, s, c, row1)))
+            ERR(retval);
+        /* Expected: {-0.8824396f, -1.0924211f, 0.9486601f, -0.0793435f} */
+        if (fabsf(row1[0] - (-0.8824396f)) > 1e-5f)
+        { fprintf(stderr, "image[0,1,0]: expected ~-0.8824, got %g\n", row1[0]); return 1; }
+        printf("PASS: image[0,1,0:4] = %g %g %g %g\n",
+               row1[0], row1[1], row1[2], row1[3]);
+    }
+
+    /* ---- Sprint 6: 2D string column CTYPE1 [4 rows x 8 chars] ---- */
+    {
+        char ctype1[4][8];
+        int ctype1_varid;
+        size_t s[2] = {0, 0};
+        size_t c[2] = {4, 8};
+
+        if ((retval = nc_inq_varid(grpid, "CTYPE1", &ctype1_varid)))
+            ERR(retval);
+        if ((retval = nc_get_vara_text(grpid, ctype1_varid, s, c, &ctype1[0][0])))
+            ERR(retval);
+        /* All 4 rows should be "RA---TAN" */
+        if (strncmp(ctype1[0], "RA---TAN", 8) != 0)
+        { fprintf(stderr, "CTYPE1[0]: expected 'RA---TAN', got '%.8s'\n", ctype1[0]); return 1; }
+        printf("PASS: CTYPE1[0] = '%.8s'\n", ctype1[0]);
+    }
+
     if ((retval = nc_close(root_ncid)))
         ERR(retval);
     printf("PASS: nc_close\n");


### PR DESCRIPTION
- Add FITS reader section to README.md with format overview, current features, usage example, and build configuration
- Add FITS to format list in docs/mainpage.md
- Update src/fitsfile.c @file block to reflect fully implemented state
- Add Sprint 6 plan to docs/roadmap.md detailing documentation and test additions
- Add test coverage to test/tst_fits_udf.c: second image plane read, non-zero-start hyperslab, 2D string column read