### PR TITLE
v2.2.0 Sprint 2: Reassign CDF to UDF4, remove CDF/GRIB2 mutual exclusivity (#245)

### DIFF
--- a/.devin/rules/local-build-command.md
+++ b/.devin/rules/local-build-command.md
@@ -66,8 +66,6 @@ make -j$(nproc) -C build && ctest --test-dir build
 finds the system HDF5 1.14.6 instead, which conflicts with NetCDF-C 4.10.0 (built
 against HDF5 2.1.0) and causes `NetCDF: HDF error` at runtime.
 
-**IMPORTANT**: `ENABLE_CDF` and `ENABLE_GRIB2` are mutually exclusive (both use
-UDF slot 2). Always set `-DENABLE_GRIB2=OFF` when `-DENABLE_CDF=ON`.
 
 **IMPORTANT**: If CMakeCache.txt has stale HDF5 entries, delete it before reconfiguring:
 ```bash

--- a/.devin/rules/pr-etiquette.md
+++ b/.devin/rules/pr-etiquette.md
@@ -1,0 +1,13 @@
+---
+trigger: model_decision
+---
+# PR and Commit Etiquette
+
+## Attribution footer
+
+Do NOT add any of the following to PR descriptions or commit messages:
+
+- `Generated with [Devin](https://devin.ai)`
+- `Co-Authored-By: Devin <158243242+devin-ai-integration[bot]@users.noreply.github.com>`
+
+Leave PR descriptions and commit messages clean — no Devin attribution footers.

--- a/.github/workflows/ci-formats.yml
+++ b/.github/workflows/ci-formats.yml
@@ -1,10 +1,10 @@
 # GitHub Actions CI workflow for testing NEP format readers together.
 #
-# V2.2.0 Sprint 1: Make Extended Data Formats Off by Default
+# V2.2.0 Sprint 2: Reassign UDF Slot for CDF
 #
-# This workflow builds NEP with format readers explicitly enabled. The
-# combined job tests GeoTIFF + GRIB2 + FITS together. CDF is tested in a
-# separate job because CDF and GRIB2 share UDF slot 2 in this sprint.
+# CDF has been moved to UDF4, so it is no longer mutually exclusive with
+# GRIB2. This workflow builds all four extended format readers together
+# (GeoTIFF + GRIB2 + FITS + CDF) for both CMake and Autotools.
 #
 # Edward Hartnett, Intelligent Data Design, Inc.
 name: ci_formats
@@ -17,7 +17,7 @@ on:
 
 jobs:
   formats-build:
-    name: Formats (${{ matrix.build_system }}, ${{ matrix.format_set }})
+    name: Formats (${{ matrix.build_system }}, all-formats)
     runs-on: ubuntu-latest
     env:
       LD_LIBRARY_PATH: ${{ github.workspace }}/hdf5-install/lib:${{ github.workspace }}/netcdf-c-install/lib:${{ github.workspace }}/netcdf-fortran-install/lib:${{ github.workspace }}/cdf-install/lib:${{ github.workspace }}/g2c-install/lib:${{ github.workspace }}/jasper-install/lib:$LD_LIBRARY_PATH
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         build_system: [cmake, autotools]
-        format_set: [combined, cdf-only]
 
     steps:
       - name: Checkout code
@@ -37,14 +36,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake make wget zlib1g-dev autoconf automake libtool pkg-config gfortran libzstd-dev
 
-      - name: Install format libraries (combined)
-        if: matrix.format_set == 'combined'
+      - name: Install format libraries (GeoTIFF, FITS)
         run: |
           sudo apt-get install -y libgeotiff-dev libtiff-dev libcfitsio-dev libpng-dev
 
-      # Cache NASA CDF install (v1.3.0+) - used by cdf-only job
+      # Cache NASA CDF install (v1.3.0+)
       - name: Cache NASA CDF install
-        if: matrix.format_set == 'cdf-only'
         id: cache-cdf
         uses: actions/cache@v4
         with:
@@ -52,7 +49,7 @@ jobs:
           key: cdf-3.9.1-${{ runner.os }}-1
 
       - name: Download and build NASA CDF library
-        if: matrix.format_set == 'cdf-only' && steps.cache-cdf.outputs.cache-hit != 'true'
+        if: steps.cache-cdf.outputs.cache-hit != 'true'
         run: |
           wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf39_1/cdf39_1-dist-cdf.tar.gz &> /dev/null
           tar -xzf cdf39_1-dist-cdf.tar.gz
@@ -123,9 +120,8 @@ jobs:
           make -j$(nproc)
           make install
 
-      # Cache Jasper install (combined only)
+      # Cache Jasper install
       - name: Cache Jasper install
-        if: matrix.format_set == 'combined'
         id: cache-jasper
         uses: actions/cache@v4
         with:
@@ -133,7 +129,7 @@ jobs:
           key: jasper-4.2.4-${{ runner.os }}-1
 
       - name: Download and build Jasper 4.2.4
-        if: matrix.format_set == 'combined' && steps.cache-jasper.outputs.cache-hit != 'true'
+        if: steps.cache-jasper.outputs.cache-hit != 'true'
         run: |
           git clone --depth 1 --branch version-4.2.4 https://github.com/jasper-software/jasper.git jasper-4.2.4
           # Build outside the source tree; Jasper's build/cmake/modules directory
@@ -147,9 +143,8 @@ jobs:
           make -j$(nproc)
           make install
 
-      # Cache g2c install (combined only)
+      # Cache g2c install
       - name: Cache g2c install
-        if: matrix.format_set == 'combined'
         id: cache-g2c
         uses: actions/cache@v4
         with:
@@ -157,7 +152,7 @@ jobs:
           key: g2c-2.3.0-${{ runner.os }}-1
 
       - name: Download and build NCEPLIBS-g2c 2.3.0
-        if: matrix.format_set == 'combined' && steps.cache-g2c.outputs.cache-hit != 'true'
+        if: steps.cache-g2c.outputs.cache-hit != 'true'
         run: |
           wget https://github.com/NOAA-EMC/NCEPLIBS-g2c/archive/refs/tags/v2.3.0.tar.gz &> /dev/null
           tar -xzf v2.3.0.tar.gz
@@ -178,43 +173,25 @@ jobs:
         run: |
           mkdir -p build && cd build
           export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/netcdf-c-install/lib/pkgconfig:$GITHUB_WORKSPACE/hdf5-install/lib/pkgconfig:${PKG_CONFIG_PATH}"
-          if [ "${{ matrix.format_set }}" = "combined" ]; then
-            cmake .. \
-              -DCMAKE_C_FLAGS="-Wall -Werror" \
-              -DCMAKE_Fortran_FLAGS="-Wall -Werror" \
-              -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/netcdf-fortran-install;$GITHUB_WORKSPACE/g2c-install;$GITHUB_WORKSPACE/jasper-install" \
-              -DENABLE_GEOTIFF=ON \
-              -DENABLE_GRIB2=ON \
-              -DENABLE_FITS=ON \
-              -DENABLE_CDF=OFF \
-              -DENABLE_FORTRAN=ON \
-              -DBUILD_LZ4=OFF \
-              -DBUILD_BZIP2=OFF \
-              -DBUILD_DOCUMENTATION=OFF \
-              -DBUILD_EXAMPLES=OFF \
-              -DBUILD_TESTING=ON
-            echo "=== Checking config.h for format flags ==="
-            grep "define HAVE_GEOTIFF" config.h && echo "SUCCESS: HAVE_GEOTIFF" || (echo "FAILURE: HAVE_GEOTIFF"; exit 1)
-            grep "define HAVE_GRIB2" config.h && echo "SUCCESS: HAVE_GRIB2" || (echo "FAILURE: HAVE_GRIB2"; exit 1)
-            grep "define HAVE_FITS" config.h && echo "SUCCESS: HAVE_FITS" || (echo "FAILURE: HAVE_FITS"; exit 1)
-          else
-            cmake .. \
-              -DCMAKE_C_FLAGS="-Wall -Werror" \
-              -DCMAKE_Fortran_FLAGS="-Wall -Werror" \
-              -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/netcdf-fortran-install;$GITHUB_WORKSPACE/cdf-install" \
-              -DENABLE_CDF=ON \
-              -DENABLE_GEOTIFF=OFF \
-              -DENABLE_GRIB2=OFF \
-              -DENABLE_FITS=OFF \
-              -DENABLE_FORTRAN=ON \
-              -DBUILD_LZ4=OFF \
-              -DBUILD_BZIP2=OFF \
-              -DBUILD_DOCUMENTATION=OFF \
-              -DBUILD_EXAMPLES=OFF \
-              -DBUILD_TESTING=ON
-            echo "=== Checking config.h for HAVE_CDF ==="
-            grep "define HAVE_CDF" config.h && echo "SUCCESS: HAVE_CDF" || (echo "FAILURE: HAVE_CDF"; exit 1)
-          fi
+          cmake .. \
+            -DCMAKE_C_FLAGS="-Wall -Werror" \
+            -DCMAKE_Fortran_FLAGS="-Wall -Werror" \
+            -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/netcdf-fortran-install;$GITHUB_WORKSPACE/cdf-install;$GITHUB_WORKSPACE/g2c-install;$GITHUB_WORKSPACE/jasper-install" \
+            -DENABLE_CDF=ON \
+            -DENABLE_GEOTIFF=ON \
+            -DENABLE_GRIB2=ON \
+            -DENABLE_FITS=ON \
+            -DENABLE_FORTRAN=ON \
+            -DBUILD_LZ4=OFF \
+            -DBUILD_BZIP2=OFF \
+            -DBUILD_DOCUMENTATION=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TESTING=ON
+          echo "=== Checking config.h for format flags ==="
+          grep "define HAVE_CDF" config.h && echo "SUCCESS: HAVE_CDF" || (echo "FAILURE: HAVE_CDF"; exit 1)
+          grep "define HAVE_GEOTIFF" config.h && echo "SUCCESS: HAVE_GEOTIFF" || (echo "FAILURE: HAVE_GEOTIFF"; exit 1)
+          grep "define HAVE_GRIB2" config.h && echo "SUCCESS: HAVE_GRIB2" || (echo "FAILURE: HAVE_GRIB2"; exit 1)
+          grep "define HAVE_FITS" config.h && echo "SUCCESS: HAVE_FITS" || (echo "FAILURE: HAVE_FITS"; exit 1)
 
       - name: Build (CMake)
         if: matrix.build_system == 'cmake'
@@ -240,44 +217,25 @@ jobs:
         run: |
           export PATH="$GITHUB_WORKSPACE/hdf5-install/bin:$PATH"
           export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/netcdf-c-install/lib/pkgconfig:$GITHUB_WORKSPACE/hdf5-install/lib/pkgconfig:${PKG_CONFIG_PATH}"
-          export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include -I$GITHUB_WORKSPACE/netcdf-fortran-install/include"
-          export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib -L$GITHUB_WORKSPACE/netcdf-fortran-install/lib"
-          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/netcdf-fortran-install/lib:$LD_LIBRARY_PATH"
-          if [ "${{ matrix.format_set }}" = "combined" ]; then
-            export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include -I$GITHUB_WORKSPACE/netcdf-fortran-install/include -I$GITHUB_WORKSPACE/g2c-install/include"
-            export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib -L$GITHUB_WORKSPACE/netcdf-fortran-install/lib -L$GITHUB_WORKSPACE/g2c-install/lib -L$GITHUB_WORKSPACE/jasper-install/lib"
-            ./configure \
-              --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc \
-              --enable-geotiff \
-              --enable-grib2 \
-              --enable-fits \
-              --disable-cdf \
-              --enable-fortran \
-              --disable-lz4 \
-              --disable-bzip2 \
-              --disable-docs \
-              || (echo "Configure failed:"; cat config.log; exit 1)
-            echo "=== Checking config.h for format flags ==="
-            grep "define HAVE_GEOTIFF" config.h && echo "SUCCESS: HAVE_GEOTIFF" || (echo "FAILURE: HAVE_GEOTIFF"; exit 1)
-            grep "define HAVE_GRIB2" config.h && echo "SUCCESS: HAVE_GRIB2" || (echo "FAILURE: HAVE_GRIB2"; exit 1)
-            grep "define HAVE_FITS" config.h && echo "SUCCESS: HAVE_FITS" || (echo "FAILURE: HAVE_FITS"; exit 1)
-          else
-            export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include -I$GITHUB_WORKSPACE/netcdf-fortran-install/include -I$GITHUB_WORKSPACE/cdf-install/include"
-            export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib -L$GITHUB_WORKSPACE/netcdf-fortran-install/lib -L$GITHUB_WORKSPACE/cdf-install/lib"
-            ./configure \
-              --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc \
-              --enable-cdf \
-              --disable-geotiff \
-              --disable-grib2 \
-              --disable-fits \
-              --enable-fortran \
-              --disable-lz4 \
-              --disable-bzip2 \
-              --disable-docs \
-              || (echo "Configure failed:"; cat config.log; exit 1)
-            echo "=== Checking config.h for HAVE_CDF ==="
-            grep "define HAVE_CDF" config.h && echo "SUCCESS: HAVE_CDF" || (echo "FAILURE: HAVE_CDF"; exit 1)
-          fi
+          export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include -I$GITHUB_WORKSPACE/netcdf-fortran-install/include -I$GITHUB_WORKSPACE/g2c-install/include -I$GITHUB_WORKSPACE/cdf-install/include"
+          export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib -L$GITHUB_WORKSPACE/netcdf-fortran-install/lib -L$GITHUB_WORKSPACE/g2c-install/lib -L$GITHUB_WORKSPACE/jasper-install/lib -L$GITHUB_WORKSPACE/cdf-install/lib"
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/netcdf-fortran-install/lib:$GITHUB_WORKSPACE/cdf-install/lib:$GITHUB_WORKSPACE/g2c-install/lib:$GITHUB_WORKSPACE/jasper-install/lib:$LD_LIBRARY_PATH"
+          ./configure \
+            --with-hdf5=$GITHUB_WORKSPACE/hdf5-install/bin/h5cc \
+            --enable-cdf \
+            --enable-geotiff \
+            --enable-grib2 \
+            --enable-fits \
+            --enable-fortran \
+            --disable-lz4 \
+            --disable-bzip2 \
+            --disable-docs \
+            || (echo "Configure failed:"; cat config.log; exit 1)
+          echo "=== Checking config.h for format flags ==="
+          grep "define HAVE_CDF" config.h && echo "SUCCESS: HAVE_CDF" || (echo "FAILURE: HAVE_CDF"; exit 1)
+          grep "define HAVE_GEOTIFF" config.h && echo "SUCCESS: HAVE_GEOTIFF" || (echo "FAILURE: HAVE_GEOTIFF"; exit 1)
+          grep "define HAVE_GRIB2" config.h && echo "SUCCESS: HAVE_GRIB2" || (echo "FAILURE: HAVE_GRIB2"; exit 1)
+          grep "define HAVE_FITS" config.h && echo "SUCCESS: HAVE_FITS" || (echo "FAILURE: HAVE_FITS"; exit 1)
 
       - name: Build (Autotools)
         if: matrix.build_system == 'autotools'
@@ -291,7 +249,7 @@ jobs:
           export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/netcdf-fortran-install/lib:$GITHUB_WORKSPACE/cdf-install/lib:$GITHUB_WORKSPACE/g2c-install/lib:$GITHUB_WORKSPACE/jasper-install/lib:$LD_LIBRARY_PATH"
           make check || (
             echo "Tests failed. Collecting test logs:";
-            for log in test/test-suite.log test_geotiff/test-suite.log test_grib2/test-suite.log test_fits/test-suite.log ftest/test-suite.log; do
+            for log in test/test-suite.log test_geotiff/test-suite.log test_grib2/test-suite.log test_fits/test-suite.log test_cdf/test-suite.log ftest/test-suite.log; do
               if [ -f "$log" ]; then
                 echo "=== $log ===";
                 cat "$log";
@@ -305,7 +263,7 @@ jobs:
         run: |
           echo "=== Formats CI Build Summary ==="
           echo "Build System: ${{ matrix.build_system }}"
-          echo "Format Set: ${{ matrix.format_set }}"
+          echo "Format Set: all-formats (CDF + GeoTIFF + GRIB2 + FITS)"
           echo "HDF5: 2.0.0"
           echo "NetCDF-C: 4.10.0"
           echo "NetCDF-Fortran: 4.6.2"

--- a/.ncrc-cdf.in
+++ b/.ncrc-cdf.in
@@ -1,4 +1,4 @@
 
-# NASA CDF format (UDF slot 2)
-NETCDF.UDF2.LIBRARY=@NEP_LIBDIR@/libnccdf.so
-NETCDF.UDF2.INIT=NC_CDF_initialize
+# NASA CDF format (UDF slot 4)
+NETCDF.UDF4.LIBRARY=@NEP_LIBDIR@/libnccdf.so
+NETCDF.UDF4.INIT=NC_CDF_initialize

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,7 @@ option(BUILD_BZIP2 "Enable BZIP2 filter support" OFF)
 add_definitions(-DUSE_HDF5=yes)
 
 # CDF library detection (v1.3.0) - default OFF; enable with -DENABLE_CDF=ON
-# CDF and GRIB2 share UDF slot 2 and are mutually exclusive.
-option(ENABLE_CDF "Enable CDF library detection; mutually exclusive with ENABLE_GRIB2" OFF)
+option(ENABLE_CDF "Enable CDF library detection" OFF)
 
 # GeoTIFF library detection (v1.5.0) - default OFF; enable with -DENABLE_GEOTIFF=ON
 option(ENABLE_GEOTIFF "Enable GeoTIFF library detection" OFF)
@@ -111,8 +110,7 @@ endif()
 option(ENABLE_FITS "Enable FITS reader support via CFITSIO" OFF)
 
 # GRIB2 library detection (v1.7.0) - default OFF; enable with -DENABLE_GRIB2=ON
-# GRIB2 and CDF share UDF slot 2 and are mutually exclusive.
-option(ENABLE_GRIB2 "Enable GRIB2 support; mutually exclusive with ENABLE_CDF" OFF)
+option(ENABLE_GRIB2 "Enable GRIB2 support" OFF)
 
 # Parallel I/O test support (v1.9.0) - default OFF; enable with -DENABLE_PARALLEL_TESTS=ON
 option(ENABLE_PARALLEL_TESTS "Enable parallel I/O test programs" OFF)
@@ -173,11 +171,6 @@ if(NOT DOCS_ONLY)
         else()
             message(FATAL_ERROR "libcfitsio is required for the FITS reader. Install libcfitsio-dev or use -DENABLE_FITS=OFF")
         endif()
-    endif()
-
-    # Enforce mutual exclusion: GRIB2 and CDF both use UDF slot 2.
-    if(ENABLE_GRIB2 AND ENABLE_CDF)
-        message(FATAL_ERROR "ENABLE_GRIB2 and ENABLE_CDF are mutually exclusive: both use UDF slot 2. Enable only one.")
     endif()
 
     # GRIB2 library detection

--- a/configure.ac
+++ b/configure.ac
@@ -116,11 +116,10 @@ AC_ARG_ENABLE([docs],
     [enable_docs=auto])
 
 # CDF library detection (v1.3.0) - default OFF; enable with --enable-cdf
-# CDF and GRIB2 share UDF slot 2 and are mutually exclusive.
 AC_MSG_CHECKING([whether CDF library detection should be enabled])
 AC_ARG_ENABLE([cdf],
               [AS_HELP_STRING([--enable-cdf],
-                              [Enable CDF library detection; mutually exclusive with --enable-grib2 (default: disabled)])])
+                              [Enable CDF library detection (default: disabled)])])
 test "x$enable_cdf" = xyes || enable_cdf=no
 AC_MSG_RESULT([$enable_cdf])
 
