### PR TITLE
v2.5.0 Sprint 3: Add CDF Spack variant

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -55,7 +55,9 @@ jobs:
         run: |
           echo "=== Creating local Spack repository for NEP ==="
           mkdir -p $HOME/nep-repo/packages/nep
+          mkdir -p $HOME/nep-repo/packages/cdf
           cp spack/NEP/package.py $HOME/nep-repo/packages/nep/
+          cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
           cat > $HOME/nep-repo/repo.yaml << 'EOF'
           repo:
             namespace: nep-local
@@ -117,7 +119,9 @@ jobs:
         run: |
           echo "=== Creating local Spack repository for NEP ==="
           mkdir -p $HOME/nep-repo/packages/nep
+          mkdir -p $HOME/nep-repo/packages/cdf
           cp spack/NEP/package.py $HOME/nep-repo/packages/nep/
+          cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
           cat > $HOME/nep-repo/repo.yaml << 'EOF'
           repo:
             namespace: nep-local
@@ -164,6 +168,13 @@ jobs:
           . $HOME/spack/share/spack/setup-env.sh
           spack spec -I nep@2.4.0+grib2
           spack spec -I nep@main+grib2
+
+      - name: Check package concretization (cdf variant)
+        run: |
+          echo "=== Concretizing NEP with CDF variant ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack spec -I nep@2.4.0+cdf
+          spack spec -I nep@main+cdf
 
   # Full install test - only runs on pushes to main
   install:
@@ -286,7 +297,9 @@ jobs:
         run: |
           echo "=== Creating local Spack repository for NEP ==="
           mkdir -p $HOME/nep-repo/packages/nep
+          mkdir -p $HOME/nep-repo/packages/cdf
           cp spack/NEP/package.py $HOME/nep-repo/packages/nep/
+          cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
           cat > $HOME/nep-repo/repo.yaml << 'EOF'
           repo:
             namespace: nep-local
@@ -359,6 +372,20 @@ jobs:
           spack install -v --fail-fast nep@main+grib2~docs~fortran 2>&1 | tee spack_install_main_grib2.log || true
           echo "=== nep@main+grib2 installation attempt complete ==="
 
+      - name: Install NEP 2.4.0 with Spack (CDF variant)
+        run: |
+          echo "=== Installing nep@2.4.0+cdf ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@2.4.0+cdf~docs~fortran 2>&1 | tee spack_install_2.4.0_cdf.log || true
+          echo "=== nep@2.4.0+cdf installation attempt complete ==="
+
+      - name: Install NEP main with Spack (CDF variant)
+        run: |
+          echo "=== Installing nep@main+cdf ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@main+cdf~docs~fortran 2>&1 | tee spack_install_main_cdf.log || true
+          echo "=== nep@main+cdf installation attempt complete ==="
+
       - name: Show build logs (always runs)
         run: |
           echo "=== Showing build logs for manual review ==="
@@ -372,6 +399,10 @@ jobs:
           tail -200 spack_install_2.4.0_grib2.log || true
           echo "=== Spack install main grib2 log (last 200 lines) ==="
           tail -200 spack_install_main_grib2.log || true
+          echo "=== Spack install 2.4.0 cdf log (last 200 lines) ==="
+          tail -200 spack_install_2.4.0_cdf.log || true
+          echo "=== Spack install main cdf log (last 200 lines) ==="
+          tail -200 spack_install_main_cdf.log || true
           echo "=== Finding build directories ==="
           find $HOME/spack/var/spack/stage -name '*.log' -o -name 'spack-build-out.txt' 2>/dev/null | head -10 || true
           echo "=== Showing any build output files ==="

