### PR TITLE
Add PDS4 documentation to mainpage.md and expand Doxygen comments in …

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -934,8 +934,24 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @abs_top_srcdir@/src/nep.c \
+                         @abs_top_srcdir@/src/pds4dispatch.c \
                          @abs_top_srcdir@/src/pds4file.c \
+                         @abs_top_srcdir@/src/geotiffdispatch.c \
+                         @abs_top_srcdir@/src/geotifffile.c \
+                         @abs_top_srcdir@/src/grib2dispatch.c \
+                         @abs_top_srcdir@/src/grib2file.c \
+                         @abs_top_srcdir@/src/fitsdispatch.c \
+                         @abs_top_srcdir@/src/fitsfile.c \
+                         @abs_top_srcdir@/src/cdfdispatch.c \
+                         @abs_top_srcdir@/src/cdffile.c \
+                         @abs_top_srcdir@/src/cdffunc.c \
+                         @abs_top_srcdir@/src/cdfvar.c \
+                         @abs_top_srcdir@/include/nep.h \
                          @abs_top_srcdir@/include/pds4dispatch.h \
+                         @abs_top_srcdir@/include/geotiffdispatch.h \
+                         @abs_top_srcdir@/include/grib2dispatch.h \
+                         @abs_top_srcdir@/include/fitsdispatch.h \
+                         @abs_top_srcdir@/include/cdfdispatch.h \
                          @abs_top_srcdir@/fsrc/nep.F90 \
                          @abs_top_srcdir@/docs/mainpage.md \
                          @abs_top_srcdir@/docs/build-options.md \

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -10,6 +10,7 @@ NEP (NetCDF Extension Pack) extends NetCDF-4 with high-performance compression a
 - **GeoTIFF File Reader**: Read GeoTIFF geospatial raster files through the NetCDF API
 - **GRIB2 File Reader**: Read GRIB2 meteorological and oceanographic data files through the NetCDF API
 - **FITS File Reader**: Read NASA/ESA FITS astronomical image and table HDUs through the NetCDF API
+- **PDS4 File Reader**: Read NASA/ESA Planetary Data System 4 XML-label datasets through the NetCDF API
 
 NEP provides flexible compression options and unified data access for diverse scientific data workflows.
 
@@ -138,6 +139,87 @@ BZIP2 is a lossless data compression algorithm using the Burrows-Wheeler block s
 
 - **Use LZ4 when**: I/O speed is critical, working with real-time data, running on HPC systems, need fast decompression
 - **Use BZIP2 when**: Storage space is limited, archiving data long-term, transferring over slow networks, compression ratio matters most
+
+## PDS4 File Reader
+
+NEP provides a User-Defined Format (UDF) handler that enables reading PDS4 (Planetary Data System version 4) datasets using the familiar NetCDF API.
+
+### What is PDS4?
+
+PDS4 is the current archival standard used by NASA and ESA for planetary science data. A PDS4 dataset consists of an XML label file (`.xml`) that describes the data layout and one or more binary or text data files. The XML label is self-describing: it identifies the data types, dimensions, byte order, and physical units for every data object in the dataset.
+
+**Key Characteristics:**
+- Self-describing XML label with full data provenance metadata
+- Multiple data object types: n-dimensional arrays, binary tables, character (ASCII) tables, and delimited tables
+- Mandatory namespace validation (`http://pds.nasa.gov/pds4/pds/v1`) prevents false positive opens
+- Used by NASA/ESA missions: Mars Reconnaissance Orbiter, Curiosity, Perseverance, Cassini, OSIRIS-REx, and many others
+- Data files may be big-endian (MSB) or little-endian (LSB); byte order is recorded in the label
+
+### PDS4 Support in NEP
+
+**Transparent Access**: Read PDS4 datasets using standard NetCDF functions (`nc_open()`, `nc_get_vara()`, `nc_inq_dim()`) without file conversion.
+
+**netCDF Model Mapping**: The XML label structure is mapped into the netCDF-4 in-memory model:
+- `Identification_Area` and `Observation_Area` elements become global string attributes on the root group
+- Each `File_Area_Observational` becomes a child group named from the `File/file_name` element
+- `Array` / `Array_2D_Image`: dimensions created from `Axis_Array` entries (sorted by `sequence_number`); `axis_name` becomes the dimension name; `Last Index Fastest` maps to C-order (fastest-varying rightmost)
+- `Table_Binary` / `Table_Character` / `Table_Delimited`: a `record` dimension from `<records>`; one netCDF variable per `Field_*` with name, type, and optional `units` attribute
+
+**Data Reading** (`NC_PDS4_get_vara`):
+- Arrays: contiguous row-major reads with full hyperslab (`start`/`count`) support
+- Binary table fields: per-record seek using `field_location`, `field_length`, and `record_length`
+- ASCII table fields: fixed-width text parsed via `strtod`/`strtoll` into the mapped netCDF type
+- Automatic byte-order conversion: MSB (big-endian) types are swapped on little-endian hosts; LSB types are native
+
+**Data File Resolution**: Data filenames from `<File/file_name>` are resolved relative to the directory that contains the XML label file.
+
+**`.ncrc` Autoload**: Placing the generated `.ncrc` in your home directory allows `nc_open()` and `ncdump` to open PDS4 files with no code changes.
+
+**Use Cases:**
+- Planetary science data access (images, spectra, tables from rover and orbiter missions)
+- Cross-format workflows combining PDS4 with NetCDF, FITS, or GeoTIFF
+- Archive ingestion and format conversion pipelines
+
+### Enabling PDS4 Support
+
+PDS4 support is disabled by default. To enable:
+
+```bash
+# CMake
+cmake -B build -DENABLE_PDS4=ON
+
+# Autotools
+./configure --enable-pds4
+```
+
+**Requirements**: libxml2 must be installed (`libxml2-dev` on Ubuntu/Debian; `libxml2-devel` on RHEL/Fedora).
+
+### C API Usage Example
+
+```c
+#include <netcdf.h>
+#include "pds4dispatch.h"
+
+int ncid, grpid, varid;
+float image_data[512 * 512];
+size_t start[2] = {0, 0};
+size_t count[2] = {512, 512};
+
+/* Register the PDS4 handler (returns NC_EINVAL if already registered via .ncrc) */
+NC_PDS4_initialize();
+
+/* Open a PDS4 XML label file using the standard NetCDF API */
+nc_open("test_image.xml", NC_NOWRITE, &ncid);
+
+/* The label file area becomes a child group named from File/file_name */
+nc_inq_grp_ncid(ncid, "test_image.img", &grpid);
+
+/* Read the image array hyperslab */
+nc_inq_varid(grpid, "Array_2D_Image", &varid);
+nc_get_vara_float(grpid, varid, start, count, image_data);
+
+nc_close(ncid);
+```
 
 ## CDF File Reader
 