@@ -232,18 +231,12 @@ AC_SUBST([CFITSIO_LDFLAGS])
 AC_SUBST([BUILD_FITS], [$enable_fits])
 
 # GRIB2 library detection (v1.7.0) - default OFF; enable with --enable-grib2
-# GRIB2 and CDF share UDF slot 2 and are mutually exclusive.
 AC_MSG_CHECKING([whether GRIB2 library detection should be enabled])
 AC_ARG_ENABLE([grib2],
               [AS_HELP_STRING([--enable-grib2],
-                              [Enable GRIB2 library detection; mutually exclusive with --enable-cdf (default: disabled)])])
+                              [Enable GRIB2 library detection (default: disabled)])])
 test "x$enable_grib2" = xyes || enable_grib2=no
 AC_MSG_RESULT([$enable_grib2])
-
-# Enforce mutual exclusion: GRIB2 and CDF both use UDF slot 2.
-if test "x$enable_grib2" = xyes && test "x$enable_cdf" = xyes; then
-    AC_MSG_ERROR([--enable-grib2 and --enable-cdf are mutually exclusive: both use UDF slot 2. Build with one or the other.])
-fi
 
 if test "x$enable_grib2" = "xyes"; then
     LIBS="-ljasper $LIBS"

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -174,14 +174,14 @@ The Common Data Format (CDF) is a self-describing data format developed by NASA'
 
 ### Enabling CDF Support
 