--- a/docs/plan/v2.5.0-sprint3-cdf-variant.md
+++ b/docs/plan/v2.5.0-sprint3-cdf-variant.md
@@ -1,0 +1,227 @@
+# NEP v2.5.0 Sprint 3 — CDF Spack Variant
+
+## Goal
+
+Add the `cdf` variant to the NEP Spack package, wire it to CMake's
+`NEP_ENABLE_CDF` option, register the in-repo `spack/cdf/package.py` in the
+`spack.yml` local repository, and add dedicated Spack CI spec/install checks for
+both `nep@2.4.0` and `nep@main`.
+
+---
+
+## Background
+
+Sprints 1 and 2 added `geotiff` and `grib2` variants following a consistent
+pattern: add a variant (default OFF), declare the library dependency, pass the
+CMake option via `define_from_variant`, assert the dispatch library on install,
+and add dedicated spec/install CI steps.
+
+Sprint 3 follows the same pattern but with one important difference: CDF is **not**
+a Spack builtin package. It is provided by the in-repo `spack/cdf/package.py`. For
+Spack to resolve `depends_on("cdf", when="+cdf")` in the NEP package, the CDF
+package must be registered in the same local repository that `spack.yml` builds.
+
+NASA CDF is not available in standard Ubuntu apt repositories; Spack builds it from
+source using the in-repo `MakefilePackage` definition.
+
+The installed CDF dispatch library name is `libnccdf.so`, confirmed from
+`src/CMakeLists.txt`: `set(CDF_LIB_NAME nccdf)`.
+
+`spack-cdf.yml` remains a separate workflow; consolidation into `spack.yml` is
+deferred to Sprint 5.
+
+---
+
+## Clarified Decisions
+
+- **`cdf` variant**: default OFF to match `NEP_ENABLE_CDF=OFF` in CMake and all
+  other format variants.
+- **Spack package**: `cdf` from in-repo `spack/cdf/package.py` — not a Spack
+  builtin. Must be co-registered in the `nep-repo` local repository.
+- **Local repo registration**: copy `spack/cdf/package.py` into
+  `$HOME/nep-repo/packages/cdf/` in the "Add NEP package to Spack" step across
+  all three `spack.yml` jobs (lint, spec, install). One repo, one `spack repo add`.
+- **CMake option**: `self.define_from_variant("NEP_ENABLE_CDF", "cdf")`.
+- **`check_install` assertion**: assert `libnccdf.so` exists when `+cdf`
+  (CMake target `nccdf`), consistent with `libncgeotiff.so` and `libncgrib2.so`.
+- **`spack-cdf.yml`**: kept separate; merging deferred to Sprint 5.
+- **CI pattern**: dedicated spec step + install steps with `|| true` + log tailing,
+  matching sprints 1 and 2.
+
+---
+
+## Tasks
+
+### 1. Add the `cdf` variant to `spack/NEP/package.py`
+
+Add after the `grib2` variant line:
+
+```python
+variant("cdf", default=False, description="Enable NASA CDF reader support")
+```
+
+**Acceptance:** `spack info nep` lists the `cdf` variant with default OFF.
+
+---
+
+### 2. Add the `cdf` dependency
+
+Add after the `g2c` dependency:
+
+```python
+depends_on("cdf", when="+cdf", type=("build", "link"))
+```
+
+**Acceptance:** `spack spec -I nep+cdf` shows `cdf` in the dependency tree.
+
+---
+
+### 3. Pass `NEP_ENABLE_CDF` in `cmake_args`
+
+Add to the `cmake_args()` list:
+
+```python
+self.define_from_variant("NEP_ENABLE_CDF", "cdf"),
+```
+
+**Acceptance:** `spack spec -I nep+cdf` shows `-DNEP_ENABLE_CDF=ON`;
+`spack spec -I nep~cdf` shows `-DNEP_ENABLE_CDF=OFF`.
+
+---
+
+### 4. Add `check_install` assertion for `libnccdf.so`
+
+Extend `check_install()` to assert the presence of `libnccdf.so` when `+cdf`:
+
+```python
+if "+cdf" in self.spec:
+    assert os.path.exists(join_path(self.prefix.lib, "libnccdf.so"))
+```
+
+**Acceptance:** `spack install nep+cdf` fails the install-time check if the CDF
+dispatch library is missing.
+
+---
+
+### 5. Register the in-repo CDF package in `spack.yml`
+
+In every "Add NEP package to Spack" step across all three jobs (lint, spec,
+install), add the CDF package alongside the NEP package in the same local repo:
+
+```yaml
+mkdir -p $HOME/nep-repo/packages/cdf
+cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
+```
+
+The full updated block becomes:
+
+```yaml
+- name: Add NEP package to Spack
+  run: |
+    echo "=== Creating local Spack repository for NEP ==="
+    mkdir -p $HOME/nep-repo/packages/nep
+    mkdir -p $HOME/nep-repo/packages/cdf
+    cp spack/NEP/package.py $HOME/nep-repo/packages/nep/
+    cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
+    cat > $HOME/nep-repo/repo.yaml << 'EOF'
+    repo:
+      namespace: nep-local
+    EOF
+    ...
+    spack repo add $HOME/nep-repo
+```
+
+This change must be applied to all three jobs: `lint`, `spec`, and `install`.
+
+**Acceptance:** `spack spec -I nep+cdf` resolves without "unknown package" error.
+
+---
+
+### 6. Update `.github/workflows/spack.yml` spec job
+
+Add a dedicated CDF spec step after the GRIB2 spec step:
+
+```yaml
+- name: Check package concretization (cdf variant)
+  run: |
+    echo "=== Concretizing NEP with CDF variant ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack spec -I nep@2.4.0+cdf
+    spack spec -I nep@main+cdf
+```
+
+**Acceptance:** The spec job reports successful concretization for both
+`nep@2.4.0+cdf` and `nep@main+cdf`.
+
+---
+
+### 7. Update `.github/workflows/spack.yml` install job
+
+Add two CDF install steps after the GRIB2 install steps:
+
+```yaml
+- name: Install NEP 2.4.0 with Spack (CDF variant)
+  run: |
+    echo "=== Installing nep@2.4.0+cdf ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@2.4.0+cdf~docs~fortran 2>&1 | tee spack_install_2.4.0_cdf.log || true
+    echo "=== nep@2.4.0+cdf installation attempt complete ==="
+
+- name: Install NEP main with Spack (CDF variant)
+  run: |
+    echo "=== Installing nep@main+cdf ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@main+cdf~docs~fortran 2>&1 | tee spack_install_main_cdf.log || true
+    echo "=== nep@main+cdf installation attempt complete ==="
+```
+
+Add log tailing to the "Show build logs" step:
+
+```yaml
+echo "=== Spack install 2.4.0 cdf log (last 200 lines) ==="
+tail -200 spack_install_2.4.0_cdf.log || true
+echo "=== Spack install main cdf log (last 200 lines) ==="
+tail -200 spack_install_main_cdf.log || true
+```
+
+**Acceptance:** The install job runs CDF install steps for both `2.4.0` and
+`main`, producing build logs for manual review.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `spack/NEP/package.py` | Add `cdf` variant, `cdf` dep, `NEP_ENABLE_CDF` in `cmake_args`, install check for `libnccdf.so` |
+| `.github/workflows/spack.yml` | Register in-repo CDF package in all three job setup steps; add CDF spec and install steps; add log tailing |
+| `docs/roadmap.md` | Expand v2.5.0 Sprint 3 with clarified decisions and plan/issue references |
+
+No changes to `spack/cdf/package.py`, `spack-cdf.yml`, source code, or build system.
+
+---
+
+## Acceptance Criteria
+
+- `spack spec -I nep@2.4.0+cdf` concretizes without error.
+- `spack spec -I nep@main+cdf` concretizes without error.
+- `spack info nep` lists `cdf` variant with default OFF and `cdf` as conditional dep.
+- `spack spec nep+cdf` includes `-DNEP_ENABLE_CDF=ON`.
+- `spack spec nep~cdf` includes `-DNEP_ENABLE_CDF=OFF`.
+- `spack install nep+cdf` verifies `libnccdf.so` exists.
+- `spack.yml` spec job runs dedicated `+cdf` concretization step.
+- `spack.yml` install job runs `+cdf` install steps with log tailing.
+
+---
+
+## Definition of Done
+
+- [ ] `cdf` variant declared in `spack/NEP/package.py` with default OFF.
+- [ ] `cdf` conditional dep declared for `+cdf`.
+- [ ] `NEP_ENABLE_CDF` wired via `define_from_variant` in `cmake_args`.
+- [ ] `check_install()` asserts `libnccdf.so` when `+cdf`.
+- [ ] `spack.yml` lint/spec/install jobs all register `spack/cdf/package.py` in nep-repo.
+- [ ] `spack.yml` spec job has dedicated `+cdf` step for `2.4.0` and `main`.
+- [ ] `spack.yml` install job has `+cdf` steps for `2.4.0` and `main` with log tailing.
+- [ ] `docs/roadmap.md` expanded with clarified decisions and plan/issue references.
+- [ ] GitHub issue created and roadmap references it.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,11 +39,25 @@
 **GitHub Issue:** #270
 
 #### Sprint 3: CDF Variant
