### PR TITLE
Add Zstandard compression support to compression.c example with head-…

### DIFF
--- a/.github/workflows/ci-fits.yml
+++ b/.github/workflows/ci-fits.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install base dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake make wget zlib1g-dev autoconf automake libtool pkg-config libcfitsio-dev gfortran
+          sudo apt-get install -y cmake make wget zlib1g-dev autoconf automake libtool pkg-config libcfitsio-dev gfortran libzstd-dev
 
       - name: Cache HDF5 install
         id: cache-hdf5-fits
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-c-install
-          key: netcdf-c-main-fits-${{ runner.os }}-1
+          key: netcdf-c-main-fits-${{ runner.os }}-2
 
       - name: Clone and build NetCDF-C (main branch)
         if: steps.cache-netcdf-c-fits.outputs.cache-hit != 'true'
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-fortran-install
-          key: netcdf-fortran-main-fits-${{ runner.os }}-1
+          key: netcdf-fortran-main-fits-${{ runner.os }}-2
 
       - name: Clone and build NetCDF-Fortran (main branch)
         if: steps.cache-netcdf-fortran-fits.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-parallel.yml
+++ b/.github/workflows/ci-parallel.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install base dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake make wget zlib1g-dev autoconf automake libtool pkg-config
+          sudo apt-get install -y cmake make wget zlib1g-dev autoconf automake libtool pkg-config libzstd-dev
 
       - name: Install OpenMPI
         run: |
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-c-install
-          key: netcdf-c-4.10.0-parallel-openmpi-${{ runner.os }}-3
+          key: netcdf-c-4.10.0-parallel-openmpi-${{ runner.os }}-4
 
       - name: Download and build NetCDF-C (parallel)
         if: steps.cache-netcdf-c.outputs.cache-hit != 'true'
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-fortran-install
-          key: netcdf-fortran-4.6.2-parallel-openmpi-${{ runner.os }}-1
+          key: netcdf-fortran-4.6.2-parallel-openmpi-${{ runner.os }}-2
 
       - name: Download and build NetCDF-Fortran (parallel)
         if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-parallel.yml
+++ b/.github/workflows/ci-parallel.yml
@@ -109,14 +109,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-fortran-install
-          key: netcdf-fortran-4.5.4-parallel-openmpi-${{ runner.os }}-3
+          key: netcdf-fortran-4.6.2-parallel-openmpi-${{ runner.os }}-1
 
       - name: Download and build NetCDF-Fortran (parallel)
         if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/Unidata/netcdf-fortran/archive/v4.5.4.tar.gz &> /dev/null
-          tar -xzf v4.5.4.tar.gz
-          cd netcdf-fortran-4.5.4
+          wget https://github.com/Unidata/netcdf-fortran/archive/v4.6.2.tar.gz &> /dev/null
+          tar -xzf v4.6.2.tar.gz
+          cd netcdf-fortran-4.6.2
           export PATH="$GITHUB_WORKSPACE/hdf5-install/bin:$GITHUB_WORKSPACE/netcdf-c-install/bin:$PATH"
           export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include"
           export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
 
       - name: Install base dependencies
         run: |
-          sudo apt-get install -y cmake make wget zlib1g-dev libjpeg-dev liblz4-dev libbz2-dev liblzf-dev
+          sudo apt-get install -y cmake make wget zlib1g-dev libjpeg-dev liblz4-dev libbz2-dev liblzf-dev libzstd-dev
 
       - name: Install documentation dependencies
         if: matrix.fortran == 'on' && matrix.compression == 'all'
@@ -409,7 +409,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-c-install
-          key: netcdf-c-4.10.0-${{ runner.os }}-2
+          key: netcdf-c-4.10.0-${{ runner.os }}-3
 
       - name: Download and build NetCDF-C
         if: steps.cache-netcdf-c.outputs.cache-hit != 'true'
@@ -452,7 +452,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-fortran-install
-          key: netcdf-fortran-4.6.2-${{ runner.os }}-1
+          key: netcdf-fortran-4.6.2-${{ runner.os }}-2
 
       - name: Download and build NetCDF-Fortran
         if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,14 +452,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/netcdf-fortran-install
-          key: netcdf-fortran-4.5.4-${{ runner.os }}-1
+          key: netcdf-fortran-4.6.2-${{ runner.os }}-1
 
       - name: Download and build NetCDF-Fortran
         if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/Unidata/netcdf-fortran/archive/v4.5.4.tar.gz &> /dev/null
-          tar -xzf v4.5.4.tar.gz
-          cd netcdf-fortran-4.5.4
+          wget https://github.com/Unidata/netcdf-fortran/archive/v4.6.2.tar.gz &> /dev/null
+          tar -xzf v4.6.2.tar.gz
+          cd netcdf-fortran-4.6.2
           export PATH="$GITHUB_WORKSPACE/hdf5-install/bin:$GITHUB_WORKSPACE/netcdf-c-install/bin:$PATH"
           export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include"
           export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 b/
 build/
 build_*/