-CDF support is disabled by default (mutually exclusive with GRIB2). To enable:
+CDF support is disabled by default. To enable:
 
 ```bash
 # CMake
-cmake -B build -DENABLE_CDF=ON -DENABLE_GRIB2=OFF
+cmake -B build -DENABLE_CDF=ON
 
 # Autotools
-./configure --enable-cdf --disable-grib2
+./configure --enable-cdf
 ```
 
 **Requirements**: NASA CDF library v3.9+ must be installed. Download from: https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest/
@@ -235,7 +235,7 @@ cmake -B build -DENABLE_GRIB2=OFF
 
 **Requirements**: NOAA NCEPLIBS-g2c (>= 2.1.0) and libjasper (>= 3.0.0) must be installed. Supply the g2c install path at configure time.
 
-**Note**: GRIB2 and CDF are mutually exclusive — both use UDF slot 2. Enable one or the other, not both.
+**Note**: GRIB2 uses UDF slot 2. CDF uses UDF slot 4 (since v2.2.0). Both can be enabled together.
 
 ## GeoTIFF File Reader
 
@@ -295,7 +295,7 @@ NEP requires:
 - LZ4 library
 - BZIP2 library
 - NetCDF-Fortran library (optional, for Fortran support)
-- NASA CDF library v3.9+ (optional, for CDF file reading; mutually exclusive with GRIB2)
+- NASA CDF library v3.9+ (optional, for CDF file reading)
 - libgeotiff and libtiff (enabled by default, for GeoTIFF file reading)
 - NOAA NCEPLIBS-g2c >= 2.1.0 and libjasper >= 3.0.0 (enabled by default, for GRIB2 file reading)
 