+**Detailed Plan**: See `docs/plan/v2.5.0-sprint3-cdf-variant.md`
+
 - Add variant `cdf` (default off).
-- Add `depends_on("cdf", when="+cdf")` — references the in-repo `spack/cdf/package.py`.
-- Pass `NEP_ENABLE_CDF` in `cmake_args`.
-- Update `spack/cdf/package.py` as needed to work as a dependency.
-- **Testing**: Add `spack spec -I nep@2.4.0+cdf` and `spack spec -I nep@main+cdf` to spec job; add `spack install -v nep@2.4.0+cdf~docs~fortran` and `spack install -v nep@main+cdf~docs~fortran` to install job. Consider merging `spack-cdf.yml` into `spack.yml` since CDF becomes a transitive dependency.
+- Add `depends_on("cdf", when="+cdf")` — references the in-repo `spack/cdf/package.py`; not a Spack builtin.
+- Pass `NEP_ENABLE_CDF` in `cmake_args` via `self.define_from_variant("NEP_ENABLE_CDF", "cdf")`.
+- Register the in-repo CDF package in `spack.yml` by copying `spack/cdf/package.py` into the same `nep-repo` local repository (add a `cdf/` subdirectory alongside `nep/`).
+- Add `check_install` assertion for `libnccdf.so` when `+cdf` (library name confirmed from `src/CMakeLists.txt`: `set(CDF_LIB_NAME nccdf)`).
+- Keep `spack-cdf.yml` separate; consolidation deferred to Sprint 5.
+- **Testing**: Add dedicated spec step for `nep@2.4.0+cdf` and `nep@main+cdf`; add install steps with `|| true` and log tailing, consistent with sprints 1 and 2.
+
+**Clarified decisions:**
+- `cdf` variant default OFF to match `NEP_ENABLE_CDF=OFF` in CMake and all other format variants.
+- CDF is an in-repo Spack package (`spack/cdf/package.py`), not a builtin; `spack.yml` must register it in the local repo before concretizing `+cdf`.
+- Register by copying `spack/cdf/package.py` into `$HOME/nep-repo/packages/cdf/` in the "Add NEP package to Spack" step — one repo, one setup, no second `spack repo add`.
+- `check_install()` asserts `libnccdf.so` when `+cdf` (CMake target name: `nccdf`), consistent with `libncgeotiff.so` and `libncgrib2.so` checks.
+- `spack-cdf.yml` remains separate; merging into `spack.yml` deferred to Sprint 5.
+- Dedicated spec/install CI steps following the sprint 1 and 2 pattern.
+
+**GitHub Issue:** #272
 
 #### Sprint 4: PDS4 + Parallel + Remaining Variants
 - Add variants: `pds4`, `parallel`, `examples`, `benchmarks`.