--- a/docs/plan/v2.3.0-sprint1-pds4-doxygen.md
+++ b/docs/plan/v2.3.0-sprint1-pds4-doxygen.md
@@ -1,0 +1,98 @@
+# NEP v2.3.0 Sprint 1 — Doxygen Docs for PDS4 Reader
+
+## Goal
+
+Bring the PDS4 reader documentation to the same level as the other format readers (CDF, GeoTIFF, GRIB2, FITS): a full section in the Doxygen mainpage, complete public-function API docs in `pds4file.c`, visible structs in the Doxygen Data Structures page, and a PDS4 API subsection in `docs/prd.md`.
+
+No code logic changes. No new tests (deferred to Sprint 2).
+
+---
+
+## Tasks
+
+### 1. Add PDS4 section to `docs/mainpage.md`
+
+The mainpage currently lists CDF, GeoTIFF, GRIB2, and FITS readers in the Overview bullet list and as full sections. PDS4 is absent.
+
+**Changes:**
+- Add `**PDS4 File Reader**` bullet to the Overview list under the FITS entry.
+- Add a `## PDS4 File Reader` section after the FITS section, containing:
+  - *What is PDS4?* — brief description of the NASA/ESA Planetary Data System version 4 XML-label format.
+  - *Key Characteristics* — self-describing XML label, multiple data object types (arrays, binary/character/delimited tables), used by NASA/ESA planetary missions.
+  - *PDS4 Support in NEP* — transparent `nc_open()` access, group-per-file-area, dimension/variable mapping from `Axis_Array`, full data I/O with byte-swap.
+  - *Enabling PDS4 Support* — CMake `-DENABLE_PDS4=ON` and Autotools `--enable-pds4`; requires `libxml2-dev`.
+  - *C API usage example* — open a PDS4 label, call `NC_PDS4_initialize()`, read a variable via `nc_get_vara_float()`.
+
+### 2. Expand `@file` block in `src/pds4file.c`
+
+The current `@file` block names the supported object types but does not describe the netCDF model mapping. Doxygen renders the file header as the main description for the file page.
+
+**Changes to `src/pds4file.c` `@file` block:**
+- Add a **netCDF model mapping** section explaining:
+  - XML label → root group (global attributes from `Identification_Area` and `Observation_Area`)
+  - Each `File_Area_Observational` → child group named from `File/file_name`
+  - `Array` / `Array_2D_Image` → dimensions from `Axis_Array` (sorted by `sequence_number`); variable from `Element_Array/data_type`; `axis_name` → dimension name; `Last Index Fastest` → C-order (fastest-varying rightmost)
+  - `Table_Binary` / `Table_Character` / `Table_Delimited` → `records` → row dimension; one variable per `Field_*` with `units` attribute
+- Add a **byte-order handling** paragraph: MSB types are byte-swapped on little-endian hosts; LSB types are native; ASCII numeric fields are parsed via `strtod`/`strtoll`.
+- Add a **data file resolution** paragraph: data file paths are resolved relative to the directory containing the XML label file.
+
+**Changes to public function Doxygen tags in `src/pds4file.c`:**
+
+Add or complete `@param` / `@return` entries for these public functions (all currently lack them):
+- `NC_PDS4_open()` — params: `path`, `mode`, `basepe`, `chunksizehintp`, `parameters`, dispatch pointer, `ncid`; return: `NC_NOERR` or netCDF error code.
+- `NC_PDS4_close()` — params: `ncid`, `ignore`; return: `NC_NOERR` or netCDF error code.
+- `NC_PDS4_abort()` — params: `ncid`; return: `NC_NOERR` or netCDF error code.
+- `NC_PDS4_inq_format()` — params: `ncid`, `formatp`; return: `NC_NOERR`.
+- `NC_PDS4_inq_format_extended()` — params: `ncid`, `formatp`, `modep`; return: `NC_NOERR`.
+- `NC_PDS4_get_vara()` — params: `ncid`, `varid`, `start`, `count`, `value`, `memtype`; return: `NC_NOERR` or `NC_EINVAL`/`NC_ENOTVAR`/`NC_ENOMEM`.
+- `NC_PDS4_initialize()` — no params; return: `NC_NOERR` or `NC_EINVAL` if already registered.
+- `NC_PDS4_finalize()` — no params; return: `NC_NOERR`.
+
+Internal `@internal`-tagged helpers (`pds4_trim`, `pds4_node_text`, `pds4_map_type`, `pds4_parse_arrays`, `pds4_parse_tables`, `pds4_read_label`, `pds4_free_var_info`) are **not** touched.
+
+### 3. Fix struct visibility in `include/pds4dispatch.h`
+
+**Root cause:** The `@file` block in `pds4dispatch.h` is tagged `@internal`, which causes Doxygen to treat the entire file as private. As a result `NC_PDS4_VAR_INFO_T` and `NC_PDS4_FILE_INFO_T` do not appear in the Data Structures page.
+
+**Fix:**
+- Remove `@internal` from the `@file` block in `include/pds4dispatch.h`.
+- Change the description from "This header file contains the prototypes for the PDS4 versions of the netCDF functions. This is part of the PDS4 dispatch layer and this header should not be included by any file outside the libncpds4 directory." to a concise public description: "Public types and prototypes for the PDS4 UDF dispatch layer."
+- Add `@brief` one-line descriptions to all struct fields in `NC_PDS4_VAR_INFO_T` and `NC_PDS4_FILE_INFO_T` that currently lack them (they already have them — verify and expand if any field description is ambiguous).
+
+**Do not** set `EXTRACT_PRIVATE = YES` in `Doxyfile.in` — that would expose internal entities from all other files globally.
+
+### 4. Add PDS4 API subsection to `docs/prd.md`
+
+`docs/prd.md` has sections for CDF (§4), GeoTIFF (§5), GRIB2 (§6), FITS (§7). PDS4 needs a parallel section.
+
+**New section content:**
+- Public initializer API: `NC_PDS4_initialize()` / `NC_PDS4_finalize()`
+- Data reading API: `NC_PDS4_get_vara()` — replaces default dispatch no-op; reads arrays and table fields
+- `NC_PDS4_VAR_INFO_T`: per-variable layout struct stored in `var->format_var_info`
+- Build options: `-DENABLE_PDS4=ON` / `--enable-pds4` (default OFF); requires `libxml2-dev`
+- UDF slot: UDF5 (`NC_FORMATX_UDF5`)
+- Known limitations (from v2.2.0 release notes): no `nc_get_vars()` native stride, no type conversion, grouped/bit fields not supported, `Product_Observational` only, delimited table row count from label only
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `docs/mainpage.md` | Add PDS4 bullet + full `## PDS4 File Reader` section |
+| `src/pds4file.c` | Expand `@file` block; add `@param`/`@return` to 8 public functions |
+| `include/pds4dispatch.h` | Remove `@internal` from `@file`; update file description |
+| `docs/prd.md` | New PDS4 API subsection |
+
+No build system changes. No source logic changes. No new tests.
+
+---
+
+## Definition of Done
+
+- [ ] `docs/mainpage.md` has a full PDS4 section with C usage example
+- [ ] `src/pds4file.c` `@file` block covers model mapping, byte-order, and data file resolution
+- [ ] All 8 public functions in `pds4file.c` have `@param`/`@return` Doxygen tags
+- [ ] `include/pds4dispatch.h` `@internal` tag removed; both structs appear in Doxygen Data Structures page
+- [ ] `docs/prd.md` has a PDS4 API subsection parallel to the CDF/GeoTIFF/GRIB2/FITS sections
+- [ ] `doxygen Doxyfile` runs without new warnings related to PDS4 symbols

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -520,12 +520,8 @@ Parallel I/O builds are tested in a separate CI workflow (`ci-parallel.yml`) wit
 PDS4 (Planetary Data System version 4) support via UDF handler enables transparent
 access to NASA/ESA Planetary Data System 4 label files through the standard NetCDF
 API. PDS4 is used to archive and distribute planetary science data from missions
-such as Mars Reconnaissance Orbiter, Curiosity, Perseverance, Cassini, and many
-others.
-
-v2.2.0 Sprint 3 delivers the dispatch skeleton: UDF5 slot registration, libxml2
-label parsing and namespace validation, and an open/close round-trip. Metadata and
-data reading will be added in subsequent releases.
+such as Mars Reconnaissance Orbiter, Curiosity, Perseverance, Cassini, OSIRIS-REx,
+and many others.
 
 ### 14.2 Features
 
@@ -533,40 +529,99 @@ data reading will be added in subsequent releases.
   verified against `http://pds.nasa.gov/pds4/pds/v1`
 - **UDF Registration**: PDS4 assigned to UDF slot 5 (`NC_UDF5`), permanently
   separate from all other NEP format slots
-- **Open/Close Round-trip**: `nc_open()` / `nc_close()` succeed on any valid
-  PDS4 XML label; returns `NC_ENOTNC` for XML files that are not PDS4 labels
+- **Metadata Mapping**: Full label-to-netCDF model mapping (see §14.3)
+- **Data Reading**: `NC_PDS4_get_vara()` reads array hyperslabs and table field
+  values with automatic byte-order conversion for MSB/LSB binary types and text
+  parsing for ASCII fields
 - **libxml2 Integration**: XML parsing uses libxml2 with `XML_PARSE_NONET` to