@@ -424,7 +424,7 @@ No special code is needed—the GeoTIFF UDF handler automatically detects and pr
   - `.ncrc` autoload support for zero-code-change `nc_open()` / `ncdump` access
 - **Configurable Build Options**:
   - LZ4 and BZIP2 support can be enabled or disabled at build time
-  - CDF support is optional (disabled by default; mutually exclusive with GRIB2)
+  - CDF support is optional (disabled by default)
   - GeoTIFF and GRIB2 support are enabled by default; disable with `--disable-geotiff` / `--disable-grib2`
 - **Fortran Support**:
   - Optional Fortran wrappers for NEP functions

--- a/docs/prfaq.md
+++ b/docs/prfaq.md
@@ -161,7 +161,7 @@ See the README for detailed instructions.
 **A:** Yes! Use build options to control which features are compiled:
 - **CMake**: `-DBUILD_LZ4=ON/OFF`, `-DBUILD_BZIP2=ON/OFF`, `-DENABLE_FORTRAN=ON/OFF`, `-DENABLE_CDF=ON/OFF`, `-DENABLE_GEOTIFF=ON/OFF`, `-DENABLE_GRIB2=ON/OFF`, `-DBUILD_EXAMPLES=ON/OFF`
 - **Autotools**: `--enable-lz4`, `--enable-bzip2`, `--enable-fortran`, `--enable-cdf`, `--enable-geotiff`, `--disable-grib2`, `--disable-examples`