+build-fortran/
 build_test/
 */build/
 */*/build/

--- a/docs/plan/v1.9.0-sprint1-mpi-ci.md
+++ b/docs/plan/v1.9.0-sprint1-mpi-ci.md
@@ -44,7 +44,7 @@ New file. Does **not** modify `ci.yml`.
 **Cached dependencies** (parallel-specific cache keys, separate from `ci.yml`):
 - HDF5 2.0.0 → `hdf5-install`, key `hdf5-2.0.0-parallel-{mpi}-${{ runner.os }}-1`
 - NetCDF-C 4.10.0 → `netcdf-c-install`, key `netcdf-c-4.10.0-parallel-{mpi}-${{ runner.os }}-1`
-- NetCDF-Fortran 4.5.4 → `netcdf-fortran-install`, key `netcdf-fortran-4.5.4-parallel-{mpi}-${{ runner.os }}-1`
+- NetCDF-Fortran 4.6.2 → `netcdf-fortran-install`, key `netcdf-fortran-4.6.2-parallel-{mpi}-${{ runner.os }}-1`
 
 Cache keys are keyed per MPI implementation since openmpi and mpich produce incompatible builds.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -500,7 +500,7 @@ Parallel I/O builds are tested in a separate CI workflow (`ci-parallel.yml`) wit
 ### 13.2 Optional Dependencies
 - LZ4 library (for LZ4 compression)
 - BZIP2 library (for BZIP2 compression)
-- NetCDF-Fortran v4.5.4+ (for Fortran wrappers)
+- NetCDF-Fortran v4.6.2+ (for Fortran wrappers; zstd API requires 4.6.0+)
 - NASA CDF Library v3.9.x (for CDF support)
 - libgeotiff (for GeoTIFF support)
 - libtiff (transitive, for GeoTIFF support)

--- a/docs/prfaq.md
+++ b/docs/prfaq.md
@@ -143,7 +143,7 @@ All features integrate seamlessly with the standard NetCDF API.
 - **Operating System**: Linux or Unix
 - **Core Libraries**: NetCDF-C (v4.9+), HDF5 (v1.12+)
 - **Compression (optional)**: LZ4, BZIP2
-- **Fortran Support (optional)**: NetCDF-Fortran (v4.5.4+)
+- **Fortran Support (optional)**: NetCDF-Fortran (v4.6.2+; zstd API requires 4.6.0+)
 - **CDF Support (optional)**: NASA CDF Library (v3.9.x)
 - **GeoTIFF Support (optional)**: libgeotiff, libtiff
 - **GRIB2 Support (optional)**: NOAA NCEPLIBS-g2c (≥ 2.1.0), libjasper (≥ 3.0.0)

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -127,7 +127,7 @@ NEP v1.1.0 adds Fortran 90 wrappers for the existing compression filters introdu
 No new external dependencies compared to v1.0.0. This release reuses the existing stack:
 
 - NetCDF-C (v4.9+)
-- NetCDF-Fortran (v4.5.4+)
+- NetCDF-Fortran (v4.6.2+; zstd API requires 4.6.0+)
 - HDF5 (v1.14.6 used in CI)
 - LZ4, BZIP2, and LZF libraries
 

--- a/examples/f_netcdf-4/f_compression.f90
+++ b/examples/f_netcdf-4/f_compression.f90
@@ -70,6 +70,7 @@ program f_compression
    integer :: i, t, lat, lon
    real :: base_temp, seasonal, spatial
    real, parameter :: PI = 3.14159265359
+   logical :: zstd_available
    
    print *, "Compression Filter Demonstration"
    print *, "================================="
@@ -173,8 +174,15 @@ program f_compression
    deflate_levels(11) = 0
    zstd_levels(11) = 9
    
+   ! Probe for runtime Zstandard support
+   zstd_available = check_zstd_support()
+   if (.not. zstd_available) then
+      print *, "Note: Zstandard not available at runtime (skipping zstd tests)"
+   end if
+
    ! Run all tests
    do i = 1, NUM_TESTS
+      if (zstd_levels(i) >= 0 .and. .not. zstd_available) cycle
       call create_compressed_file( &
            trim(test_names(i)), &
            trim(filenames(i)), &
@@ -208,6 +216,7 @@ program f_compression
         "--------", "---------", "-----"
    
    do i = 1, NUM_TESTS
+      if (zstd_levels(i) >= 0 .and. .not. zstd_available) cycle
       print '(A35, F12.3, F12.3, F12.2, F9.2, A1)', &
          trim(test_names(i)), write_times(i), read_times(i), &
          real(file_sizes(i), 8) / 1048576.0_8, compression_ratios(i), "x"
@@ -219,6 +228,7 @@ program f_compression
      best_zlib = -1
      best_zstd = -1
      do i = 1, NUM_TESTS
+        if (zstd_levels(i) >= 0 .and. .not. zstd_available) cycle
         if (deflate_flags(i) == 1) then
            if (best_zlib == -1 .or. compression_ratios(i) > compression_ratios(best_zlib)) then
               best_zlib = i
@@ -260,9 +270,11 @@ program f_compression
    print *, "- Deflate level 1: PREFERRED zlib setting for almost all real-world data"
    print *, "- Deflate level 5: Marginally better ratio, significantly slower"
    print *, "- Deflate level 9: Maximum zlib compression, much slower"
-   print *, "- Zstandard level 3: Better ratio than zlib level 1, often faster writes"
-   print *, "- Zstandard level 9: Best zstd ratio; compare against zlib level 9 for archival"
-   print *, "- Shuffle + Zstandard 3: Strong speed/ratio tradeoff for scientific data"
+   if (zstd_available) then
+      print *, "- Zstandard level 3: Better ratio than zlib level 1, often faster writes"
+      print *, "- Zstandard level 9: Best zstd ratio; compare against zlib level 9 for archival"
+      print *, "- Shuffle + Zstandard 3: Strong speed/ratio tradeoff for scientific data"
+   end if
    print *, "- Shuffle + Deflate 1: RECOMMENDED default for universal compatibility"
    print *, "- Level 1 gives nearly the same compression as higher levels"
    print *, "- Higher levels cost much more CPU time for diminishing returns"
@@ -274,6 +286,23 @@ program f_compression
    print *, "*** SUCCESS: All compression strategies tested!"
    
 contains
+
+   function check_zstd_support() result(zstd_available)
+      logical :: zstd_available
+      integer :: ncid, varid, dimid, retval, zstd_ret
+
+      zstd_available = .false.
+      retval = nf90_create("zstd_probe.nc", NF90_CLOBBER + NF90_NETCDF4, ncid)
+      if (retval /= nf90_noerr) return
+
+      retval = nf90_def_dim(ncid, "x", 1, dimid)
+      if (retval == nf90_noerr) retval = nf90_def_var(ncid, "v", NF90_FLOAT, (/dimid/), varid)
+      zstd_ret = nf90_def_var_zstandard(ncid, varid, 3)
+
+      retval = nf90_close(ncid)
+      call system("rm -f zstd_probe.nc")
+      zstd_available = (retval == nf90_noerr .and. zstd_ret == nf90_noerr)
+   end function check_zstd_support
 
    subroutine create_compressed_file( &
         test_name, filename, &

--- a/examples/f_netcdf-4/f_compression.f90
+++ b/examples/f_netcdf-4/f_compression.f90
@@ -8,7 +8,7 @@
 !! performance.
 !!
 !! **Learning Objectives:**
-!! - Configure compression with nf90_def_var_deflate() in Fortran
+!! - Configure compression with nf90_def_var_deflate() and nf90_def_var_zstandard() in Fortran
 !! - Measure compression performance in Fortran applications
 !! - Select appropriate compression levels for different data
 !! - Set fill values with nf90_def_var_fill() for chunked/compressed variables
@@ -16,10 +16,11 @@
 !!
 !! **Fortran Compression Functions:**
 !! - nf90_def_var_deflate(ncid, varid, shuffle, deflate, deflate_level)
-!! - shuffle: 0=off, 1=on
-!! - deflate: 0=off, 1=on
-!! - deflate_level: 1-9 (higher=better compression, slower)
-!! - For almost all real-world data, level 1 is the preferred value.
+!!   - shuffle: 0=off, 1=on; deflate: 0=off, 1=on; deflate_level: 1-9
+!! - nf90_def_var_zstandard(ncid, varid, level)
+!!   - level: 1-22 (higher=better compression, slower)
+!! - For almost all real-world data, zlib level 1 is the preferred deflate value.
+!!   Zstandard level 3 is the best Zstandard tradeoff for most data.
 !!   Higher levels yield diminishing returns at much greater CPU cost.
 !!
 !! **Fortran Fill Value Functions:**
@@ -53,7 +54,7 @@ program f_compression
    integer, parameter :: NLAT = 90
    integer, parameter :: NLON = 180
    integer, parameter :: NDIMS = 3
-   integer, parameter :: NUM_TESTS = 6
+   integer, parameter :: NUM_TESTS = 11
    real, parameter :: FILL_VALUE = -9999.0
    
    real, allocatable :: data(:,:,:)
@@ -65,6 +66,7 @@ program f_compression
    integer :: shuffle_flags(NUM_TESTS)
    integer :: deflate_flags(NUM_TESTS)
    integer :: deflate_levels(NUM_TESTS)
+   integer :: zstd_levels(NUM_TESTS)
    integer :: i, t, lat, lon
    real :: base_temp, seasonal, spatial
    real, parameter :: PI = 3.14159265359
@@ -99,36 +101,77 @@ program f_compression
    shuffle_flags(1) = 0
    deflate_flags(1) = 0
    deflate_levels(1) = 0
+   zstd_levels(1) = -1
    
    test_names(2) = "Shuffle only"
    filenames(2) = "f_compress_shuffle.nc"
    shuffle_flags(2) = 1
    deflate_flags(2) = 0
    deflate_levels(2) = 0
+   zstd_levels(2) = -1
    
    test_names(3) = "Deflate level 1 (preferred)"
    filenames(3) = "f_compress_deflate1.nc"
    shuffle_flags(3) = 0
    deflate_flags(3) = 1
    deflate_levels(3) = 1
+   zstd_levels(3) = -1
    
    test_names(4) = "Deflate level 5"
    filenames(4) = "f_compress_deflate5.nc"
    shuffle_flags(4) = 0
    deflate_flags(4) = 1
    deflate_levels(4) = 5
+   zstd_levels(4) = -1
    
    test_names(5) = "Deflate level 9"
    filenames(5) = "f_compress_deflate9.nc"
    shuffle_flags(5) = 0
    deflate_flags(5) = 1
    deflate_levels(5) = 9
+   zstd_levels(5) = -1
    
    test_names(6) = "Shuffle + Deflate 1 (recommended)"
    filenames(6) = "f_compress_shuffle_deflate1.nc"
    shuffle_flags(6) = 1
    deflate_flags(6) = 1
    deflate_levels(6) = 1
+   zstd_levels(6) = -1
+   
+   test_names(7) = "Zstandard level 1"
+   filenames(7) = "f_compress_zstd1.nc"
+   shuffle_flags(7) = 0
+   deflate_flags(7) = 0
+   deflate_levels(7) = 0
+   zstd_levels(7) = 1
+   
+   test_names(8) = "Zstandard level 3"
+   filenames(8) = "f_compress_zstd3.nc"
+   shuffle_flags(8) = 0
+   deflate_flags(8) = 0
+   deflate_levels(8) = 0
+   zstd_levels(8) = 3
+   
+   test_names(9) = "Zstandard level 9"
+   filenames(9) = "f_compress_zstd9.nc"
+   shuffle_flags(9) = 0
+   deflate_flags(9) = 0
+   deflate_levels(9) = 0
+   zstd_levels(9) = 9
+   
+   test_names(10) = "Shuffle + Zstandard 3"
+   filenames(10) = "f_compress_shuffle_zstd3.nc"
+   shuffle_flags(10) = 1
+   deflate_flags(10) = 0
+   deflate_levels(10) = 0
+   zstd_levels(10) = 3
+   
+   test_names(11) = "Shuffle + Zstandard 9"
+   filenames(11) = "f_compress_shuffle_zstd9.nc"
+   shuffle_flags(11) = 1
+   deflate_flags(11) = 0
+   deflate_levels(11) = 0
+   zstd_levels(11) = 9
    
    ! Run all tests
    do i = 1, NUM_TESTS
@@ -138,12 +181,14 @@ program f_compression
            shuffle_flags(i), &
            deflate_flags(i), &
            deflate_levels(i), &
+           zstd_levels(i), &
            data, write_times(i), file_sizes(i))
       call read_compressed_file( &
            trim(filenames(i)), &
            shuffle_flags(i), &
            deflate_flags(i), &
-           deflate_levels(i), data, &
+           deflate_levels(i), &
+           zstd_levels(i), data, &
            read_times(i))
    end do
    
@@ -168,17 +213,57 @@ program f_compression
          real(file_sizes(i), 8) / 1048576.0_8, compression_ratios(i), "x"
    end do
    
+   ! Find best zlib and best zstd by compression ratio
+   block
+     integer :: best_zlib, best_zstd
+     best_zlib = -1
+     best_zstd = -1
+     do i = 1, NUM_TESTS
+        if (deflate_flags(i) == 1) then
+           if (best_zlib == -1 .or. compression_ratios(i) > compression_ratios(best_zlib)) then
+              best_zlib = i
+           end if
+        end if
+        if (zstd_levels(i) >= 0) then
+           if (best_zstd == -1 .or. compression_ratios(i) > compression_ratios(best_zstd)) then
+              best_zstd = i
+           end if
+        end if
+     end do
+
+     print *, ""
+     print *, "=== Best Ratio Head-to-Head ==="
+     print '(A35, A12, A12, A12, A10)', &
+          "Strategy", "Write (s)", &
+          "Read (s)", "Size (MB)", "Ratio"
+     print '(A35, A12, A12, A12, A10)', &
+          "--------", "---------", &
+          "--------", "---------", "-----"
+     if (best_zlib > 0) then
+        print '(A35, F12.3, F12.3, F12.2, F9.2, A1)', &
+             trim(test_names(best_zlib)), write_times(best_zlib), read_times(best_zlib), &
+             real(file_sizes(best_zlib), 8) / 1048576.0_8, compression_ratios(best_zlib), "x"
+     end if
+     if (best_zstd > 0) then
+        print '(A35, F12.3, F12.3, F12.2, F9.2, A1)', &
+             trim(test_names(best_zstd)), write_times(best_zstd), read_times(best_zstd), &
+             real(file_sizes(best_zstd), 8) / 1048576.0_8, compression_ratios(best_zstd), "x"
+     end if
+   end block
+
    ! Print recommendations
    print *, ""
    print *, "=== Recommendations ==="
    print *, "- Uncompressed: Fastest I/O but largest files"
    print *, "- Shuffle only: Reorganizes", &
-        " bytes for better compression"
-   print *, "- Deflate level 1: PREFERRED for almost all real-world data"
+        " bytes for better compression (use with deflate or zstd)"
+   print *, "- Deflate level 1: PREFERRED zlib setting for almost all real-world data"
    print *, "- Deflate level 5: Marginally better ratio, significantly slower"
-   print *, "- Deflate level 9: Maximum", &
-        " compression, much slower"
-   print *, "- Shuffle + Deflate 1: RECOMMENDED default for scientific data"
+   print *, "- Deflate level 9: Maximum zlib compression, much slower"
+   print *, "- Zstandard level 3: Better ratio than zlib level 1, often faster writes"
+   print *, "- Zstandard level 9: Best zstd ratio; compare against zlib level 9 for archival"
+   print *, "- Shuffle + Zstandard 3: Strong speed/ratio tradeoff for scientific data"
+   print *, "- Shuffle + Deflate 1: RECOMMENDED default for universal compatibility"
    print *, "- Level 1 gives nearly the same compression as higher levels"
    print *, "- Higher levels cost much more CPU time for diminishing returns"
    print *, "- Read performance generally similar across compression levels"
@@ -193,9 +278,9 @@ contains
    subroutine create_compressed_file( &
         test_name, filename, &
         shuffle, deflate, deflate_level, &
-                                     data, write_time, file_size)
+        zstd_level, data, write_time, file_size)
       character(len=*), intent(in) :: test_name, filename
-      integer, intent(in) :: shuffle, deflate, deflate_level
+      integer, intent(in) :: shuffle, deflate, deflate_level, zstd_level
       real, intent(in) :: data(:,:,:)
       real(8), intent(out) :: write_time
       integer(int64), intent(out) :: file_size
@@ -207,6 +292,7 @@ contains
       integer(int64) :: start_count, end_count, count_rate
       logical :: file_exists
       integer :: start_idx(NDIMS), count_idx(NDIMS)
+      integer :: chunksizes(NDIMS)
 
       print *, ""
       print *, "=== ", trim(test_name), " ==="
@@ -228,8 +314,20 @@ contains
       dimids(3) = time_dimid
       retval = nf90_def_var(ncid, "temperature", NF90_FLOAT, dimids, varid)
       if (retval /= nf90_noerr) call handle_err(retval)
+
+      ! Set consistent chunking for all compression tests
+      chunksizes = (/ 90, 45, 10 /)
+      retval = nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, chunksizes)
+      if (retval /= nf90_noerr) call handle_err(retval)
       
-      if (deflate == 1 .or. shuffle == 1) then
+      if (zstd_level >= 0) then
+         if (shuffle == 1) then
+            retval = nf90_def_var_deflate(ncid, varid, 1, 0, 0)
+            if (retval /= nf90_noerr) call handle_err(retval)
+         end if
+         retval = nf90_def_var_zstandard(ncid, varid, zstd_level)
+         if (retval /= nf90_noerr) call handle_err(retval)
+      else if (deflate == 1 .or. shuffle == 1) then
          retval = nf90_def_var_deflate(ncid, &
               varid, shuffle, deflate, &
               deflate_level)
@@ -276,14 +374,15 @@ contains
       
       if (shuffle == 1) print *, "Shuffle: enabled"
       if (deflate == 1) print *, "Deflate: level ", deflate_level
+      if (zstd_level >= 0) print *, "Zstandard: level ", zstd_level
       
    end subroutine create_compressed_file
    
    subroutine read_compressed_file(filename, &
         expected_shuffle, expected_deflate, &
-        expected_level, original_data, read_time)
+        expected_level, expected_zstd, original_data, read_time)
       character(len=*), intent(in) :: filename
-      integer, intent(in) :: expected_shuffle, expected_deflate, expected_level
+      integer, intent(in) :: expected_shuffle, expected_deflate, expected_level, expected_zstd
       real, intent(in) :: original_data(:,:,:)
       real(8), intent(out) :: read_time
       
@@ -292,6 +391,7 @@ contains
       integer(int64) :: start_count, end_count, count_rate
       real, allocatable :: data(:,:,:)
       integer :: shuffle, deflate, deflate_level
+      integer :: zstd, zstd_level
       integer :: errors, i
       integer :: no_fill
       real :: fill_value_in
@@ -306,15 +406,23 @@ contains
       retval = nf90_inq_varid(ncid, "temperature", varid)
       if (retval /= nf90_noerr) call handle_err(retval)
       
-      retval = nf90_inq_var_deflate(ncid, &
-           varid, shuffle, deflate, &
-           deflate_level)
-      if (retval /= nf90_noerr) call handle_err(retval)
-      
-      if (shuffle /= expected_shuffle .or. deflate /= expected_deflate .or. &
-          (deflate == 1 .and. deflate_level /= expected_level)) then
-         print *, "Error: Compression settings mismatch"
-         stop 2
+      if (expected_zstd >= 0) then
+         retval = nf90_inq_var_zstandard(ncid, varid, zstd, zstd_level)
+         if (retval /= nf90_noerr) call handle_err(retval)
+         if (zstd /= 1 .or. zstd_level /= expected_zstd) then
+            print *, "Error: Zstandard settings mismatch"
+            stop 2
+         end if
+      else
+         retval = nf90_inq_var_deflate(ncid, &
+              varid, shuffle, deflate, &
+              deflate_level)
+         if (retval /= nf90_noerr) call handle_err(retval)
+         if (shuffle /= expected_shuffle .or. deflate /= expected_deflate .or. &
+             (deflate == 1 .and. deflate_level /= expected_level)) then
+            print *, "Error: Compression settings mismatch"
+            stop 2
+         end if
       end if
       
       ! Verify fill value using nf90_inq_var_fill()

--- a/examples/netcdf-4/compression.c
+++ b/examples/netcdf-4/compression.c
@@ -330,6 +330,29 @@ void read_compressed_file(CompressionTest *test, float *original_data) {
     free(data);
 }
 
+/* Check whether Zstandard is available at runtime by attempting to create
+ * a tiny file with the zstd filter applied. */
+int check_zstd_support(void) {
+    int ncid, varid, dimid;
+    int retval;
+    int supported = 0;
+
+    if ((retval = nc_create("zstd_probe.nc", NC_CLOBBER|NC_NETCDF4, &ncid)))
+        return 0;
+
+    if ((retval = nc_def_dim(ncid, "x", 1, &dimid)) == NC_NOERR &&
+        (retval = nc_def_var(ncid, "v", NC_FLOAT, 1, &dimid, &varid)) == NC_NOERR)
+        retval = nc_def_var_zstandard(ncid, varid, 3);
+
+    nc_close(ncid);
+    remove("zstd_probe.nc");
+
+    supported = (retval == NC_NOERR);
+    if (!supported)
+        printf("Note: Zstandard not available at runtime (skipping zstd tests)\n");
+    return supported;
+}
+
 int main() {
     printf("Compression Filter Demonstration\n");
     printf("=================================\n");
@@ -345,6 +368,9 @@ int main() {
         return ERRCODE;
     }
     generate_temperature_data(data);
+
+    /* Probe for runtime Zstandard support */
+    int zstd_available = check_zstd_support();
     
     /* Define compression tests */
     CompressionTest tests[] = {
@@ -362,8 +388,10 @@ int main() {
     };
     int num_tests = sizeof(tests) / sizeof(tests[0]);
     
-    /* Run all tests */
+    /* Run all tests, skipping zstd cases if the filter is unavailable */
     for (int i = 0; i < num_tests; i++) {
+        if (tests[i].zstd_level >= 0 && !zstd_available)
+            continue;
         create_compressed_file(&tests[i], data);
         read_compressed_file(&tests[i], data);
     }
@@ -382,6 +410,8 @@ int main() {
            "--------", "---------", "--------", "---------", "-----");
     
     for (int i = 0; i < num_tests; i++) {
+        if (tests[i].zstd_level >= 0 && !zstd_available)
+            continue;
         printf("%-35s %12.3f %12.3f %12.2f %10.2fx\n",
                tests[i].name,
                tests[i].write_time,
@@ -393,6 +423,8 @@ int main() {
     /* Find best zlib and best zstd by compression ratio */
     int best_zlib = -1, best_zstd = -1;
     for (int i = 0; i < num_tests; i++) {
+        if (tests[i].zstd_level >= 0 && !zstd_available)
+            continue;
         if (tests[i].deflate &&
             (best_zlib == -1 || tests[i].compression_ratio > tests[best_zlib].compression_ratio))
             best_zlib = i;
@@ -431,9 +463,11 @@ int main() {
     printf("- Deflate level 1: PREFERRED zlib setting for almost all real-world data\n");
     printf("- Deflate level 5: Marginally better ratio, significantly slower\n");
     printf("- Deflate level 9: Maximum zlib compression, much slower, rarely worth it\n");
-    printf("- Zstandard level 3: Better ratio than zlib level 1, often faster writes\n");
-    printf("- Zstandard level 9: Best zstd ratio; compare against zlib level 9 for archival\n");
-    printf("- Shuffle + Zstandard 3: Strong speed/ratio tradeoff for scientific data\n");
+    if (zstd_available) {
+        printf("- Zstandard level 3: Better ratio than zlib level 1, often faster writes\n");
+        printf("- Zstandard level 9: Best zstd ratio; compare against zlib level 9 for archival\n");
+        printf("- Shuffle + Zstandard 3: Strong speed/ratio tradeoff for scientific data\n");
+    }
     printf("- Shuffle + Deflate 1: RECOMMENDED default for universal compatibility\n");
     printf("- Level 1 gives nearly the same compression as higher levels for most data\n");
     printf("- Higher levels cost much more CPU time for diminishing returns\n");

--- a/examples/netcdf-4/compression.c
+++ b/examples/netcdf-4/compression.c
@@ -8,23 +8,25 @@
  * I/O bandwidth for large scientific datasets.
  *
  * The program generates realistic 3D temperature data (time×lat×lon) and creates
- * files with various compression configurations: no compression, deflate only,
- * shuffle only, and shuffle+deflate combinations at different compression levels.
- * It measures write/read times, file sizes, and compression ratios.
+ * files with various compression configurations: no compression, deflate (zlib)
+ * only, Zstandard (zstd) only, shuffle only, and shuffle+deflate or shuffle+zstd
+ * combinations at different compression levels. It measures write/read times,
+ * file sizes, and compression ratios.
  *
  * **Learning Objectives:**
- * - Understand NetCDF-4 compression filters (deflate, shuffle)
- * - Learn to configure compression with nc_def_var_deflate() and nc_def_var_shuffle()
- * - Master compression level selection (1-9 tradeoff between speed and ratio)
+ * - Understand NetCDF-4 compression filters (deflate, shuffle, Zstandard)
+ * - Learn to configure compression with nc_def_var_deflate() and nc_def_var_zstandard()
+ * - Master compression level selection (zlib 1-9, zstd 1-22 tradeoff)
  * - Measure compression performance (time, size, ratio)
  * - Make informed compression decisions for different data types
  *
  * **Key Concepts:**
  * - **Deflate Filter**: GZIP compression (levels 1-9, higher = better compression)
+ * - **Zstandard Filter**: Modern zstd compression (levels 1-22, wider speed/ratio range)
  * - **Shuffle Filter**: Byte reordering to improve compression of typed data
  * - **Compression Ratio**: Original size / compressed size
  * - **Compression Overhead**: Extra CPU time for compression/decompression
- * - **Filter Pipeline**: Shuffle then deflate for optimal results
+ * - **Filter Pipeline**: Shuffle then deflate or shuffle then zstd for optimal results
  * - **Level 1 is best**: For almost all real-world scientific data, deflate
  *   level 1 provides nearly the same compression ratio as higher levels but
  *   at a fraction of the CPU cost. Higher levels yield diminishing returns.
@@ -65,12 +67,15 @@
  *
  * **Expected Output:**
  * Creates multiple files with compression analysis:
- * - compression_none.nc (uncompressed baseline)
- * - compression_deflate_N.nc (deflate levels 1, 5, 9)
- * - compression_shuffle.nc (shuffle only)
- * - compression_shuffle_deflate_N.nc (combined, levels 1, 5, 9)
- * Note: Level 1 is the preferred deflate level for almost all real-world data.
- * Displays performance comparison table with times, sizes, and ratios.
+ * - compress_none.nc (uncompressed baseline)
+ * - compress_deflate_N.nc (deflate levels 1, 5, 9)
+ * - compress_shuffle.nc (shuffle only)
+ * - compress_shuffle_deflate1.nc (combined, level 1)
+ * - compress_zstd_N.nc (zstd levels 1, 3, 9)
+ * - compress_shuffle_zstd_N.nc (combined, levels 3, 9)
+ * Note: Level 1 is the preferred deflate level; zstd level 3 is the best
+ * Zstandard tradeoff for most real-world data.
+ * Displays performance comparison table and a best zlib vs best zstd head-to-head.
  *
  * @author Edward Hartnett, Intelligent Data Design, Inc.
  * @date 2026
@@ -82,6 +87,7 @@
 #include <time.h>
 #include <math.h>
 #include <netcdf.h>
+#include <netcdf_filter.h>
 
 #define NTIME 50
 #define NLAT 90
@@ -97,6 +103,7 @@ typedef struct {
     int shuffle;
     int deflate;
     int deflate_level;
+    int zstd_level;
     double write_time;
     double read_time;
     long file_size;
@@ -143,6 +150,7 @@ void create_compressed_file(CompressionTest *test, float *data) {
     int dimids[NDIMS];
     int retval;
     struct timespec start, end;
+    size_t chunksizes[NDIMS] = {10, 45, 90};
     
     printf("\n=== %s ===\n", test->name);
     
@@ -168,16 +176,26 @@ void create_compressed_file(CompressionTest *test, float *data) {
     if ((retval = nc_def_var(ncid, "temperature", NC_FLOAT, NDIMS, dimids, &varid)))
         ERR(retval);
     
+    if ((retval = nc_def_var_chunking(ncid, varid, NC_CHUNKED, chunksizes)))
+        ERR(retval);
+
     /* Set fill value: nc_def_var_fill() registers the sentinel returned for unwritten
      * chunks. In chunked/compressed variables, unwritten chunks are stored as fill
      * value data, making fill value part of the chunk metadata. */
     float fill_value = FILL_VALUE;
     if ((retval = nc_def_var_fill(ncid, varid, NC_FILL, &fill_value)))
         ERR(retval);
-    
+
     /* Set compression */
-    if (test->deflate || test->shuffle) {
-        if ((retval = nc_def_var_deflate(ncid, varid, test->shuffle, 
+    if (test->zstd_level >= 0) {
+        if (test->shuffle) {
+            if ((retval = nc_def_var_deflate(ncid, varid, 1, 0, 0)))
+                ERR(retval);
+        }
+        if ((retval = nc_def_var_zstandard(ncid, varid, test->zstd_level)))
+            ERR(retval);
+    } else if (test->deflate || test->shuffle) {
+        if ((retval = nc_def_var_deflate(ncid, varid, test->shuffle,
                                          test->deflate, test->deflate_level)))
             ERR(retval);
     }
@@ -212,6 +230,7 @@ void create_compressed_file(CompressionTest *test, float *data) {
     
     if (test->shuffle) printf("Shuffle: enabled\n");
     if (test->deflate) printf("Deflate: level %d\n", test->deflate_level);
+    if (test->zstd_level >= 0) printf("Zstandard: level %d\n", test->zstd_level);
 }
 
 /* Read and validate compressed file */
@@ -239,13 +258,22 @@ void read_compressed_file(CompressionTest *test, float *original_data) {
         ERR(retval);
     
     /* Verify compression settings */
-    if ((retval = nc_inq_var_deflate(ncid, varid, &shuffle, &deflate, &deflate_level)))
-        ERR(retval);
-    
-    if (shuffle != test->shuffle || deflate != test->deflate || 
-        (deflate && deflate_level != test->deflate_level)) {
-        printf("Error: Compression settings mismatch\n");
-        exit(ERRCODE);
+    if (test->zstd_level >= 0) {
+        int zstd_out, zstd_level_out;
+        if ((retval = nc_inq_var_zstandard(ncid, varid, &zstd_out, &zstd_level_out)))
+            ERR(retval);
+        if (!zstd_out || zstd_level_out != test->zstd_level) {
+            printf("Error: Zstandard settings mismatch\n");
+            exit(ERRCODE);
+        }
+    } else {
+        if ((retval = nc_inq_var_deflate(ncid, varid, &shuffle, &deflate, &deflate_level)))
+            ERR(retval);
+        if (shuffle != test->shuffle || deflate != test->deflate ||
+            (deflate && deflate_level != test->deflate_level)) {
+            printf("Error: Compression settings mismatch\n");
+            exit(ERRCODE);
+        }
     }
     
     /* Verify fill value using nc_inq_var_fill() */
@@ -320,12 +348,17 @@ int main() {
     
     /* Define compression tests */
     CompressionTest tests[] = {
-        {"Uncompressed (baseline)", "compress_none.nc", 0, 0, 0, 0, 0, 0, 0},
-        {"Shuffle only", "compress_shuffle.nc", 1, 0, 0, 0, 0, 0, 0},
-        {"Deflate level 1 (preferred)", "compress_deflate1.nc", 0, 1, 1, 0, 0, 0, 0},
-        {"Deflate level 5", "compress_deflate5.nc", 0, 1, 5, 0, 0, 0, 0},
-        {"Deflate level 9", "compress_deflate9.nc", 0, 1, 9, 0, 0, 0, 0},
-        {"Shuffle + Deflate 1 (recommended)", "compress_shuffle_deflate1.nc", 1, 1, 1, 0, 0, 0, 0}
+        {"Uncompressed (baseline)", "compress_none.nc", 0, 0, 0, -1, 0, 0, 0, 0},
+        {"Shuffle only", "compress_shuffle.nc", 1, 0, 0, -1, 0, 0, 0, 0},
+        {"Deflate level 1 (preferred)", "compress_deflate1.nc", 0, 1, 1, -1, 0, 0, 0, 0},
+        {"Deflate level 5", "compress_deflate5.nc", 0, 1, 5, -1, 0, 0, 0, 0},
+        {"Deflate level 9", "compress_deflate9.nc", 0, 1, 9, -1, 0, 0, 0, 0},
+        {"Shuffle + Deflate 1 (recommended)", "compress_shuffle_deflate1.nc", 1, 1, 1, -1, 0, 0, 0, 0},
+        {"Zstandard level 1", "compress_zstd1.nc", 0, 0, 0, 1, 0, 0, 0, 0},
+        {"Zstandard level 3", "compress_zstd3.nc", 0, 0, 0, 3, 0, 0, 0, 0},
+        {"Zstandard level 9", "compress_zstd9.nc", 0, 0, 0, 9, 0, 0, 0, 0},
+        {"Shuffle + Zstandard 3", "compress_shuffle_zstd3.nc", 1, 0, 0, 3, 0, 0, 0, 0},
+        {"Shuffle + Zstandard 9", "compress_shuffle_zstd9.nc", 1, 0, 0, 9, 0, 0, 0, 0}
     };
     int num_tests = sizeof(tests) / sizeof(tests[0]);
     
@@ -357,15 +390,52 @@ int main() {
                tests[i].compression_ratio);
     }
     
+    /* Find best zlib and best zstd by compression ratio */
+    int best_zlib = -1, best_zstd = -1;
+    for (int i = 0; i < num_tests; i++) {
+        if (tests[i].deflate &&
+            (best_zlib == -1 || tests[i].compression_ratio > tests[best_zlib].compression_ratio))
+            best_zlib = i;
+        if (tests[i].zstd_level >= 0 &&
+            (best_zstd == -1 || tests[i].compression_ratio > tests[best_zstd].compression_ratio))
+            best_zstd = i;
+    }
+
+    /* Print head-to-head comparison */
+    printf("\n=== Best Ratio Head-to-Head ===\n");
+    printf("%-35s %12s %12s %12s %10s\n",
+           "Strategy", "Write (s)", "Read (s)", "Size (MB)", "Ratio");
+    printf("%-35s %12s %12s %12s %10s\n",
+           "--------", "---------", "--------", "---------", "-----");
+    if (best_zlib >= 0) {
+        printf("%-35s %12.3f %12.3f %12.2f %10.2fx\n",
+               tests[best_zlib].name,
+               tests[best_zlib].write_time,
+               tests[best_zlib].read_time,
+               tests[best_zlib].file_size / 1048576.0,
+               tests[best_zlib].compression_ratio);
+    }
+    if (best_zstd >= 0) {
+        printf("%-35s %12.3f %12.3f %12.2f %10.2fx\n",
+               tests[best_zstd].name,
+               tests[best_zstd].write_time,
+               tests[best_zstd].read_time,
+               tests[best_zstd].file_size / 1048576.0,
+               tests[best_zstd].compression_ratio);
+    }
+
     /* Print recommendations */
     printf("\n=== Recommendations ===\n");
     printf("- Uncompressed: Fastest I/O but largest files\n");
-    printf("- Shuffle only: Reorganizes bytes for better compression (use with deflate)\n");
-    printf("- Deflate level 1: PREFERRED for almost all real-world data\n");
+    printf("- Shuffle only: Reorganizes bytes for better compression (use with deflate or zstd)\n");
+    printf("- Deflate level 1: PREFERRED zlib setting for almost all real-world data\n");
     printf("- Deflate level 5: Marginally better ratio, significantly slower\n");
-    printf("- Deflate level 9: Maximum compression, much slower, rarely worth it\n");
-    printf("- Shuffle + Deflate 1: RECOMMENDED default for scientific data\n");
-    printf("- Level 1 gives nearly the same compression as higher levels\n");
+    printf("- Deflate level 9: Maximum zlib compression, much slower, rarely worth it\n");
+    printf("- Zstandard level 3: Better ratio than zlib level 1, often faster writes\n");
+    printf("- Zstandard level 9: Best zstd ratio; compare against zlib level 9 for archival\n");
+    printf("- Shuffle + Zstandard 3: Strong speed/ratio tradeoff for scientific data\n");
+    printf("- Shuffle + Deflate 1: RECOMMENDED default for universal compatibility\n");
+    printf("- Level 1 gives nearly the same compression as higher levels for most data\n");
     printf("- Higher levels cost much more CPU time for diminishing returns\n");
     printf("- Read performance generally similar across compression levels\n");
     printf("- Compression effectiveness depends on data patterns\n");


### PR DESCRIPTION
…to-head comparison

- Add zstd_level field to CompressionTest struct
- Add netcdf_filter.h header for nc_def_var_zstandard() and nc_inq_var_zstandard()
- Add 5 Zstandard test cases: zstd levels 1, 3, 9 and shuffle+zstd levels 3, 9
- Add explicit chunking configuration (10×45×90) before compression setup
- Update compression setup to handle zstd via nc_def_var_zstandard()
- Update read validation to verify zstd settings with nc_inq_var_z