### PR TITLE
v2.5.0 Sprint 2: Add GRIB2 Spack variant

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -158,6 +158,13 @@ jobs:
           spack spec -I nep@2.4.0+geotiff
           spack spec -I nep@main+geotiff
 
+      - name: Check package concretization (grib2 variant)
+        run: |
+          echo "=== Concretizing NEP with GRIB2 variant ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack spec -I nep@2.4.0+grib2
+          spack spec -I nep@main+grib2
+
   # Full install test - only runs on pushes to main
   install:
     name: Spack Install Test
@@ -338,6 +345,20 @@ jobs:
           spack install -v --fail-fast nep@main+geotiff~docs~fortran 2>&1 | tee spack_install_main_geotiff.log || true
           echo "=== nep@main+geotiff installation attempt complete ==="
 
+      - name: Install NEP 2.4.0 with Spack (GRIB2 variant)
+        run: |
+          echo "=== Installing nep@2.4.0+grib2 ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@2.4.0+grib2~docs~fortran 2>&1 | tee spack_install_2.4.0_grib2.log || true
+          echo "=== nep@2.4.0+grib2 installation attempt complete ==="
+
+      - name: Install NEP main with Spack (GRIB2 variant)
+        run: |
+          echo "=== Installing nep@main+grib2 ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@main+grib2~docs~fortran 2>&1 | tee spack_install_main_grib2.log || true
+          echo "=== nep@main+grib2 installation attempt complete ==="
+
       - name: Show build logs (always runs)
         run: |
           echo "=== Showing build logs for manual review ==="
@@ -347,6 +368,10 @@ jobs:
           tail -200 spack_install_2.4.0_geotiff.log || true
           echo "=== Spack install main geotiff log (last 200 lines) ==="
           tail -200 spack_install_main_geotiff.log || true
+          echo "=== Spack install 2.4.0 grib2 log (last 200 lines) ==="
+          tail -200 spack_install_2.4.0_grib2.log || true
+          echo "=== Spack install main grib2 log (last 200 lines) ==="
+          tail -200 spack_install_main_grib2.log || true
           echo "=== Finding build directories ==="
           find $HOME/spack/var/spack/stage -name '*.log' -o -name 'spack-build-out.txt' 2>/dev/null | head -10 || true
           echo "=== Showing any build output files ==="