--- a/spack/NEP/package.py
+++ b/spack/NEP/package.py
@@ -46,6 +46,7 @@ class Nep(CMakePackage):
     variant("fits", default=False, description="Enable FITS reader support via CFITSIO")
     variant("geotiff", default=False, description="Enable GeoTIFF reader support via libgeotiff")
     variant("grib2", default=False, description="Enable GRIB2 reader support via NCEPLIBS-g2c")
+    variant("cdf", default=False, description="Enable NASA CDF reader support")
 
     depends_on("c", type="build")
     depends_on("fortran", when="+fortran", type="build")
@@ -58,6 +59,7 @@ class Nep(CMakePackage):
     depends_on("cfitsio", when="+fits", type=("build", "link"))
     depends_on("libgeotiff", when="+geotiff", type=("build", "link"))
     depends_on("g2c", when="+grib2", type=("build", "link"))
+    depends_on("cdf", when="+cdf", type=("build", "link"))
     depends_on("libtiff", when="+geotiff", type=("build", "link"))
     depends_on("doxygen", when="+docs", type="build")
 
@@ -70,6 +72,7 @@ class Nep(CMakePackage):
             self.define_from_variant("NEP_ENABLE_FITS", "fits"),
             self.define_from_variant("NEP_ENABLE_GEOTIFF", "geotiff"),
             self.define_from_variant("NEP_ENABLE_GRIB2", "grib2"),