-  avoid network access during format detection
+  avoid network access
 
-### 14.3 Build Configuration
+### 14.3 netCDF Model Mapping
 
-CMake:
+The PDS4 XML label is mapped into the netCDF-4 in-memory model as follows:
+
+- **Root group**: `Identification_Area` and `Observation_Area` elements become
+  global string attributes
+- **Child groups**: Each `File_Area_Observational` becomes a child group named
+  from `File/file_name`
+- **Array / Array_2D_Image**: Dimensions from `Axis_Array` entries (sorted by
+  `sequence_number`); `axis_name` → dimension name; `elements` → dimension length;
+  `Last Index Fastest` maps to C-order. Variable type from `Element_Array/data_type`
+- **Table_Binary / Table_Character / Table_Delimited**: `record` dimension from
+  `<records>`; one netCDF variable per `Field_*` with name from `<name>`, type from
+  `<data_type>`, optional `units` attribute from `<unit>`
+
+### 14.4 Public API
+
+**Initializer / Finalizer** (in `src/pds4dispatch.c`):
+- `NC_PDS4_initialize(void)` — Registers the PDS4 dispatch table for UDF slot 5
+  via `nc_def_user_format()`. Returns `NC_NOERR` on success or `NC_EINVAL` if
+  already registered (safe to call repeatedly; `.ncrc` autoload also registers it).
+- `NC_PDS4_finalize(void)` — No-op; returns `NC_NOERR`.
+
+**File Operations** (in `src/pds4file.c`):
+- `NC_PDS4_open()` — Parses the XML label, validates PDS4 namespace, maps label
+  to netCDF-4 in-memory model. Read-only (`NC_NOWRITE` only).
+- `NC_PDS4_close()` — Frees XML document and per-file PDS4 state.
+- `NC_PDS4_abort()` — Releases partial-open resources.
+- `NC_PDS4_inq_format()` — Returns `NC_FORMAT_NETCDF4`.
+- `NC_PDS4_inq_format_extended()` — Returns `NC_FORMATX_NC_PDS4`
+  (`NC_FORMATX_UDF5`) and `NC_NOWRITE`.
+- `NC_PDS4_get_vara()` — Reads array hyperslabs or table field records from
+  the referenced data file; byte-swaps binary types as needed; parses ASCII types
+  via `strtod()`/`strtoll()`.
+
+**Per-Variable Layout Struct** (`NC_PDS4_VAR_INFO_T` in `include/pds4dispatch.h`):
+
+Stored in `var->format_var_info` for every PDS4 variable. Fields:
+
+| Field | Description |
+|-------|-------------|
+| `data_offset` | Byte offset of the Array or Table start in the data file |
+| `record_length` | Record length in bytes (tables only) |
+| `field_offset` | Field byte offset within each record, 0-based (tables only) |
+| `field_length` | Field byte length (tables only) |
+| `is_table_field` | 1 if this variable is a table field; 0 if it is an array |
+| `is_ascii` | 1 if the field is ASCII text (needs parsing); 0 if binary |
+
+### 14.5 Build Configuration
+
+**CMake:**
 - `ENABLE_PDS4=ON/OFF` — Enable/disable PDS4 support (default: OFF)
 - Requires `find_package(LibXml2 REQUIRED)` when enabled
 
-Autotools:
+**Autotools:**
 - `--enable-pds4/--disable-pds4` — PDS4 support (default: disabled)
 - Uses `AC_CHECK_HEADERS([libxml/parser.h])` + `AC_CHECK_LIB([xml2], [xmlReadFile])`
 
-### 14.4 Dependencies
+### 14.6 Dependencies
 
-- libxml2 (`libxml2-dev` on Ubuntu / Debian; `libxml2-devel` on RHEL/Fedora)
+- libxml2 (`libxml2-dev` on Ubuntu/Debian; `libxml2-devel` on RHEL/Fedora)
 
-### 14.5 Known Limitations (v2.2.0)
+### 14.7 UDF Slot
 
-- Array metadata and data are read for `Array` and `Array_2D_Image` products.
-  Hyperslab access (`nc_get_vara`) is supported with automatic byte-order
-  conversion for MSB/LSB types.
-- Table metadata and data are read for `Table_Binary`, `Table_Character`, and
-  `Table_Delimited`: each table creates a `record` dimension and one variable per
-  field. Binary fields are byte-swapped; ASCII numeric fields are parsed.
-- Data file paths are resolved relative to the XML label directory.
-- Only `Product_Observational` root element type is validated; other PDS4 product
-  classes are not checked in this release.
-- Grouped fields (`Group_Field_Binary`, etc.) and bit fields are not yet supported.
-- `nc_get_vars()` and `nc_get_varm()` rely on default dispatch fallbacks.
+PDS4 is assigned UDF slot 5 (`NC_FORMATX_UDF5`). Permanent slot map:
+
+| Slot | Format |
+|------|--------|
+| UDF0 | GeoTIFF (BigTIFF) |
+| UDF1 | GeoTIFF (standard) |
+| UDF2 | GRIB2 |
+| UDF3 | FITS |
+| UDF4 | CDF |
+| UDF5 | PDS4 |
+
+### 14.8 Known Limitations (v2.2.0)
+
+- `nc_get_vars()` and `nc_get_varm()` rely on default dispatch fallbacks (no
+  native strided reads)
 - Type conversion between `memtype` and the file type is not yet performed; the
-  caller must request data in the native type.
+  caller must request the native type
+- Grouped fields (`Group_Field_Binary`, etc.) and bit fields are not supported
+- Only `Product_Observational` root element type is validated; other PDS4 product
+  classes are not checked
+- Delimited table row count is derived from the label `<records>` element only
+  (no file scanning)
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,22 @@
 # NEP Development Roadmap
+
+### V2.3.0 Documentation and More Testing for PDS4 Read
+
+#### Sprint 1: Doxygen Docs for PDS4 Reader
+**Detailed Plan**: See `docs/plan/v2.3.0-sprint1-pds4-doxygen.md`
+
+- Add a "PDS4 File Reader" section to `docs/mainpage.md` matching the style and depth of the existing FITS section (What is PDS4 / Key Characteristics / PDS4 Support in NEP / Enabling PDS4 Support / C API usage example).
+- Expand the `@file` block in `src/pds4file.c` to add sections on the netCDF model mapping (groups, dimensions, variables, attributes), byte-order handling, and data file resolution. Add `@param`/`@return` Doxygen tags to all public functions missing them; leave internal helpers with their existing comments.
+- Fix struct visibility in the Doxygen Data Structures page: remove the `@internal` tag from the `@file` block in `include/pds4dispatch.h` so `NC_PDS4_VAR_INFO_T` and `NC_PDS4_FILE_INFO_T` appear publicly, and add `@brief` descriptions to all struct fields.
+- Add a PDS4 API subsection to `docs/prd.md` covering `NC_PDS4_initialize()`, `NC_PDS4_finalize()`, and `NC_PDS4_get_vara()`, consistent with the CDF/GeoTIFF/GRIB2/FITS sections already present.
+
+**Clarified decisions:**
+- `pds4file.c` expansion: public functions only (not `@internal` helpers); add `@param`/`@return` where missing.
+- Struct fix: remove `@internal` from `pds4dispatch.h` `@file` tag (not `EXTRACT_PRIVATE=YES`, which would expose other internal entities globally).
+- `docs/mainpage.md`: full PDS4 section with C usage example, matching FITS section depth.
+- `docs/prd.md`: new PDS4 API subsection; no code changes.
+- Sprint 1 is documentation-only; new tests deferred to Sprint 2.
+
 ### V2.2.0 Read NASA/ESA Planetary Data System 4 Data
 
 #### Sprint 1: Make Extended Data Formats Off by Default