--- a/docs/plan/v2.5.0-sprint2-grib2-variant.md
+++ b/docs/plan/v2.5.0-sprint2-grib2-variant.md
@@ -1,0 +1,183 @@
+# NEP v2.5.0 Sprint 2 — GRIB2 Spack Variant
+
+## Goal
+
+Add the `grib2` variant to the NEP Spack package, wire it to CMake's
+`NEP_ENABLE_GRIB2` option, and add dedicated Spack CI spec/install checks for
+both the pinned `nep@2.4.0` release and the ongoing `nep@main` branch.
+
+---
+
+## Background
+
+Sprint 1 added the `geotiff` variant and the `nep@2.4.0` release entry. Sprint 2
+follows the same pattern for GRIB2. CMake already supports `NEP_ENABLE_GRIB2` and
+looks for `libg2c` from NCEPLIBS-g2c. The Spack package does not yet expose this
+option.
+
+NCEPLIBS-g2c is not available in standard Ubuntu apt repositories, so the install
+job must let Spack build it from source. The g2c library's transitive dependencies
+(Jasper for JPEG2000, libpng, zlib) are resolved automatically by Spack through the
+`nceplibs-g2c` package definition.
+
+---
+
+## Clarified Decisions
+
+- **Spack package name**: `nceplibs-g2c` — matches the NCEPLIBS GitHub repo naming
+  convention and is the canonical name in Spack.
+- **`grib2` variant**: default OFF to match `NEP_ENABLE_GRIB2=OFF` in CMake and
+  the pattern of all other format variants (`geotiff`, `fits`, `cdf`) defaulting OFF.
+- **Transitive dependencies**: Jasper, libpng, and zlib are resolved by Spack
+  through `nceplibs-g2c`; no explicit re-declaration in the NEP package needed.
+- **CMake option**: use `self.define_from_variant("NEP_ENABLE_GRIB2", "grib2")`.
+- **`check_install` assertion**: assert `libncgrib2.so` exists when `+grib2`,
+  consistent with the `libncgeotiff.so` check from Sprint 1.
+- **CI spec step**: dedicated step for `+grib2` (separate from the all-variants
+  step) for easier per-format CI triage.
+- **CI install step**: include `+grib2` install steps with `|| true`; Spack builds
+  `nceplibs-g2c` from source. Log tailing for manual review, consistent with Sprint 1.
+
+---
+
+## Tasks
+
+### 1. Add the `grib2` variant to `spack/NEP/package.py`
+
+Add after the `fits` variant line:
+
+```python
+variant("grib2", default=False, description="Enable GRIB2 reader support via NCEPLIBS-g2c")
+```
+
+**Acceptance:** `spack info nep` lists the `grib2` variant with default OFF.
+
+---
+
+### 2. Add the `nceplibs-g2c` dependency
+
+Add after the `cfitsio` dependency:
+
+```python
+depends_on("nceplibs-g2c", when="+grib2", type=("build", "link"))
+```
+
+**Acceptance:** `spack spec -I nep+grib2` shows `nceplibs-g2c` in the dependency
+tree.
+
+---
+
+### 3. Pass `NEP_ENABLE_GRIB2` in `cmake_args`
+
+Add to the `cmake_args()` list:
+
+```python
+self.define_from_variant("NEP_ENABLE_GRIB2", "grib2"),
+```
+
+**Acceptance:** `spack spec -I nep+grib2` shows `-DNEP_ENABLE_GRIB2=ON`;
+`spack spec -I nep~grib2` shows `-DNEP_ENABLE_GRIB2=OFF`.
+
+---
+
+### 4. Add `check_install` assertion for `libncgrib2.so`
+
+Extend `check_install()` to assert the presence of `libncgrib2.so` when `+grib2`:
+
+```python
+if "+grib2" in self.spec:
+    assert os.path.exists(join_path(self.prefix.lib, "libncgrib2.so"))
+```
+
+**Acceptance:** `spack install nep+grib2` fails the install-time check if the
+GRIB2 dispatch library is missing.
+
+---
+
+### 5. Update `.github/workflows/spack.yml` spec job
+
+Add a dedicated GRIB2 spec step in the `spec` job after the GeoTIFF spec step:
+
+```yaml
+- name: Check package concretization (grib2 variant)
+  run: |
+    echo "=== Concretizing NEP with GRIB2 variant ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack spec -I nep@2.4.0+grib2
+    spack spec -I nep@main+grib2
+```
+
+**Acceptance:** The spec job reports successful concretization for both
+`nep@2.4.0+grib2` and `nep@main+grib2`.
+
+---
+
+### 6. Update `.github/workflows/spack.yml` install job
+
+Add two GRIB2 install steps in the `install` job after the GeoTIFF install steps:
+
+```yaml
+- name: Install NEP 2.4.0 with Spack (GRIB2 variant)
+  run: |
+    echo "=== Installing nep@2.4.0+grib2 ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@2.4.0+grib2~docs~fortran 2>&1 | tee spack_install_2.4.0_grib2.log || true
+    echo "=== nep@2.4.0+grib2 installation attempt complete ==="
+
+- name: Install NEP main with Spack (GRIB2 variant)
+  run: |
+    echo "=== Installing nep@main+grib2 ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@main+grib2~docs~fortran 2>&1 | tee spack_install_main_grib2.log || true
+    echo "=== nep@main+grib2 installation attempt complete ==="
+```
+
+Add the new log files to the "Show build logs" step:
+
+```yaml
+echo "=== Spack install 2.4.0 grib2 log (last 200 lines) ==="
+tail -200 spack_install_2.4.0_grib2.log || true
+echo "=== Spack install main grib2 log (last 200 lines) ==="
+tail -200 spack_install_main_grib2.log || true
+```
+
+**Acceptance:** The install job runs GRIB2 install steps for both `2.4.0` and
+`main`, producing build logs for manual review.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `spack/NEP/package.py` | Add `grib2` variant, `nceplibs-g2c` dep, `NEP_ENABLE_GRIB2` in `cmake_args`, install check for `libncgrib2.so` |
+| `.github/workflows/spack.yml` | Add GRIB2 spec and install steps for `nep@2.4.0` and `nep@main`; add log tailing for new logs |
+| `docs/roadmap.md` | Expand v2.5.0 Sprint 2 with clarified decisions and detailed plan reference |
+
+No source code, build system, or test changes beyond the Spack package and CI.
+
+---
+
+## Acceptance Criteria
+
+- `spack spec -I nep@2.4.0+grib2` concretizes without error.
+- `spack spec -I nep@main+grib2` concretizes without error.
+- `spack info nep` lists `grib2` with default OFF and `nceplibs-g2c` as conditional dep.
+- `spack spec nep+grib2` includes `-DNEP_ENABLE_GRIB2=ON`.
+- `spack spec nep~grib2` includes `-DNEP_ENABLE_GRIB2=OFF`.
+- `spack install nep+grib2` verifies `libncgrib2.so` exists.
+- `spack.yml` spec job runs `+grib2` concretization for both `2.4.0` and `main`.
+- `spack.yml` install job runs `+grib2` install steps for both `2.4.0` and `main`.
+
+---
+
+## Definition of Done
+
+- [ ] `grib2` variant declared in `spack/NEP/package.py` with default OFF.
+- [ ] `nceplibs-g2c` conditional dep declared for `+grib2`.
+- [ ] `NEP_ENABLE_GRIB2` wired via `define_from_variant` in `cmake_args`.
+- [ ] `check_install()` asserts `libncgrib2.so` when `+grib2`.
+- [ ] `spack.yml` spec job has dedicated `+grib2` step for `2.4.0` and `main`.
+- [ ] `spack.yml` install job has `+grib2` steps for `2.4.0` and `main` with log tailing.
+- [ ] `docs/roadmap.md` expanded with clarified decisions and plan reference.
+- [ ] GitHub issue created and roadmap references it.

