### PR TITLE
Move v2.4.0 Spack sprints 2-6 to new v2.5.0 section and retain v2.4.0…

### DIFF
--- a/docs/releases/v1.5.1-announcement.txt
+++ b/docs/releases/v1.5.1-announcement.txt
@@ -1,0 +1,93 @@
+Subject: [ANN] NEP v1.5.1 Released - NetCDF Example Programs
+
+Dear NetCDF Community,
+
+We are pleased to announce the release of NEP (NetCDF Extension Pack) version 1.5.1, which adds comprehensive NetCDF example programs to help users learn and master the NetCDF API.
+
+## What's New in v1.5.1
+
+This release integrates 22 example programs demonstrating NetCDF programming patterns in both C and Fortran, covering classic NetCDF and NetCDF-4 features. All examples include automated output validation and are fully integrated into the build system.
+
+### Example Programs Included
+
+**C Classic Examples (6 programs):**
+- Basic 2D arrays and coordinate variables
+- NetCDF format variants (classic, 64-bit offset, CDF-5)
+- Size limits and unlimited dimensions
+- Multi-dimensional (4D) variables
+
+**C NetCDF-4 Examples (5 programs):**
+- NetCDF-4/HDF5 format basics
+- Compression filters (deflate, shuffle)
+- Chunking strategies and performance optimization
+- Multiple unlimited dimensions
+- User-defined types (compound, vlen, enum, opaque)
+
+**Fortran Examples (11 programs):**
+- Complete Fortran equivalents of all C examples
+- Identical output for cross-language learning
+- Demonstrates Fortran 90+ NetCDF API
+
+### Key Features
+
+- **Automated Testing**: All examples run as automated tests with CDL-based output validation
+- **Learning Paths**: Structured progression from beginner to advanced topics
+- **Comprehensive Documentation**: Doxygen-integrated with detailed explanations
+- **Build Integration**: Examples build by default, can be disabled with `-DBUILD_EXAMPLES=OFF` (CMake) or `--disable-examples` (Autotools)
+- **CI Validation**: Examples tested automatically in GitHub Actions
+
+### Building Examples
+
+CMake:
+```
+cmake -B build -DBUILD_EXAMPLES=ON
+cmake --build build
+ctest --test-dir build
+```
+
+Autotools:
+```
+./configure --enable-examples
+make
+make check
+```
+
+Fortran examples require NetCDF-Fortran library and are automatically skipped if unavailable.
+
+## About NEP
+
+NEP (NetCDF Extension Pack) extends NetCDF-4 with:
+- High-performance compression (LZ4, BZIP2)
+- CDF file reader (NASA Common Data Format)
+- GeoTIFF file reader (geospatial raster data)
+- Now: Comprehensive example programs
+
+## Download and Documentation
+
+- **GitHub**: https://github.com/Intelligent-Data-Design-Inc/NEP
+- **Release Notes**: https://github.com/Intelligent-Data-Design-Inc/NEP/blob/main/docs/releases/v1.5.1.md
+- **Documentation**: https://intelligent-data-design-inc.github.io/NEP/
+
+## Installation
+
+NEP requires NetCDF-C v4.9+ and HDF5 v1.12+. Install via:
+
+**From Source:**
+```
+git clone https://github.com/Intelligent-Data-Design-Inc/NEP.git
+cd NEP
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr/local
+cmake --build build
+cmake --install build
+```
+
+## Feedback
+
+We welcome feedback, bug reports, and contributions. Please visit our GitHub repository to report issues or submit pull requests.
+
+Thank you for your continued support of the NetCDF ecosystem!
+
+Best regards,
+Ed Hartnett
+Intelligent Data Design, Inc.
+https://github.com/Intelligent-Data-Design-Inc/NEP

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -1,0 +1,119 @@
+# NEP v2.4.0 - Spack Improvements and CMake Option Hygiene
+
+> Adds Spack release packaging for v2.3.0, aligns all project-specific CMake options under a consistent `NEP_` prefix, and tightens the netcdf-c dependency to >= 4.10.1 across both Spack and CI.
+
+---
+
+## Highlights
+
+- **Spack v2.3.0 Release Packaged** (#264) — `spack/NEP/package.py` now ships `version("2.3.0", ...)` with the correct SHA256, making the latest stable release installable via `spack install nep@2.3.0`
+- **`NEP_` Prefix for All CMake Options** (#265) — Thirteen project-specific CMake options renamed from unprefixed names (e.g., `ENABLE_FITS`) to namespaced equivalents (e.g., `NEP_ENABLE_FITS`), eliminating collision risk in super-build and subdirectory usage
+- **Spack `cmake_args` Corrected** (#264, #265) — `define_from_variant` calls in `package.py` now emit the new `NEP_*` option names so variant choices (`+fits`, `+lz4`, etc.) propagate correctly to CMake
+- **CI Workflows Updated** (#266) — All five GitHub Actions workflows (`ci.yml`, `ci-fits.yml`, `ci-formats.yml`, `ci-parallel.yml`, `geotiff-test.yml`) updated to the renamed option names; no CI changes required for Autotools (unchanged)
+
+---
+
+## Features
+
+### Spack Foundation — Version 2.3.0 and Dependency Alignment (#264)
+
+- **`spack/NEP/package.py`**: added `version("2.3.0", sha256="ce6eb7640a44e4b068af4beef3a1b7c5a4772666fbea73db34d81d71b4144dde", url=...)` — v2.3.0 is the earliest supported Spack release
+- Updated package description from compression-only to full multi-format reader (`GeoTIFF`, `GRIB2`, `FITS`, `NASA CDF`, `PDS4`)
+- Bumped `depends_on("netcdf-c@4.10.1:")` from `4.10:` to align with the build-system minimum established in v2.3.0 Sprint 2
+- **`.github/workflows/spack.yml`**: added `nep@2.3.0~docs~fortran` install step alongside `nep@develop` so both pinned release and latest main are exercised in CI
+- Added `BUILD_LZ4` and `BUILD_BZIP2` to `cmake_args()` via `define_from_variant` so those variant choices propagate to CMake
+
+### CMake Option `NEP_` Prefix Rename (#265)
+
+All thirteen project-specific CMake options renamed; `BUILD_TESTING` and `DEBUG` intentionally left unprefixed:
+
+| Old name | New name |
+|---|---|
+| `ENABLE_FORTRAN` | `NEP_ENABLE_FORTRAN` |
+| `BUILD_LZ4` | `NEP_BUILD_LZ4` |
+| `BUILD_BZIP2` | `NEP_BUILD_BZIP2` |
+| `BUILD_DOCUMENTATION` | `NEP_BUILD_DOCUMENTATION` |
+| `BUILD_EXAMPLES` | `NEP_BUILD_EXAMPLES` |
+| `ENABLE_CDF` | `NEP_ENABLE_CDF` |
+| `ENABLE_GEOTIFF` | `NEP_ENABLE_GEOTIFF` |
+| `ENABLE_FITS` | `NEP_ENABLE_FITS` |
+| `ENABLE_PDS4` | `NEP_ENABLE_PDS4` |
+| `ENABLE_GRIB2` | `NEP_ENABLE_GRIB2` |
+| `ENABLE_PARALLEL_TESTS` | `NEP_ENABLE_PARALLEL_TESTS` |
+| `ENABLE_BENCHMARKS` | `NEP_ENABLE_BENCHMARKS` |
+| `ENABLE_OPENDAP_EXAMPLES` | `NEP_ENABLE_OPENDAP_EXAMPLES` |
+
+- `CMakeLists.txt`: every `option()` declaration, `if()` guard, and `configure_file` mapping updated
+- Internal `config.h.cmake.in` macros (`BUILD_LZ4`, `BUILD_BZIP2`, `HAVE_*`) left unchanged — source code references these directly
+- Old unprefixed names removed with no deprecated aliases; all in-repo callers updated in the same sprint
+
+---
+
+## Bug Fixes
+
+None.
+
+---
+
+## API Changes
+
+None.
+
+---
+
+## Build System
+
+- All thirteen NEP-specific CMake options now carry the `NEP_` prefix (#265)
+- `spack/NEP/package.py` `cmake_args` emits `NEP_BUILD_DOCUMENTATION`, `NEP_BUILD_LZ4`, `NEP_BUILD_BZIP2`, `NEP_ENABLE_FORTRAN`, `NEP_ENABLE_FITS` (#264, #265)
+- `depends_on("netcdf-c@4.10.1:")` in `spack/NEP/package.py` (#264)
+- CI workflows use renamed options throughout; Autotools `--enable-*` / `--disable-*` flags unchanged (#266)
+
+---
+
+## Testing
+
+- Existing CI configure/build/test matrix exercises the renamed CMake options through normal jobs; no new test programs required (#265)
+- **Spack CI** (`spack.yml`): both `nep@develop` and `nep@2.3.0~docs~fortran` install steps now run in CI (#264)
+
+---
+
+## Documentation
+
+- `docs/plan/v2.4.0-sprint1-spack-foundation.md`: detailed sprint plan for Spack foundation work
+- `docs/plan/v2.4.0-sprint1.5-fix-cmake-options.md`: detailed sprint plan for CMake option rename
+- `README.md`: build options table and example `cmake` commands updated to `NEP_*` names
+- `nep_skill.md`: configure example and options table updated
+- `.devin/rules/local-build-command.md`: example configure commands updated
+- `test_cdf/README.md`: `ENABLE_CDF` reference updated to `NEP_ENABLE_CDF`
+- `docs/roadmap.md`: v2.4.0 sprints expanded; v1.x roadmap history archived to `docs/roadmap_v1x.md`
+
+---
+
+## Dependencies
+
+- **netcdf-c** >= 4.10.1 required (unchanged from v2.3.0; now also enforced in Spack package)
+- No new library dependencies
+
+---
+
+## Known Limitations
+
+- `nc_get_vars()` and `nc_get_varm()` rely on default dispatch fallbacks (no strided native reads)
+- PDS4: `Table_Delimited` row-count derived from label `<records>` only
+- Grouped fields (`Group_Field_Binary`, etc.) and bit fields not yet supported in PDS4 reader
+
+---
+
+## Breaking Changes
+
+- **All project-specific CMake options have been renamed** with a `NEP_` prefix. Any downstream `cmake` invocation or CMake cache using the old names (e.g., `-DENABLE_FITS=ON`) must be updated to the new names (e.g., `-DNEP_ENABLE_FITS=ON`). No deprecated aliases are provided.
+
+---
+
+## Release Summary
+
+- **Released**: 2026-07-11
+- **Scope**: v2.4.0 — Spack Improvements and CMake Option Hygiene
+- **Issues**: #265
+- **Pull Requests**: #264, #266
+- **Contributors**: captainkirk99 (Edward Hartnett)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,38 @@
 # NEP Development Roadmap
+### V2.5.0 More Spack Improvements
+#### Sprint 2: GeoTIFF Variant
+- Add variant `geotiff` (default off).
+- Add `depends_on("libgeotiff", when="+geotiff")` and `depends_on("libtiff", when="+geotiff")`.
+- Pass `NEP_ENABLE_GEOTIFF` in `cmake_args`.
+- **Testing**: Add `spack spec -I nep@2.3.0+geotiff` to spec job; add `spack install -v nep@2.3.0+geotiff~docs~fortran` to install job.
+
+#### Sprint 3: GRIB2 Variant
+- Add variant `grib2` (default off).
+- Add appropriate spack dependency for g2c/GRIB2.
+- Pass `NEP_ENABLE_GRIB2` in `cmake_args`.
+- **Testing**: Add `spack spec -I nep@2.3.0+grib2` to spec job; add `spack install -v nep@2.3.0+grib2~docs~fortran` to install job.
+
+#### Sprint 4: CDF Variant
+- Add variant `cdf` (default off).
+- Add `depends_on("cdf", when="+cdf")` — references the in-repo `spack/cdf/package.py`.
+- Pass `NEP_ENABLE_CDF` in `cmake_args`.
+- Update `spack/cdf/package.py` as needed to work as a dependency.
+- **Testing**: Add `spack spec -I nep@2.3.0+cdf` to spec job; add `spack install -v nep@2.3.0+cdf~docs~fortran` to install job. Consider merging `spack-cdf.yml` into `spack.yml` since CDF becomes a transitive dependency.
+
+#### Sprint 5: PDS4 + Parallel + Remaining Variants
+- Add variants: `pds4`, `parallel`, `examples`, `benchmarks`.
+- Add deps: `libxml2` (pds4), `mpi` (parallel).
+- Pass all remaining `NEP_ENABLE_*` / `NEP_BUILD_*` flags in `cmake_args`.
+- When `+parallel`, adjust `hdf5` dep to `+mpi`.
+- **Testing**: Add `spack spec -I nep@2.3.0+pds4` and `spack spec -I nep@2.3.0+parallel` to spec job; add `spack install -v nep@2.3.0+pds4~docs~fortran` to install job. Parallel install-test optional (requires MPI).
+
+#### Sprint 6: Polish, CI, and Integration Testing
+- Add `conflicts()` for known incompatibilities.
+- Add spack CI smoke test or documentation.
+- Verify full `spack install nep +geotiff +grib2 +cdf +fits +pds4` resolves and builds.
+- Update `README.md` spack installation instructions.
+- **Testing**: All-variants spec check: `spack spec -I nep@2.3.0+geotiff+grib2+cdf+fits+pds4+fortran+docs`. Full install with all format variants enabled. Verify `spack spec` correctly rejects invalid combinations from `conflicts()` declarations.
+
 
 ### V2.4.0 Spack Improvements
 
@@ -38,38 +72,6 @@
 
 **GitHub Issue:** #265
 
-#### Sprint 2: GeoTIFF Variant
-- Add variant `geotiff` (default off).
-- Add `depends_on("libgeotiff", when="+geotiff")` and `depends_on("libtiff", when="+geotiff")`.
-- Pass `NEP_ENABLE_GEOTIFF` in `cmake_args`.
-- **Testing**: Add `spack spec -I nep@2.3.0+geotiff` to spec job; add `spack install -v nep@2.3.0+geotiff~docs~fortran` to install job.
-
-#### Sprint 3: GRIB2 Variant
-- Add variant `grib2` (default off).
-- Add appropriate spack dependency for g2c/GRIB2.
-- Pass `NEP_ENABLE_GRIB2` in `cmake_args`.
-- **Testing**: Add `spack spec -I nep@2.3.0+grib2` to spec job; add `spack install -v nep@2.3.0+grib2~docs~fortran` to install job.
-
-#### Sprint 4: CDF Variant
-- Add variant `cdf` (default off).
-- Add `depends_on("cdf", when="+cdf")` — references the in-repo `spack/cdf/package.py`.
-- Pass `NEP_ENABLE_CDF` in `cmake_args`.
-- Update `spack/cdf/package.py` as needed to work as a dependency.
-- **Testing**: Add `spack spec -I nep@2.3.0+cdf` to spec job; add `spack install -v nep@2.3.0+cdf~docs~fortran` to install job. Consider merging `spack-cdf.yml` into `spack.yml` since CDF becomes a transitive dependency.
-
-#### Sprint 5: PDS4 + Parallel + Remaining Variants
-- Add variants: `pds4`, `parallel`, `examples`, `benchmarks`.
-- Add deps: `libxml2` (pds4), `mpi` (parallel).
-- Pass all remaining `NEP_ENABLE_*` / `NEP_BUILD_*` flags in `cmake_args`.
-- When `+parallel`, adjust `hdf5` dep to `+mpi`.
-- **Testing**: Add `spack spec -I nep@2.3.0+pds4` and `spack spec -I nep@2.3.0+parallel` to spec job; add `spack install -v nep@2.3.0+pds4~docs~fortran` to install job. Parallel install-test optional (requires MPI).
-
-#### Sprint 6: Polish, CI, and Integration Testing
-- Add `conflicts()` for known incompatibilities.
-- Add spack CI smoke test or documentation.
-- Verify full `spack install nep +geotiff +grib2 +cdf +fits +pds4` resolves and builds.
-- Update `README.md` spack installation instructions.
-- **Testing**: All-variants spec check: `spack spec -I nep@2.3.0+geotiff+grib2+cdf+fits+pds4+fortran+docs`. Full install with all format variants enabled. Verify `spack spec` correctly rejects invalid combinations from `conflicts()` declarations.
 
 ### V2.3.0 Documentation and More Testing for PDS4 Read
 


### PR DESCRIPTION
… Sprint 1

- Create new V2.5.0 section "More Spack Improvements" at top of roadmap
- Move Sprints 2-6 (GeoTIFF, GRIB2, CDF, PDS4/Parallel, Polish/CI) from v2.4.0 to v2.5.0
- Keep v2.4.0 Sprint 1 (foundation: version 2.3.0, cmake_args fixes, netcdf-c minimum bump) and GitHub issue #265 reference in v2.4.0 section