--- a/include/cdfdispatch.h
+++ b/include/cdfdispatch.h
@@ -1,8 +1,6 @@
 /**
- * @file @internal This header file contains the prototypes for the
- * CDF versions of the netCDF functions. This is part of the CDF
- * dispatch layer and this header should not be included by any file
- * outside the libcdf directory.
+ * @file
+ * @brief Public types and prototypes for the CDF UDF dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2025-11-23

--- a/include/fitsdispatch.h
+++ b/include/fitsdispatch.h
@@ -1,9 +1,6 @@
 /**
  * @file
- * @internal This header file contains the prototypes for the
- * FITS versions of the netCDF functions. This is part of the FITS
- * dispatch layer and this header should not be included by any file
- * outside the libncfits directory.
+ * @brief Public types and prototypes for the FITS UDF dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2026-06-28

--- a/include/geotiffdispatch.h
+++ b/include/geotiffdispatch.h
@@ -1,9 +1,6 @@
 /**
  * @file
- * @internal This header file contains the prototypes for the
- * GeoTIFF versions of the netCDF functions. This is part of the GeoTIFF
- * dispatch layer and this header should not be included by any file
- * outside the libgeotiff directory.
+ * @brief Public types and prototypes for the GeoTIFF UDF dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2025-12-26

--- a/include/grib2dispatch.h
+++ b/include/grib2dispatch.h
@@ -1,9 +1,6 @@
 /**
  * @file
- * @internal This header file contains the prototypes for the
- * GRIB2 versions of the netCDF functions. This is part of the GRIB2
- * dispatch layer and this header should not be included by any file
- * outside the libgrib2 directory.
+ * @brief Public types and prototypes for the GRIB2 UDF dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2026-03-08

--- a/include/pds4dispatch.h
+++ b/include/pds4dispatch.h
@@ -1,9 +1,10 @@
 /**
  * @file
- * @internal This header file contains the prototypes for the
- * PDS4 versions of the netCDF functions. This is part of the PDS4
- * dispatch layer and this header should not be included by any file
- * outside the libncpds4 directory.
+ * @brief Public types and prototypes for the PDS4 UDF dispatch layer.
+ *
+ * Defines the per-variable layout struct (NC_PDS4_VAR_INFO_T), the
+ * per-file state struct (NC_PDS4_FILE_INFO_T), and the public API
+ * prototypes for the PDS4 User-Defined Format handler.
  *
  * @author Edward Hartnett
  * @date 2026-07-08

--- a/src/cdfdispatch.c
+++ b/src/cdfdispatch.c
@@ -1,7 +1,6 @@
 /**
  * @file
- * @internal Dispatch code for CDF. CDF access is read-only, for
- * CDF SD files only.
+ * @brief CDF dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2025-11-23

--- a/src/cdfdispatch.c
+++ b/src/cdfdispatch.c
@@ -132,7 +132,7 @@ NC_CDF_initialize(void)
 /**
  * @internal Finalize CDF dispatch layer.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Ed Hartnett
  */
 int