--- a/docs/plan/v2.5.0-sprint2-grib2-variant.md
+++ b/docs/plan/v2.5.0-sprint2-grib2-variant.md
@@ -18,18 +18,18 @@ option.
 NCEPLIBS-g2c is not available in standard Ubuntu apt repositories, so the install
 job must let Spack build it from source. The g2c library's transitive dependencies
 (Jasper for JPEG2000, libpng, zlib) are resolved automatically by Spack through the
-`nceplibs-g2c` package definition.
+`g2c` package definition.
 
 ---
 
 ## Clarified Decisions
 
-- **Spack package name**: `nceplibs-g2c` — matches the NCEPLIBS GitHub repo naming
-  convention and is the canonical name in Spack.
+- **Spack package name**: `g2c` — the Spack builtin name for NCEPLIBS-g2c (see
+  `spack/spack-packages` builtin repo; not `nceplibs-g2c`).
 - **`grib2` variant**: default OFF to match `NEP_ENABLE_GRIB2=OFF` in CMake and
   the pattern of all other format variants (`geotiff`, `fits`, `cdf`) defaulting OFF.
 - **Transitive dependencies**: Jasper, libpng, and zlib are resolved by Spack
-  through `nceplibs-g2c`; no explicit re-declaration in the NEP package needed.
+  through `g2c`; no explicit re-declaration in the NEP package needed.
 - **CMake option**: use `self.define_from_variant("NEP_ENABLE_GRIB2", "grib2")`.
 - **`check_install` assertion**: assert `libncgrib2.so` exists when `+grib2`,
   consistent with the `libncgeotiff.so` check from Sprint 1.