-- Note: `ENABLE_CDF` and `ENABLE_GRIB2` are mutually exclusive (both use UDF slot 2)
+- Note: `ENABLE_CDF` and `ENABLE_GRIB2` can be used together (CDF uses UDF slot 4, GRIB2 uses UDF slot 2)
 - **Spack**: `spack install nep+lz4+bzip2+fortran` (variants control features)
 
 #### Q: How do I use LZ4 compression in my NetCDF files?
@@ -245,7 +245,7 @@ Or use `ncdump forecast.grib2` directly after installing the `.ncrc` file.
 #### Q: What is the current version?
 **A:** NEP v1.7.0 is the current release (March 2026), providing:
 - LZ4 and BZIP2 compression for HDF5/NetCDF-4 files (C and Fortran APIs)
-- NASA CDF format support via UDF handler (mutually exclusive with GRIB2)
+- NASA CDF format support via UDF handler (UDF slot 4)
 - GeoTIFF format support via UDF handler
 - **GRIB2 meteorological/oceanographic data support via UDF handler**
 - Spack package manager support

--- a/include/cdfdispatch.h
+++ b/include/cdfdispatch.h
@@ -15,9 +15,9 @@
 #include "ncdispatch.h"
 #include "nep.h"
 
-/** CDF format uses UDF2 slot for dispatch table model field (see NEP.h for slot allocation) */
-#ifdef NC_FORMATX_UDF2
-#define NC_FORMATX_NC_CDF NC_FORMATX_UDF2
+/** CDF format uses UDF4 slot for dispatch table model field (see NEP.h for slot allocation) */
+#ifdef NC_FORMATX_UDF4
+#define NC_FORMATX_NC_CDF NC_FORMATX_UDF4
 #else
 #define NC_FORMATX_NC_CDF NC_FORMATX_UDF0
 #endif