+            self.define_from_variant("NEP_ENABLE_CDF", "cdf"),
         ]
         return args
 
@@ -88,3 +91,5 @@ class Nep(CMakePackage):
             assert os.path.exists(join_path(self.prefix.lib, "libncgeotiff.so"))
         if "+grib2" in self.spec:
             assert os.path.exists(join_path(self.prefix.lib, "libncgrib2.so"))
+        if "+cdf" in self.spec:
+            assert os.path.exists(join_path(self.prefix.lib, "libnccdf.so"))


### PR DESCRIPTION
Implements [#272](https://github.com/Intelligent-Data-Design-Inc/NEP/issues/272) — v2.5.0 Sprint 3: CDF Spack Variant.

Closes #272

## Changes

- **`spack/NEP/package.py`**: Add `cdf` variant (default OFF), `depends_on("cdf", when="+cdf")`, `define_from_variant("NEP_ENABLE_CDF", "cdf")` in `cmake_args()`, and `check_install()` assertion for `libnccdf.so`
- **`.github/workflows/spack.yml`**: Register `spack/cdf/package.py` in the `nep-repo` local repository across all three jobs (lint, spec, install); add dedicated CDF spec concretization step for `nep@2.4.0+cdf` and `nep@main+cdf`; add CDF install steps for both versions with `|| true` and log tailing
- **`docs/roadmap.md`**: Expand v2.5.0 Sprint 3 with clarified decisions and plan/issue references
- **`docs/plan/v2.5.0-sprint3-cdf-variant.md`**: Detailed implementation plan

## Key design note

CDF is an in-repo Spack package (`spack/cdf/package.py`), not a Spack builtin. All three `spack.yml` jobs now co-register `spack/cdf/package.py` alongside `spack/NEP/package.py` in the same local repo so `depends_on("cdf", when="+cdf")` resolves correctly during concretization.

## Acceptance Criteria

- `spack spec -I nep@2.4.0+cdf` concretizes without error
- `spack spec -I nep@main+cdf` concretizes without error
- `spack info nep` lists `cdf` variant (default OFF) with `cdf` as conditional dep
- `spack spec nep+cdf` includes `-DNEP_ENABLE_CDF=ON`
- `spack install nep+cdf` verifies `libnccdf.so` exists