@@ -54,15 +54,15 @@ variant("grib2", default=False, description="Enable GRIB2 reader support via NCE
 
 ---
 
-### 2. Add the `nceplibs-g2c` dependency
+### 2. Add the `g2c` dependency
 
 Add after the `cfitsio` dependency:
 
 ```python
-depends_on("nceplibs-g2c", when="+grib2", type=("build", "link"))
+depends_on("g2c", when="+grib2", type=("build", "link"))
 ```
 
-**Acceptance:** `spack spec -I nep+grib2` shows `nceplibs-g2c` in the dependency
+**Acceptance:** `spack spec -I nep+grib2` shows `g2c` in the dependency
 tree.
 
 ---
@@ -150,7 +150,7 @@ tail -200 spack_install_main_grib2.log || true
 
 | File | Change |
 |------|--------|
-| `spack/NEP/package.py` | Add `grib2` variant, `nceplibs-g2c` dep, `NEP_ENABLE_GRIB2` in `cmake_args`, install check for `libncgrib2.so` |
+| `spack/NEP/package.py` | Add `grib2` variant, `g2c` dep, `NEP_ENABLE_GRIB2` in `cmake_args`, install check for `libncgrib2.so` |
 | `.github/workflows/spack.yml` | Add GRIB2 spec and install steps for `nep@2.4.0` and `nep@main`; add log tailing for new logs |
 | `docs/roadmap.md` | Expand v2.5.0 Sprint 2 with clarified decisions and detailed plan reference |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,10 +20,23 @@
 **GitHub Issue:** #268
 
 #### Sprint 2: GRIB2 Variant
+**Detailed Plan**: See `docs/plan/v2.5.0-sprint2-grib2-variant.md`
+
 - Add variant `grib2` (default off).
-- Add appropriate spack dependency for g2c/GRIB2.
-- Pass `NEP_ENABLE_GRIB2` in `cmake_args`.
-- **Testing**: Add `spack spec -I nep@2.4.0+grib2` and `spack spec -I nep@main+grib2` to spec job; add `spack install -v nep@2.4.0+grib2~docs~fortran` and `spack install -v nep@main+grib2~docs~fortran` to install job.
+- Add `depends_on("nceplibs-g2c", when="+grib2")` — the canonical Spack package name for NCEPLIBS-g2c; transitive deps (Jasper, libpng) resolved by Spack automatically.
+- Pass `NEP_ENABLE_GRIB2` in `cmake_args` via `self.define_from_variant("NEP_ENABLE_GRIB2", "grib2")`.
+- Add `check_install` assertion for `libncgrib2.so` when `+grib2`, consistent with Sprint 1.
+- **Testing**: Add `spack spec -I nep@2.4.0+grib2` and `spack spec -I nep@main+grib2` to spec job as a dedicated step; add `spack install -v nep@2.4.0+grib2~docs~fortran` and `spack install -v nep@main+grib2~docs~fortran` to install job with `|| true` and log tailing (Spack builds `nceplibs-g2c` from source).
+
+**Clarified decisions:**
+- `grib2` variant default OFF to match `NEP_ENABLE_GRIB2=OFF` in CMake and all other format variants.
+- Use `nceplibs-g2c` as the Spack package name (matches NCEPLIBS GitHub repo naming convention).
+- Transitive g2c dependencies (Jasper, libpng, zlib) are resolved by Spack through `nceplibs-g2c`; no explicit re-declaration needed.
+- `check_install()` asserts `libncgrib2.so` exists when `+grib2`, consistent with the `libncgeotiff.so` check in Sprint 1.
+- Dedicated spec step for `+grib2` (not combined with all-variants step) for easier CI triage.
+- Install job includes `+grib2` steps with `|| true`; Spack builds `nceplibs-g2c` from source since it is not in standard apt repos.
+
+**GitHub Issue:** #270
 
 #### Sprint 3: CDF Variant
 - Add variant `cdf` (default off).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,15 +23,15 @@
 **Detailed Plan**: See `docs/plan/v2.5.0-sprint2-grib2-variant.md`
 
 - Add variant `grib2` (default off).
-- Add `depends_on("nceplibs-g2c", when="+grib2")` — the canonical Spack package name for NCEPLIBS-g2c; transitive deps (Jasper, libpng) resolved by Spack automatically.
+- Add `depends_on("g2c", when="+grib2")` — the Spack builtin package name for NCEPLIBS-g2c; transitive deps (Jasper, libpng) resolved by Spack automatically.
 - Pass `NEP_ENABLE_GRIB2` in `cmake_args` via `self.define_from_variant("NEP_ENABLE_GRIB2", "grib2")`.
 - Add `check_install` assertion for `libncgrib2.so` when `+grib2`, consistent with Sprint 1.
 - **Testing**: Add `spack spec -I nep@2.4.0+grib2` and `spack spec -I nep@main+grib2` to spec job as a dedicated step; add `spack install -v nep@2.4.0+grib2~docs~fortran` and `spack install -v nep@main+grib2~docs~fortran` to install job with `|| true` and log tailing (Spack builds `nceplibs-g2c` from source).
 
 **Clarified decisions:**
 - `grib2` variant default OFF to match `NEP_ENABLE_GRIB2=OFF` in CMake and all other format variants.
-- Use `nceplibs-g2c` as the Spack package name (matches NCEPLIBS GitHub repo naming convention).
-- Transitive g2c dependencies (Jasper, libpng, zlib) are resolved by Spack through `nceplibs-g2c`; no explicit re-declaration needed.
+- Use `g2c` as the Spack package name (Spack builtin name for NCEPLIBS-g2c; see `spack/spack-packages` repo).
+- Transitive g2c dependencies (Jasper, libpng, zlib) are resolved by Spack through `g2c`; no explicit re-declaration needed.
 - `check_install()` asserts `libncgrib2.so` exists when `+grib2`, consistent with the `libncgeotiff.so` check in Sprint 1.
 - Dedicated spec step for `+grib2` (not combined with all-variants step) for easier CI triage.
 - Install job includes `+grib2` steps with `|| true`; Spack builds `nceplibs-g2c` from source since it is not in standard apt repos.

--- a/spack/NEP/package.py
+++ b/spack/NEP/package.py
@@ -57,7 +57,7 @@ class Nep(CMakePackage):
     depends_on("netcdf-fortran", when="+fortran", type=("build", "link"))
     depends_on("cfitsio", when="+fits", type=("build", "link"))
     depends_on("libgeotiff", when="+geotiff", type=("build", "link"))
-    depends_on("nceplibs-g2c", when="+grib2", type=("build", "link"))
+    depends_on("g2c", when="+grib2", type=("build", "link"))
     depends_on("libtiff", when="+geotiff", type=("build", "link"))
     depends_on("doxygen", when="+docs", type="build")
 

--- a/spack/NEP/package.py
+++ b/spack/NEP/package.py
@@ -45,6 +45,7 @@ class Nep(CMakePackage):
     variant("fortran", default=True, description="Build Fortran wrappers")
     variant("fits", default=False, description="Enable FITS reader support via CFITSIO")
     variant("geotiff", default=False, description="Enable GeoTIFF reader support via libgeotiff")
+    variant("grib2", default=False, description="Enable GRIB2 reader support via NCEPLIBS-g2c")
 
     depends_on("c", type="build")
     depends_on("fortran", when="+fortran", type="build")
@@ -56,6 +57,7 @@ class Nep(CMakePackage):
     depends_on("netcdf-fortran", when="+fortran", type=("build", "link"))
     depends_on("cfitsio", when="+fits", type=("build", "link"))
     depends_on("libgeotiff", when="+geotiff", type=("build", "link"))
+    depends_on("nceplibs-g2c", when="+grib2", type=("build", "link"))
     depends_on("libtiff", when="+geotiff", type=("build", "link"))
     depends_on("doxygen", when="+docs", type="build")
 
@@ -67,6 +69,7 @@ class Nep(CMakePackage):
             self.define_from_variant("NEP_ENABLE_FORTRAN", "fortran"),
             self.define_from_variant("NEP_ENABLE_FITS", "fits"),
             self.define_from_variant("NEP_ENABLE_GEOTIFF", "geotiff"),
+            self.define_from_variant("NEP_ENABLE_GRIB2", "grib2"),
         ]
         return args
 