--- a/include/nep.h
+++ b/include/nep.h
@@ -10,11 +10,10 @@
  * NetCDF-C 4.10.0+ provides 10 UDF slots (UDF0-UDF9):
  * - UDF0: GeoTIFF BigTIFF (magic: "II+")
  * - UDF1: GeoTIFF standard TIFF (magic: "II*")
- * - UDF2: GRIB2 meteorological data (magic: "GRIB") [default]
- *         or NASA CDF format (magic: 0xCDF30001) [if built with --enable-cdf]
- *         GRIB2 and CDF are mutually exclusive; only one may be built at a time.
+ * - UDF2: GRIB2 meteorological data (magic: "GRIB")
  * - UDF3: FITS astronomical data (magic: "SIMPLE")
- * - UDF4-UDF9: Reserved for future use
+ * - UDF4: NASA CDF format (magic: 0xCDF30001)
+ * - UDF5-UDF9: Reserved for future use
  *
  * @author Edward Hartnett
  * @date Nov 13, 2025
@@ -66,8 +65,8 @@ extern "C" {
 /** GRIB2 meteorological format uses UDF2 slot */
 #define NEP_UDF_GRIB2 NC_UDF2
 
-/** NASA CDF format uses UDF2 slot (mutually exclusive with GRIB2) */
-#define NEP_UDF_CDF NC_UDF2
+/** NASA CDF format uses UDF4 slot */
+#define NEP_UDF_CDF NC_UDF4
 
 /** FITS astronomical data format uses UDF3 slot */
 #define NEP_UDF_FITS NC_UDF3

--- a/nep_skill.md
+++ b/nep_skill.md
@@ -42,8 +42,10 @@ NEP has two primary components:
 NetCDF-C 4.10.0+ provides 10 UDF slots:
 - **UDF0**: GeoTIFF BigTIFF (magic: "II+")
 - **UDF1**: GeoTIFF standard TIFF (magic: "II*")
-- **UDF2**: GRIB2 (magic: "GRIB") [default] OR NASA CDF (magic: 0xCDF30001) [mutually exclusive]
-- **UDF3-UDF9**: Reserved for future use
+- **UDF2**: GRIB2 (magic: "GRIB")
+- **UDF3**: FITS (magic: "SIMPLE")
+- **UDF4**: NASA CDF (magic: 0xCDF30001)
+- **UDF5-UDF9**: Reserved for future use
 
 ## Directory Structure
 
@@ -181,7 +183,7 @@ ctest -V
 |--------------|------------------|-------------|
 | `-DENABLE_CDF=ON` | `--enable-cdf` | Enable CDF file support |
 | `-DENABLE_GEOTIFF=ON` | `--enable-geotiff` | Enable GeoTIFF support |
-| `-DENABLE_GRIB2=ON` | `--enable-grib2` | Enable GRIB2 support (mutually exclusive with CDF) |
+| `-DENABLE_GRIB2=ON` | `--enable-grib2` | Enable GRIB2 support |
 | `-DBUILD_LZ4=ON` | `--enable-lz4` | Build LZ4 filter |
 | `-DBUILD_BZIP2=ON` | `--enable-bzip2` | Build BZIP2 filter |
 | `-DENABLE_FORTRAN=ON` | `--enable-fortran` | Build Fortran wrappers |

--- a/test/tst_cdf_udf.c
+++ b/test/tst_cdf_udf.c
@@ -197,7 +197,7 @@ int main(void)
     /* CDF files start with magic bytes 0xCDF30001 or 0xCDF26002 */
     /* Using CDF3 magic number: 0xCD, 0xF3, 0x00, 0x01 */
     char cdf_magic[5] = "\xCD\xF3\x00\x01";
-    retval = nc_def_user_format(NC_UDF2, (NC_Dispatch *)CDF_dispatch_table, cdf_magic);
+    retval = nc_def_user_format(NEP_UDF_CDF, (NC_Dispatch *)CDF_dispatch_table, cdf_magic);
     if (retval != NC_NOERR) {
         fprintf(stderr, "ERROR: Failed to register CDF UDF handler: %s\n", 
                 nc_strerror(retval));
@@ -213,7 +213,7 @@ int main(void)
     
     // /* Open the CDF file using NetCDF API */
     printf("Opening CDF file via NetCDF API: %s\n", TEST_FILE);
-    retval = nc_open(TEST_FILE, NC_UDF2, &ncid);
+    retval = nc_open(TEST_FILE, NEP_UDF_CDF, &ncid);
     if (retval != NC_NOERR) {
         fprintf(stderr, "ERROR: Failed to open CDF file via NetCDF API: %s\n", 
                 nc_strerror(retval));

--- a/test/tst_imap_mag.c
+++ b/test/tst_imap_mag.c
@@ -318,7 +318,7 @@ int main(void)
     /* CDF files start with magic bytes 0xCDF30001 or 0xCDF26002 */
     /* Using CDF3 magic number: 0xCD, 0xF3, 0x00, 0x01 */
     char cdf_magic[5] = "\xCD\xF3\x00\x01";
-    retval = nc_def_user_format(NC_UDF2, (NC_Dispatch *)CDF_dispatch_table, cdf_magic);
+    retval = nc_def_user_format(NEP_UDF_CDF, (NC_Dispatch *)CDF_dispatch_table, cdf_magic);
     if (retval != NC_NOERR)
     {
         fprintf(stderr, "ERROR: Failed to register CDF UDF handler: %s\n", 
@@ -329,7 +329,7 @@ int main(void)
     
     /* Open the IMAP MAG CDF file using NetCDF API */
     printf("Opening IMAP MAG CDF file via NetCDF API: %s\n", TEST_FILE);
-    if ((retval = nc_open(TEST_FILE, NC_UDF2, &ncid)))
+    if ((retval = nc_open(TEST_FILE, NEP_UDF_CDF, &ncid)))
     {
         fprintf(stderr, "ERROR: Failed to open IMAP MAG CDF file via NetCDF API: %s\n", 
                 nc_strerror(retval));

--- a/test_cdf/tst_cdf_ncrc_autoload.c
+++ b/test_cdf/tst_cdf_ncrc_autoload.c
@@ -8,7 +8,7 @@
  * file, then calls nc_open() directly. NetCDF-C reads the RC file and
  * loads libnep automatically.
  *
- * UDF slot used: UDF2 (NASA CDF, magic: \xCD\xF3\x00\x01)
+ * UDF slot used: UDF4 (NASA CDF, magic: \xCD\xF3\x00\x01)
  *
  * The test file tst_cdf_simple.cdf must already exist (created by
  * tst_cdf_basic which runs before this test).
@@ -54,8 +54,8 @@ static int setup_netcdf_rc(const char *lib_path)
         return 1;
     }
 
-    fprintf(f, "NETCDF.UDF2.LIBRARY=%s\n", lib_path);
-    fprintf(f, "NETCDF.UDF2.INIT=NC_CDF_initialize\n");
+    fprintf(f, "NETCDF.UDF4.LIBRARY=%s\n", lib_path);
+    fprintf(f, "NETCDF.UDF4.INIT=NC_CDF_initialize\n");
     fclose(f);
 
     if (setenv("NETCDF_RC", TMP_NCRC_DIR, 1) != 0)

--- a/test_cdf/tst_cdf_self_load.c
+++ b/test_cdf/tst_cdf_self_load.c
@@ -71,9 +71,9 @@ static int test_self_load_behavior(void)
     printf("    - NC_CDF_initialize() does NOT call nc_def_user_format()\n");
     printf("    - UDF registration happens via NetCDF-C plugin system\n");
     printf("    - Applications configure via RC file (.ncrc):\n");
-    printf("        NETCDF.UDF2.LIBRARY=/path/to/libnep.so\n");
-    printf("        NETCDF.UDF2.INIT=NC_CDF_initialize\n");
-    printf("        NETCDF.UDF2.MAGIC=\\xCD\\xF3\\x00\\x01\n");
+    printf("        NETCDF.UDF4.LIBRARY=/path/to/libnep.so\n");
+    printf("        NETCDF.UDF4.INIT=NC_CDF_initialize\n");
+    printf("        NETCDF.UDF4.MAGIC=\\xCD\\xF3\\x00\\x01\n");
     printf("    - NetCDF-C calls initialization function automatically\n");
     printf("    \u2713 Self-loading behavior documented\n");
     
@@ -132,9 +132,9 @@ static int test_with_rc_file(void)
         return 1;
     }
     
-    fprintf(rc, "NETCDF.UDF2.LIBRARY=%s\n", lib_path);
-    fprintf(rc, "NETCDF.UDF2.INIT=NC_CDF_initialize\n");
-    fprintf(rc, "NETCDF.UDF2.MAGIC=\\xCD\\xF3\\x00\\x01\n");
+    fprintf(rc, "NETCDF.UDF4.LIBRARY=%s\n", lib_path);
+    fprintf(rc, "NETCDF.UDF4.INIT=NC_CDF_initialize\n");
+    fprintf(rc, "NETCDF.UDF4.MAGIC=\\xCD\\xF3\\x00\\x01\n");
     fclose(rc);
     printf("    ✓ Created .ncrc configuration\n");
     


### PR DESCRIPTION
## Summary

- Moves CDF from UDF slot 2 to UDF slot 4 (`NC_UDF4`), giving every NEP format handler its own permanent slot
- Removes the CDF/GRIB2 mutual-exclusivity restriction; both can now be enabled together
- Upgrades `ci-formats.yml` from the Sprint 1 split matrix to a single `all-formats` job that tests all four extended format readers simultaneously

## Changes

- **`include/nep.h`**: `NEP_UDF_CDF` → `NC_UDF4`; updated `@section udf_slots` comment
- **`include/cdfdispatch.h`**: `NC_FORMATX_NC_CDF` → `NC_FORMATX_UDF4`
- **`.ncrc-cdf.in`**: `NETCDF.UDF2.*` → `NETCDF.UDF4.*`
- **`CMakeLists.txt`**: removed mutual-exclusivity `FATAL_ERROR` block; updated `option()` descriptions
- **`configure.ac`**: removed mutual-exclusivity `AC_MSG_ERROR` block; updated `AC_ARG_ENABLE` help strings
- **`test/tst_cdf_udf.c`**, **`test/tst_imap_mag.c`**: `NC_UDF2` → `NEP_UDF_CDF` for both `nc_def_user_format` and `nc_open` calls
- **`test_cdf/tst_cdf_ncrc_autoload.c`**, **`test_cdf/tst_cdf_self_load.c`**: `NETCDF.UDF2.*` → `NETCDF.UDF4.*` in generated `.ncrc` content
- **`.github/workflows/ci-formats.yml`**: collapsed `combined`/`cdf-only` matrix to single `all-formats` set; all four format readers (CDF + GeoTIFF + GRIB2 + FITS) enabled in every job; CDF library now built unconditionally in both jobs
- **`docs/mainpage.md`**, **`docs/prfaq.md`**, **`nep_skill.md`**, **`.devin/rules/local-build-command.md`**: removed mutual-exclusivity text; updated UDF slot descriptions

## Test plan

- [ ] `ci-formats.yml` passes for both `cmake` and `autotools` with all four formats enabled together
- [ ] `config.h` contains `HAVE_CDF`, `HAVE_GEOTIFF`, `HAVE_GRIB2`, `HAVE_FITS` in every job
- [ ] No PDS4 source code or build options added