--- a/src/cdffile.c
+++ b/src/cdffile.c
@@ -47,7 +47,7 @@ nc_type_size_g[NUM_TYPES] = {sizeof(char), sizeof(char), sizeof(short),
  *
  * @param grp Pointer to group info struct.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 static int
@@ -80,7 +80,7 @@ cdf_rec_grp_del(NC_GRP_INFO_T *grp)
  * @param type_sizep Pointer that gets type size. Ignored if NULL.
  * @param type_name Pointer that gets the type name. Ignored if NULL.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Ed Hartnett
  */
 static int
@@ -191,7 +191,7 @@ cdf_type_info(NC_FILE_INFO_T *h5, int cdf_typeid, nc_type* xtypep,
  * @param type_name A name for the type.
  * @param typep Pointer to a pointer that gets the TYPE_INFO_T struct.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Ed Hartnett
  */
 static int
@@ -225,10 +225,10 @@ nc4_set_var_type(nc_type xtype, int endianness, size_t type_size, char *type_nam
  * attributes.
  * @param a Index of attribute to read.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EHDFERR CDF error.
- * @return ::NC_EATTMETA Error reading CDF attribute.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_EHDFERR CDF error.
+ * @return NC_EATTMETA Error reading CDF attribute.
+ * @return NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 static int
@@ -379,11 +379,11 @@ cdf_read_att(NC_FILE_INFO_T *h5, NC_VAR_INFO_T *var, int a)
  * @param rec_dim_len Actual length of first dim for this SD.
  * @param d Dimension index for this SD.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EHDFERR CDF error.
- * @return ::NC_EDIMMETA Error reading CDF dimension info.
- * @return ::NC_ENOMEM Out of memory.
- * @return ::NC_EMAXNAME Name too long.
+ * @return NC_NOERR No error.
+ * @return NC_EHDFERR CDF error.
+ * @return NC_EDIMMETA Error reading CDF dimension info.
+ * @return NC_ENOMEM Out of memory.
+ * @return NC_EMAXNAME Name too long.
  * @author Ed Hartnett
  */
 #if 0
@@ -407,8 +407,8 @@ cdf_read_dim(NC_FILE_INFO_T *h5, NC_VAR_INFO_T *var, int rec_dim_len, int d)
  * @param format_var_info Pointer to format-specific var info struct.
  * @param var Pointer in which to return a pointer to the new var.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 static int
@@ -455,13 +455,13 @@ nc4_var_list_add_full(NC_GRP_INFO_T* grp, const char* name, int ndims, nc_type x
  * @param h5 Pointer to the file metadata struct.
  * @param v Index of variable to read.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EHDFERR CDF error.
- * @return ::NC_EDIMMETA Error reading CDF dimension info.
- * @return ::NC_EVARMETA Error reading CDF dataset or att.
- * @return ::NC_EATTMETA Error reading CDF attribute.
- * @return ::NC_ENOMEM Out of memory.
- * @return ::NC_EMAXNAME Name too long.
+ * @return NC_NOERR No error.
+ * @return NC_EHDFERR CDF error.
+ * @return NC_EDIMMETA Error reading CDF dimension info.
+ * @return NC_EVARMETA Error reading CDF dataset or att.
+ * @return NC_EATTMETA Error reading CDF attribute.
+ * @return NC_ENOMEM Out of memory.
+ * @return NC_EMAXNAME Name too long.
  * @author Ed Hartnett
  */
 static int
@@ -616,10 +616,10 @@ cdf_read_var(NC_FILE_INFO_T *h5, int v)
  * @param nc_file Pointer to an instance of NC. The ncid has already
  * been assigned, and is in nc_file->ext_ncid.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EINVAL Invalid input.
- * @return ::NC_EHDFERR Error from CDF layer.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_EINVAL Invalid input.
+ * @return NC_EHDFERR Error from CDF layer.
+ * @return NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 int
@@ -747,9 +747,9 @@ NC_CDF_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
  *
  * @param ncid File ID.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
- * @return ::NC_EHDFERR Error from CDF layer.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
+ * @return NC_EHDFERR Error from CDF layer.
  * @author Ed Hartnett
  */
 int
@@ -765,9 +765,9 @@ NC_CDF_abort(int ncid)
  * @param ncid File ID.
  * @param ignore Ignore this pointer.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
- * @return ::NC_EHDFERR Error from CDF layer.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
+ * @return NC_EHDFERR Error from CDF layer.
  * @author Ed Hartnett
  */
 int

--- a/src/cdffile.c
+++ b/src/cdffile.c
@@ -1,7 +1,6 @@
 /**
  * @file
- * @internal The CDF file functions. These provide a read-only
- * interface to CDF SD files.
+ * @brief CDF file reader functions.
  *
  * @author Edward Hartnett
  * @date 2025-11-23

--- a/src/cdffunc.c
+++ b/src/cdffunc.c
@@ -29,8 +29,8 @@
  * @param ncid File ID (ignored).
  * @param formatp Pointer that gets the constant indicating format.
 
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int
@@ -54,8 +54,8 @@ NC_CDF_inq_format(int ncid, int *formatp)
  * @param modep a pointer that gets the open/create mode associated with
  * this file. Ignored if NULL.
 
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int

--- a/src/cdffunc.c
+++ b/src/cdffunc.c
@@ -1,5 +1,6 @@
 /**
- * @file @internal CDF functions.
+ * @file
+ * @brief CDF format inquiry functions.
  *
  * @author Edward Hartnett
  * @date 2025-11-23

--- a/src/cdfvar.c
+++ b/src/cdfvar.c
@@ -59,11 +59,11 @@ get_nc4type_size(nc_type type)
  * @param ip pointer that gets the data.
  * @param memtype The type of these data after it is read into memory.
  *
- * @return ::NC_NOERR for success.
- * @return ::NC_EBADID Bad ncid.
- * @return ::NC_EINVAL Invalid input.
- * @return ::NC_ECDF CDF library error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR for success.
+ * @return NC_EBADID Bad ncid.
+ * @return NC_EINVAL Invalid input.
+ * @return NC_ECDF CDF library error.
+ * @return NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 int

--- a/src/cdfvar.c
+++ b/src/cdfvar.c
@@ -1,6 +1,6 @@
 /**
- * @file @internal This file handles the variable functions for the
- * CDF dispatch layer.
+ * @file
+ * @brief CDF variable read functions.
  *
  * @author Edward Hartnett
  * @date 2025-11-23

--- a/src/fitsdispatch.c
+++ b/src/fitsdispatch.c
@@ -118,7 +118,7 @@ const NC_Dispatch *FITS_dispatch_table = NULL;
 /**
  * @internal Initialize FITS dispatch layer.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  */
 int
@@ -132,7 +132,7 @@ NC_FITS_initialize(void)
 /**
  * @internal Finalize FITS dispatch layer.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 int

--- a/src/fitsdispatch.c
+++ b/src/fitsdispatch.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @internal Dispatch code for FITS. FITS access is read-only.
+ * @brief FITS dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2026-06-28

--- a/src/fitsfile.c
+++ b/src/fitsfile.c
@@ -73,7 +73,7 @@ extern int nc4_var_list_add(NC_GRP_INFO_T *grp, const char *name, int ndims,
  * @param type_name A name for the type.
  * @param typep Pointer to a pointer that gets the TYPE_INFO_T struct.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Ed Hartnett
  */
 static int
@@ -126,8 +126,8 @@ nc4_set_var_type(nc_type xtype, int endianness, size_t type_size,
  * @param format_var_info Format-specific per-variable metadata.
  * @param var Output: pointer to the new variable.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 static int
@@ -183,8 +183,8 @@ nc4_var_list_add_full(NC_GRP_INFO_T *grp, const char *name, int ndims,
  * name string. Ignored if NULL.
  * @param endiannessp Pointer that gets the endianness. Ignored if NULL.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADTYPE Unknown BITPIX value.
+ * @return NC_NOERR No error.
+ * @return NC_EBADTYPE Unknown BITPIX value.
  * @author Edward Hartnett
  */
 #ifdef HAVE_FITS
@@ -240,8 +240,8 @@ fits_bitpix_to_nc_type(int bitpix, nc_type *xtypep, size_t *type_sizep,
  * Ignored if NULL.
  * @param endiannessp Pointer that gets endianness. Ignored if NULL.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADTYPE Unknown typecode.
+ * @return NC_NOERR No error.
+ * @return NC_EBADTYPE Unknown typecode.
  * @author Edward Hartnett
  */
 static int
@@ -343,8 +343,8 @@ fits_sanitize_name(const char *src, char *dst, size_t dstlen)
  * @param grp Pointer to the netCDF-4 group that receives the attributes.
  * @param is_table Non-zero to also skip table column descriptor keywords.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 static int
@@ -531,8 +531,8 @@ fits_read_hdu_atts(fitsfile *fptr, NC_GRP_INFO_T *grp, int is_table)
  *
  * @param h5 Pointer to the netCDF-4 file info struct.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 static int
@@ -623,7 +623,7 @@ fits_read_primary_hdu(NC_FILE_INFO_T *h5)
  * @param grp Child group to populate.
  * @param hdu_num 1-based HDU number (for NC_FITS_VAR_INFO_T).
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 static int
@@ -696,7 +696,7 @@ fits_read_image_ext_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
  * @param grp Child group to populate.
  * @param hdu_num 1-based HDU number.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 static int
@@ -868,7 +868,7 @@ fits_read_table_hdu(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *grp, int hdu_num)
  *
  * @param h5 Pointer to the netCDF-4 file info struct.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 static int
@@ -928,10 +928,10 @@ fits_read_extension_hdus(NC_FILE_INFO_T *h5)
  * @param dispatch Pointer to dispatch table.
  * @param ncid NetCDF ID assigned to this file.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EINVAL Invalid parameters or mode flags.
- * @return ::NC_EPERM Write mode requested.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_EINVAL Invalid parameters or mode flags.
+ * @return NC_EPERM Write mode requested.
+ * @return NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 int
@@ -1035,8 +1035,8 @@ NC_FITS_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
  * @param ncid NetCDF ID.
  * @param ignore Ignored.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int
@@ -1084,7 +1084,7 @@ NC_FITS_close(int ncid, void *ignore)
  *
  * @param ncid NetCDF ID.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 int
@@ -1131,7 +1131,7 @@ NC_FITS_abort(int ncid)
  * @param ncid NetCDF ID.
  * @param formatp Pointer that gets format code.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 int
@@ -1150,7 +1150,7 @@ NC_FITS_inq_format(int ncid, int *formatp)
  * @param formatp Pointer that gets format code.
  * @param modep Pointer that gets mode flags.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 int
@@ -1172,8 +1172,8 @@ NC_FITS_inq_format_extended(int ncid, int *formatp, int *modep)
  * @param memtype netCDF type.
  * @param cfitsio_type Pointer that receives the CFITSIO type constant.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADTYPE Unknown type.
+ * @return NC_NOERR No error.
+ * @return NC_EBADTYPE Unknown type.
  * @author Edward Hartnett
  */
 static int
@@ -1219,10 +1219,10 @@ nc_type_to_cfitsio_type(nc_type memtype, int *cfitsio_type)
  * @param value Output buffer.
  * @param memtype Memory type requested by caller.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid or varid.
- * @return ::NC_EINVAL Invalid parameters.
- * @return ::NC_EIO CFITSIO read error.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid or varid.
+ * @return NC_EINVAL Invalid parameters.
+ * @return NC_EIO CFITSIO read error.
  * @author Edward Hartnett
  */
 int

--- a/src/geotiffdispatch.c
+++ b/src/geotiffdispatch.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @internal Dispatch code for GeoTIFF. GeoTIFF access is read-only.
+ * @brief GeoTIFF dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2025-12-26

--- a/src/geotifffile.c
+++ b/src/geotifffile.c
@@ -152,7 +152,7 @@ geotiff_projection_to_cf_name(int ct_projection)
  * @param type_name A name for the type.
  * @param typep Pointer to a pointer that gets the TYPE_INFO_T struct.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Ed Hartnett
  */
 static int
@@ -204,8 +204,8 @@ nc4_set_var_type(nc_type xtype, int endianness, size_t type_size, char *type_nam
  * @param format_var_info Pointer to format-specific var info struct.
  * @param var Pointer in which to return a pointer to the new var.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  * @author Ed Hartnett
  */
 static int

--- a/src/geotifffile.c
+++ b/src/geotifffile.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @internal GeoTIFF file format detection and operations.
+ * @brief GeoTIFF file format detection and operations.
  *
  * This file implements GeoTIFF format detection for the NetCDF API.
  * It validates TIFF magic numbers, headers, and GeoTIFF-specific tags

--- a/src/grib2dispatch.c
+++ b/src/grib2dispatch.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * @internal Dispatch code for GRIB2. GRIB2 access is read-only.
+ * @brief GRIB2 dispatch layer.
  *
  * @author Edward Hartnett
  * @date 2026-03-08

--- a/src/grib2dispatch.c
+++ b/src/grib2dispatch.c
@@ -131,7 +131,7 @@ NC_GRIB2_initialize(void)
 /**
  * @internal Finalize GRIB2 dispatch layer.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  */
 int

--- a/src/grib2file.c
+++ b/src/grib2file.c
@@ -1,7 +1,6 @@
 /**
  * @file
- * @internal The GRIB2 file functions. These provide a read-only
- * interface to GRIB2 meteorological data files via NCEPLIBS-g2c.
+ * @brief GRIB2 file reader functions.
  *
  * @author Edward Hartnett
  * @date 2026-03-08

--- a/src/grib2file.c
+++ b/src/grib2file.c
@@ -71,8 +71,8 @@ nc4_set_var_type(nc_type xtype, int endianness, size_t type_size,
  * @param format_var_info Format-specific var info (may be NULL).
  * @param var Output: pointer to the new NC_VAR_INFO_T.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  */
 static int
 grib2_var_list_add(NC_GRP_INFO_T *grp, const char *name,
@@ -106,8 +106,8 @@ grib2_var_list_add(NC_GRP_INFO_T *grp, const char *name,
  * @param name Attribute name.
  * @param value Integer value.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  */
 static int
 grib2_add_int_att(NCindex *att_list, const char *name, int value)
@@ -134,8 +134,8 @@ grib2_add_int_att(NCindex *att_list, const char *name, int value)
  * @param name Attribute name.
  * @param value String value (not NUL-terminated in att->data per NC_CHAR convention).
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  */
 static int
 grib2_add_str_att(NCindex *att_list, const char *name, const char *value)
@@ -163,8 +163,8 @@ grib2_add_str_att(NCindex *att_list, const char *name, const char *value)
  * @param name Attribute name.
  * @param value Float value.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
  */
 static int
 grib2_add_float_att(NCindex *att_list, const char *name, float value)
@@ -199,10 +199,10 @@ ILLEGAL_OPEN_FLAGS = (NC_MMAP|NC_64BIT_OFFSET|NC_DISKLESS|NC_WRITE);
  * @param dispatch Pointer to dispatch table.
  * @param ncid NetCDF ID assigned to this file.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EINVAL Invalid parameters or mode flags.
- * @return ::NC_ENOTNC File is not a valid GRIB2 file.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_EINVAL Invalid parameters or mode flags.
+ * @return NC_ENOTNC File is not a valid GRIB2 file.
+ * @return NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  */
 int
@@ -511,8 +511,8 @@ NC_GRIB2_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
  *
  * @param ncid NetCDF ID.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int
@@ -527,8 +527,8 @@ NC_GRIB2_abort(int ncid)
  * @param ncid NetCDF ID.
  * @param ignore Ignored.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  */
 int
@@ -568,7 +568,7 @@ NC_GRIB2_close(int ncid, void *ignore)
  * @param ncid NetCDF ID.
  * @param formatp Pointer that gets format code.
  *
- * @return ::NC_ENOTBUILT GRIB2 support not yet implemented.
+ * @return NC_ENOTBUILT GRIB2 support not yet implemented.
  * @author Edward Hartnett
  */
 int
@@ -587,7 +587,7 @@ NC_GRIB2_inq_format(int ncid, int *formatp)
  * @param formatp Pointer that gets format code.
  * @param modep Pointer that gets mode flags.
  *
- * @return ::NC_ENOTBUILT GRIB2 support not yet implemented.
+ * @return NC_ENOTBUILT GRIB2 support not yet implemented.
  * @author Edward Hartnett
  */
 int
@@ -611,10 +611,10 @@ NC_GRIB2_inq_format_extended(int ncid, int *formatp, int *modep)
  * @param value Pointer to buffer for the read data.
  * @param memtype Memory type for the data.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_ENOMEM Out of memory.
- * @return ::NC_EHDFERR Error from g2c or g2_getfld.
- * @return ::NC_EINVALCOORDS start/count exceeds dimension bounds.
+ * @return NC_NOERR No error.
+ * @return NC_ENOMEM Out of memory.
+ * @return NC_EHDFERR Error from g2c or g2_getfld.
+ * @return NC_EINVALCOORDS start/count exceeds dimension bounds.
  * @author Edward Hartnett
  */
 int

--- a/src/pds4dispatch.c
+++ b/src/pds4dispatch.c
@@ -123,8 +123,8 @@ const NC_Dispatch *PDS4_dispatch_table = NULL;
  * been registered via `.ncrc` autoload; in that case `NC_EINVAL` is
  * returned and can be ignored.
  *
- * @return ::NC_NOERR Handler registered successfully.
- * @return ::NC_EINVAL Handler already registered (safe to ignore).
+ * @return NC_NOERR Handler registered successfully.
+ * @return NC_EINVAL Handler already registered (safe to ignore).
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -141,7 +141,7 @@ NC_PDS4_initialize(void)
  *
  * No-op in the current implementation.
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  * @date 2026-07-08
  */

--- a/src/pds4dispatch.c
+++ b/src/pds4dispatch.c
@@ -116,10 +116,17 @@ static const NC_Dispatch PDS4_dispatcher = {
 const NC_Dispatch *PDS4_dispatch_table = NULL;
 
 /**
- * @internal Initialize PDS4 dispatch layer.
+ * Initialize the PDS4 dispatch layer.
  *
- * @return ::NC_NOERR on success.
+ * Registers the PDS4 dispatch table for UDF slot 5 via
+ * `nc_def_user_format()`. Safe to call when the handler has already
+ * been registered via `.ncrc` autoload; in that case `NC_EINVAL` is
+ * returned and can be ignored.
+ *
+ * @return ::NC_NOERR Handler registered successfully.
+ * @return ::NC_EINVAL Handler already registered (safe to ignore).
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_initialize(void)
@@ -130,10 +137,13 @@ NC_PDS4_initialize(void)
 }
 
 /**
- * @internal Finalize PDS4 dispatch layer.
+ * Finalize the PDS4 dispatch layer.
+ *
+ * No-op in the current implementation.
  *
  * @return ::NC_NOERR No error.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_finalize(void)

--- a/src/pds4file.c
+++ b/src/pds4file.c
@@ -204,7 +204,7 @@ pds4_att_exists(NCindex *list, const char *name)
  * @param name Attribute name.
  * @param value Attribute string value.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -244,8 +244,8 @@ pds4_add_att(NCindex *list, const char *name, const char *value)
  * @param endiannessp Pointer that gets the endianness.
  * @param type_name Buffer (at least NC_MAX_NAME+1 bytes) that gets the type name.
  *
- * @return ::NC_NOERR on success.
- * @return ::NC_EBADTYPE if the type is unknown.
+ * @return NC_NOERR on success.
+ * @return NC_EBADTYPE if the type is unknown.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -335,7 +335,7 @@ pds4_type_to_nc_type(const char *pds4_type, nc_type *xtypep, size_t *type_sizep,
  * @param type_name Type name.
  * @param typep Pointer that gets the TYPE_INFO_T struct.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -366,7 +366,7 @@ pds4_set_var_type(nc_type xtype, int endianness, size_t type_size,
  * @param grp Group to receive attributes.
  * @param area XML area element.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -408,7 +408,7 @@ pds4_add_area_atts(NC_GRP_INFO_T *grp, xmlNode *area)
  * @param grp Group to receive attributes.
  * @param node XML node to examine.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -490,7 +490,7 @@ pds4_axis_cmp(const void *a, const void *b)
  * @param grp File-area group that will contain the variable.
  * @param array XML `Array` or `Array_2D_Image` element.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -718,7 +718,7 @@ cleanup:
  * @param grp File-area group that will contain the dimension and variables.
  * @param table XML `Table_Binary`, `Table_Character`, or `Table_Delimited` element.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1059,7 +1059,7 @@ pds4_read_table(NC_GRP_INFO_T *grp, xmlNode *table)
  * @param root_grp Root group.
  * @param file_area XML `File_Area_Observational` element.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1141,7 +1141,7 @@ pds4_read_file_area(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *root_grp,
  * @param h5 Pointer to the file info struct.
  * @param pds4_file PDS4-specific file info containing the parsed XML document.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1202,11 +1202,11 @@ pds4_read_label(NC_FILE_INFO_T *h5, NC_PDS4_FILE_INFO_T *pds4_file)
  * @param dispatch Dispatch table pointer assigned by NetCDF-C.
  * @param ncid NetCDF ID assigned by the NetCDF-C dispatch layer.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EINVAL Null path, XML parse failure, or non-PDS4 namespace.
- * @return ::NC_EPERM Write mode requested.
- * @return ::NC_ENOTNC Root element namespace is not the PDS4 namespace.
- * @return ::NC_ENOMEM Out of memory.
+ * @return NC_NOERR No error.
+ * @return NC_EINVAL Null path, XML parse failure, or non-PDS4 namespace.
+ * @return NC_EPERM Write mode requested.
+ * @return NC_ENOTNC Root element namespace is not the PDS4 namespace.
+ * @return NC_ENOMEM Out of memory.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1343,8 +1343,8 @@ pds4_free_var_info(NC_GRP_INFO_T *grp)
  * @param ncid NetCDF ID of the open PDS4 file.
  * @param ignore Ignored (NULL).
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1395,8 +1395,8 @@ NC_PDS4_close(int ncid, void *ignore)
  *
  * @param ncid NetCDF ID of the partially opened file.
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1438,7 +1438,7 @@ NC_PDS4_abort(int ncid)
  * @param ncid NetCDF ID.
  * @param formatp Pointer that receives the format code (NC_FORMAT_NETCDF4).
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1459,7 +1459,7 @@ NC_PDS4_inq_format(int ncid, int *formatp)
  *        (NC_FORMATX_NC_PDS4 = NC_FORMATX_UDF5).
  * @param modep Pointer that receives the mode flags (NC_NOWRITE).
  *
- * @return ::NC_NOERR No error.
+ * @return NC_NOERR No error.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1481,7 +1481,7 @@ NC_PDS4_inq_format_extended(int ncid, int *formatp, int *modep)
  * @param data_filename Data file name from <File/file_name>.
  * @param resolved Buffer (at least PATH_MAX bytes) to receive result.
  *
- * @return ::NC_NOERR on success.
+ * @return NC_NOERR on success.
  * @author Edward Hartnett
  * @date 2026-07-08
  */
@@ -1578,12 +1578,12 @@ pds4_needs_swap(int endianness)
  * @param memtype Requested memory type (type conversion not yet implemented;
  *        caller must request the native file type).
  *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
- * @return ::NC_ENOTVAR No variable with varid in this group.
- * @return ::NC_EINVAL Invalid parameters or seek error.
- * @return ::NC_ENOMEM Out of memory.
- * @return ::NC_ENOTFOUND Data file not found.
+ * @return NC_NOERR No error.
+ * @return NC_EBADID Bad ncid.
+ * @return NC_ENOTVAR No variable with varid in this group.
+ * @return NC_EINVAL Invalid parameters or seek error.
+ * @return NC_ENOMEM Out of memory.
+ * @return NC_ENOTFOUND Data file not found.
  * @author Edward Hartnett
  * @date 2026-07-08
  */

--- a/src/pds4file.c
+++ b/src/pds4file.c
@@ -13,6 +13,48 @@
  * - Table_Character (fixed-record, ASCII fields)
  * - Table_Delimited (variable-record, ASCII fields)
  *
+ * @section pds4_model netCDF Model Mapping
+ *
+ * A PDS4 label file contains one or more `File_Area_Observational` elements,
+ * each referencing a separate binary or ASCII data file. The NEP PDS4 reader
+ * maps the label structure into the netCDF-4 in-memory model as follows:
+ *
+ * - The XML label root → root group. Elements of `Identification_Area` and
+ *   `Observation_Area` become global string attributes on the root group.
+ * - Each `File_Area_Observational` → a child group of the root group, named
+ *   from the `File/file_name` text content.
+ * - `Array` / `Array_2D_Image` inside a file area → netCDF dimensions created
+ *   from the `Axis_Array` children (sorted ascending by `sequence_number`);
+ *   each `axis_name` becomes the dimension name and `elements` its length;
+ *   `Last Index Fastest` maps to C-order (fastest-varying index is rightmost).
+ *   The array becomes a single netCDF variable in the child group, with type
+ *   derived from `Element_Array/data_type`.
+ * - `Table_Binary`, `Table_Character`, `Table_Delimited` → a `record`
+ *   dimension whose length comes from `<records>`; one netCDF variable per
+ *   `Field_Binary`/`Field_Character`/`Field_Delimited` child, named from
+ *   `<name>`, typed from `<data_type>`, with an optional `units` attribute
+ *   from `<unit>`.
+ *
+ * @section pds4_byteorder Byte-Order Handling
+ *
+ * PDS4 specifies byte order per data object: MSB (Most Significant Byte
+ * first, big-endian) or LSB (Least Significant Byte first, little-endian).
+ * NEP records the byte order as `NC_ENDIAN_BIG` or `NC_ENDIAN_LITTLE` on
+ * each netCDF variable at open time. During data reading in
+ * NC_PDS4_get_vara(), elements are byte-swapped in-place when the file
+ * byte order differs from the host byte order. ASCII numeric fields
+ * (Table_Character, Table_Delimited) do not require byte-swapping; they are
+ * parsed directly via `strtod()` or `strtoll()`.
+ *
+ * @section pds4_datapath Data File Resolution
+ *
+ * Binary and text data files are referenced by filename only in the PDS4
+ * label (the `File/file_name` element). NEP resolves each data filename
+ * relative to the directory that contains the XML label file, using
+ * pds4_resolve_data_path(). If the label has no directory component (i.e.
+ * it is in the current directory), the data file is also looked up in the
+ * current directory.
+ *
  * @author Edward Hartnett
  * @date 2026-07-08
  * @copyright Intelligent Data Design, Inc. All rights reserved.
@@ -44,6 +86,7 @@
  *
  * @return Pointer to newly allocated trimmed string, or NULL on failure.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static char *
 pds4_trim(const char *s)
@@ -83,6 +126,7 @@ pds4_trim(const char *s)
  *
  * @return Newly allocated trimmed text, or NULL if the node has no text.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static char *
 pds4_get_text(xmlNode *node)
@@ -110,6 +154,7 @@ pds4_get_text(xmlNode *node)
  *
  * @return Pointer to the child element, or NULL if not found.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static xmlNode *
 pds4_find_child(xmlNode *parent, const char *name)
@@ -134,6 +179,7 @@ pds4_find_child(xmlNode *parent, const char *name)
  *
  * @return 1 if it exists, 0 otherwise.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_att_exists(NCindex *list, const char *name)
@@ -160,6 +206,7 @@ pds4_att_exists(NCindex *list, const char *name)
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_add_att(NCindex *list, const char *name, const char *value)
@@ -200,6 +247,7 @@ pds4_add_att(NCindex *list, const char *name, const char *value)
  * @return ::NC_NOERR on success.
  * @return ::NC_EBADTYPE if the type is unknown.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_type_to_nc_type(const char *pds4_type, nc_type *xtypep, size_t *type_sizep,
@@ -289,6 +337,7 @@ pds4_type_to_nc_type(const char *pds4_type, nc_type *xtypep, size_t *type_sizep,
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_set_var_type(nc_type xtype, int endianness, size_t type_size,
@@ -319,6 +368,7 @@ pds4_set_var_type(nc_type xtype, int endianness, size_t type_size,
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_add_area_atts(NC_GRP_INFO_T *grp, xmlNode *area)
@@ -360,6 +410,7 @@ pds4_add_area_atts(NC_GRP_INFO_T *grp, xmlNode *area)
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_add_leaf_atts(NC_GRP_INFO_T *grp, xmlNode *node)
@@ -441,6 +492,7 @@ pds4_axis_cmp(const void *a, const void *b)
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_read_array(NC_GRP_INFO_T *grp, xmlNode *array)
@@ -668,6 +720,7 @@ cleanup:
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_read_table(NC_GRP_INFO_T *grp, xmlNode *table)
@@ -1008,6 +1061,7 @@ pds4_read_table(NC_GRP_INFO_T *grp, xmlNode *table)
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_read_file_area(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *root_grp,
@@ -1089,6 +1143,7 @@ pds4_read_file_area(NC_FILE_INFO_T *h5, NC_GRP_INFO_T *root_grp,
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_read_label(NC_FILE_INFO_T *h5, NC_PDS4_FILE_INFO_T *pds4_file)
@@ -1132,28 +1187,28 @@ pds4_read_label(NC_FILE_INFO_T *h5, NC_PDS4_FILE_INFO_T *pds4_file)
 #endif /* HAVE_PDS4 */
 
 /**
- * @internal Open a PDS4 XML label file.
+ * Open a PDS4 XML label file.
  *
- * Validates that the file begins with the XML declaration, parses the
- * XML label with libxml2, confirms the root element belongs to the PDS4
- * namespace, and stores the document pointer in per-file state.
- *
- * In Sprint 4 the parsed label is also converted into netCDF-4 metadata
- * (groups, dimensions, variables, attributes). Data reading is still disabled.
+ * Parses the PDS4 XML label with libxml2, validates the root element
+ * namespace, and maps the label content into the netCDF-4 in-memory
+ * model (root-group attributes, child groups, dimensions, variables).
+ * Only read-only access (NC_NOWRITE) is supported.
  *
  * @param path Path to the PDS4 XML label file.
- * @param mode Open mode flags.
- * @param basepe Ignored.
+ * @param mode Open mode flags; NC_WRITE causes NC_EPERM to be returned.
+ * @param basepe Ignored (present for dispatch interface compatibility).
  * @param chunksizehintp Ignored.
  * @param parameters Ignored.
- * @param dispatch Dispatch table pointer.
- * @param ncid NetCDF ID assigned by the dispatch layer.
+ * @param dispatch Dispatch table pointer assigned by NetCDF-C.
+ * @param ncid NetCDF ID assigned by the NetCDF-C dispatch layer.
  *
  * @return ::NC_NOERR No error.
- * @return ::NC_EINVAL Invalid parameters or not a PDS4 label.
+ * @return ::NC_EINVAL Null path, XML parse failure, or non-PDS4 namespace.
  * @return ::NC_EPERM Write mode requested.
+ * @return ::NC_ENOTNC Root element namespace is not the PDS4 namespace.
  * @return ::NC_ENOMEM Out of memory.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
@@ -1251,16 +1306,6 @@ NC_PDS4_open(const char *path, int mode, int basepe, size_t *chunksizehintp,
 }
 
 /**
- * @internal Close a PDS4 file.
- *
- * @param ncid NetCDF ID.
- * @param ignore Ignored.
- *
- * @return ::NC_NOERR No error.
- * @return ::NC_EBADID Bad ncid.
- * @author Edward Hartnett
- */
-/**
  * @internal Free format_var_info for all variables in a group and its
  * subgroups.
  */
@@ -1289,6 +1334,20 @@ pds4_free_var_info(NC_GRP_INFO_T *grp)
     }
 }
 
+/**
+ * Close a PDS4 file.
+ *
+ * Frees per-variable layout info, the parsed XML document, and the
+ * per-file PDS4 state struct.
+ *
+ * @param ncid NetCDF ID of the open PDS4 file.
+ * @param ignore Ignored (NULL).
+ *
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @author Edward Hartnett
+ * @date 2026-07-08
+ */
 int
 NC_PDS4_close(int ncid, void *ignore)
 {
@@ -1329,12 +1388,17 @@ NC_PDS4_close(int ncid, void *ignore)
 }
 
 /**
- * @internal Abort opening a PDS4 file.
+ * Abort opening a PDS4 file.
  *
- * @param ncid NetCDF ID.
+ * Releases all resources allocated during a partial open, including the
+ * parsed XML document and per-file PDS4 state.
+ *
+ * @param ncid NetCDF ID of the partially opened file.
  *
  * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_abort(int ncid)
@@ -1369,13 +1433,14 @@ NC_PDS4_abort(int ncid)
 }
 
 /**
- * @internal Inquire the format of a PDS4 file.
+ * Inquire the format of a PDS4 file.
  *
  * @param ncid NetCDF ID.
- * @param formatp Pointer that gets format code.
+ * @param formatp Pointer that receives the format code (NC_FORMAT_NETCDF4).
  *
  * @return ::NC_NOERR No error.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_inq_format(int ncid, int *formatp)
@@ -1387,14 +1452,16 @@ NC_PDS4_inq_format(int ncid, int *formatp)
 }
 
 /**
- * @internal Inquire the extended format of a PDS4 file.
+ * Inquire the extended format of a PDS4 file.
  *
  * @param ncid NetCDF ID.
- * @param formatp Pointer that gets format code.
- * @param modep Pointer that gets mode flags.
+ * @param formatp Pointer that receives the extended format code
+ *        (NC_FORMATX_NC_PDS4 = NC_FORMATX_UDF5).
+ * @param modep Pointer that receives the mode flags (NC_NOWRITE).
  *
  * @return ::NC_NOERR No error.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_inq_format_extended(int ncid, int *formatp, int *modep)
@@ -1416,6 +1483,7 @@ NC_PDS4_inq_format_extended(int ncid, int *formatp, int *modep)
  *
  * @return ::NC_NOERR on success.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_resolve_data_path(const char *label_path, const char *data_filename,
@@ -1450,6 +1518,7 @@ pds4_resolve_data_path(const char *label_path, const char *data_filename,
  * @param nelems Number of elements.
  *
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static void
 pds4_byte_swap(void *buf, size_t elem_size, size_t nelems)
@@ -1475,6 +1544,8 @@ pds4_byte_swap(void *buf, size_t elem_size, size_t nelems)
  * @param endianness Variable endianness (NC_ENDIAN_BIG or NC_ENDIAN_LITTLE).
  *
  * @return 1 if swapping needed, 0 otherwise.
+ * @author Edward Hartnett
+ * @date 2026-07-08
  */
 static int
 pds4_needs_swap(int endianness)
@@ -1490,19 +1561,31 @@ pds4_needs_swap(int endianness)
 }
 
 /**
- * @internal Read a hyperslab of data from a PDS4 variable.
+ * Read a hyperslab of data from a PDS4 variable.
  *
- * Supports contiguous array reads and fixed-record table field reads.
+ * Reads contiguous array data or fixed-record table field data from the
+ * binary or ASCII data file referenced by the PDS4 label. Array reads
+ * honor the `start`/`count` hyperslab in C (row-major) order. Table
+ * field reads iterate over records `start[0]` through
+ * `start[0]+count[0]-1`. Byte-order conversion is applied automatically
+ * for binary types; ASCII fields are parsed via `strtod()`/`strtoll()`.
  *
- * @param ncid NetCDF ID.
- * @param varid Variable ID.
- * @param start Start indices.
- * @param count Counts.
- * @param value Output buffer.
- * @param memtype Memory type.
+ * @param ncid NetCDF ID of the group containing the variable.
+ * @param varid Variable ID within the group.
+ * @param start Array of start indices (0-based) for each dimension.
+ * @param count Number of elements to read along each dimension.
+ * @param value Output buffer large enough to hold the requested elements.
+ * @param memtype Requested memory type (type conversion not yet implemented;
+ *        caller must request the native file type).
  *
- * @return ::NC_NOERR on success.
+ * @return ::NC_NOERR No error.
+ * @return ::NC_EBADID Bad ncid.
+ * @return ::NC_ENOTVAR No variable with varid in this group.
+ * @return ::NC_EINVAL Invalid parameters or seek error.
+ * @return ::NC_ENOMEM Out of memory.
+ * @return ::NC_ENOTFOUND Data file not found.
  * @author Edward Hartnett
+ * @date 2026-07-08
  */
 int
 NC_PDS4_get_vara(int ncid, int varid, const size_t *start, const size_t *count,


### PR DESCRIPTION
…pds4dispatch.h and pds4file.c

- Add PDS4 File Reader section to docs/mainpage.md with overview, netCDF model mapping, data reading details, build configuration, and C API usage example
- Update docs/prd.md: add §14.3 netCDF Model Mapping table, §14.4 Public API section with NC_PDS4_VAR_INFO_T field descriptions, §14.7 UDF Slot table; expand §14.8 Known Limitations; remove "Sprint 3 skeleton" language
- Update docs/roadmap.md: add v