@@ -83,3 +86,5 @@ class Nep(CMakePackage):
             assert os.path.exists(join_path(plugin_dir, "libh5lz4.so"))
         if "+geotiff" in self.spec:
             assert os.path.exists(join_path(self.prefix.lib, "libncgeotiff.so"))
+        if "+grib2" in self.spec:
+            assert os.path.exists(join_path(self.prefix.lib, "libncgrib2.so"))


### PR DESCRIPTION
Implements [#270](https://github.com/Intelligent-Data-Design-Inc/NEP/issues/270) — v2.5.0 Sprint 2: GRIB2 Spack Variant.

Closes #270

## Changes

- **`spack/NEP/package.py`**: Add `grib2` variant (default OFF), `depends_on("nceplibs-g2c", when="+grib2")`, `define_from_variant("NEP_ENABLE_GRIB2", "grib2")` in `cmake_args()`, and `check_install()` assertion for `libncgrib2.so`
- **`.github/workflows/spack.yml`**: Add dedicated GRIB2 spec concretization step for `nep@2.4.0+grib2` and `nep@main+grib2`; add GRIB2 install steps for both versions with `|| true` and log tailing
- **`docs/roadmap.md`**: Expand v2.5.0 Sprint 2 with clarified decisions and plan/issue references
- **`docs/plan/v2.5.0-sprint2-grib2-variant.md`**: Detailed implementation plan

## Acceptance Criteria

- `spack spec -I nep@2.4.0+grib2` concretizes without error
- `spack spec -I nep@main+grib2` concretizes without error
- `spack info nep` lists `grib2` variant (default OFF) with `nceplibs-g2c` as conditional dep
- `spack spec nep+grib2` includes `-DNEP_ENABLE_GRIB2=ON`
- `spack install nep+grib2` verifies `libncgrib2.so` exists