### PR TITLE
v2.5.0 Sprint 4: PDS4 + Parallel + Remaining Spack Variants

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -176,6 +176,20 @@ jobs:
           spack spec -I nep@2.4.0+cdf
           spack spec -I nep@main+cdf
 
+      - name: Check package concretization (pds4 variant)
+        run: |
+          echo "=== Concretizing NEP with PDS4 variant ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack spec -I nep@2.4.0+pds4
+          spack spec -I nep@main+pds4
+
+      - name: Check package concretization (parallel variant)
+        run: |
+          echo "=== Concretizing NEP with parallel variant ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack spec -I nep@2.4.0+parallel
+          spack spec -I nep@main+parallel
+
   # Full install test - only runs on pushes to main
   install:
     name: Spack Install Test
@@ -386,6 +400,20 @@ jobs:
           spack install -v --fail-fast nep@main+cdf~docs~fortran 2>&1 | tee spack_install_main_cdf.log || true
           echo "=== nep@main+cdf installation attempt complete ==="
 
+      - name: Install NEP 2.4.0 with Spack (PDS4 variant)
+        run: |
+          echo "=== Installing nep@2.4.0+pds4 ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@2.4.0+pds4~docs~fortran 2>&1 | tee spack_install_2.4.0_pds4.log || true
+          echo "=== nep@2.4.0+pds4 installation attempt complete ==="
+
+      - name: Install NEP main with Spack (PDS4 variant)
+        run: |
+          echo "=== Installing nep@main+pds4 ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@main+pds4~docs~fortran 2>&1 | tee spack_install_main_pds4.log || true
+          echo "=== nep@main+pds4 installation attempt complete ==="
+
       - name: Show build logs (always runs)
         run: |
           echo "=== Showing build logs for manual review ==="
@@ -403,6 +431,10 @@ jobs:
           tail -200 spack_install_2.4.0_cdf.log || true
           echo "=== Spack install main cdf log (last 200 lines) ==="
           tail -200 spack_install_main_cdf.log || true
+          echo "=== Spack install 2.4.0 pds4 log (last 200 lines) ==="
+          tail -200 spack_install_2.4.0_pds4.log || true
+          echo "=== Spack install main pds4 log (last 200 lines) ==="
+          tail -200 spack_install_main_pds4.log || true
           echo "=== Finding build directories ==="
           find $HOME/spack/var/spack/stage -name '*.log' -o -name 'spack-build-out.txt' 2>/dev/null | head -10 || true
           echo "=== Showing any build output files ==="

--- a/docs/plan/v2.5.0-sprint4-remaining-variants.md
+++ b/docs/plan/v2.5.0-sprint4-remaining-variants.md
@@ -1,0 +1,141 @@
+# v2.5.0 Sprint 4: PDS4 + Parallel + Remaining Variants
+
+## Sprint Goal
+
+Add the remaining Spack variants (`pds4`, `parallel`, `examples`, `benchmarks`) to `spack/NEP/package.py`, pass all outstanding `NEP_ENABLE_*` / `NEP_BUILD_*` CMake flags, wire up dependency constraints for the parallel stack, and extend CI coverage.
+
+## Scope
+
+- Add 4 new variants to `spack/NEP/package.py`
+- Add dependencies: `libxml2` for PDS4, `mpi` for parallel
+- Adjust `hdf5` and `netcdf-c` deps for `+parallel`
+- Pass `NEP_ENABLE_PDS4`, `NEP_ENABLE_PARALLEL_TESTS`, `NEP_BUILD_EXAMPLES`, `NEP_ENABLE_BENCHMARKS` in `cmake_args`
+- Add `check_install` assertions for `libncpds4.so` and `libncfits.so`
+- Add spec and install CI steps in `.github/workflows/spack.yml`
+
+## Major Tasks (Dependency Order)
+
+### 1. Add variants to `spack/NEP/package.py`
+
+```python
+variant("pds4", default=False, description="Enable PDS4 reader support via libxml2")
+variant("parallel", default=False, description="Enable parallel I/O tests (requires MPI-enabled HDF5 and netcdf-c)")
+variant("examples", default=False, description="Build example programs")
+variant("benchmarks", default=False, description="Build performance benchmark programs")
+```
+
+### 2. Add dependencies
+
+```python
+depends_on("libxml2", when="+pds4", type=("build", "link"))
+depends_on("mpi", when="+parallel", type=("build", "link", "run"))
+```
+
+### 3. Adjust HDF5 and netcdf-c for parallel
+
+Replace the existing single HDF5 dep line with:
+```python
+depends_on("hdf5@1.12:+hl~mpi", when="~parallel", type=("build", "link"))
+depends_on("hdf5@1.12:+hl+mpi", when="+parallel", type=("build", "link"))
+depends_on("netcdf-c +mpi", when="+parallel", type=("build", "link"))
+```
+
+### 4. Extend `cmake_args`
+
+Add to the args list:
+```python
+self.define_from_variant("NEP_ENABLE_PDS4", "pds4"),
+self.define_from_variant("NEP_ENABLE_PARALLEL_TESTS", "parallel"),
+self.define_from_variant("NEP_BUILD_EXAMPLES", "examples"),
+self.define_from_variant("NEP_ENABLE_BENCHMARKS", "benchmarks"),
+```
+
+### 5. Extend `check_install`
+
+```python
+if "+pds4" in self.spec:
+    assert os.path.exists(join_path(self.prefix.lib, "libncpds4.so"))
+if "+fits" in self.spec:
+    assert os.path.exists(join_path(self.prefix.lib, "libncfits.so"))
+```
+
+### 6. Add CI spec steps (`.github/workflows/spack.yml`)
+
+Add dedicated spec steps:
+```yaml
+- name: Check package concretization (pds4 variant)
+  run: |
+    . $HOME/spack/share/spack/setup-env.sh
+    spack spec -I nep@2.4.0+pds4
+    spack spec -I nep@main+pds4
+
+- name: Check package concretization (parallel variant)
+  run: |
+    . $HOME/spack/share/spack/setup-env.sh
+    spack spec -I nep@2.4.0+parallel
+    spack spec -I nep@main+parallel
+```
+
+### 7. Add CI install steps (PDS4 only; parallel skipped)
+
+```yaml
+- name: Install NEP 2.4.0 with Spack (PDS4 variant)
+  run: |
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@2.4.0+pds4~docs~fortran 2>&1 | tee spack_install_2.4.0_pds4.log || true
+
+- name: Install NEP main with Spack (PDS4 variant)
+  run: |
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@main+pds4~docs~fortran 2>&1 | tee spack_install_main_pds4.log || true
+```
+
+No install step for `+parallel` — MPI builds are slow/unreliable on GitHub runners; spec check validates the dependency graph.
+
+### 8. Update log-tailing step
+
+Add `spack_install_2.4.0_pds4.log` and `spack_install_main_pds4.log` to the "Show build logs" step.
+
+## Acceptance Criteria
+
+- [ ] `spack spec -I nep@2.4.0+pds4` concretizes successfully
+- [ ] `spack spec -I nep@main+pds4` concretizes successfully
+- [ ] `spack spec -I nep@2.4.0+parallel` concretizes with `hdf5 +mpi` and `netcdf-c +mpi`
+- [ ] `spack spec -I nep@main+parallel` concretizes with `hdf5 +mpi` and `netcdf-c +mpi`
+- [ ] `cmake_args` includes `NEP_ENABLE_PDS4`, `NEP_ENABLE_PARALLEL_TESTS`, `NEP_BUILD_EXAMPLES`, `NEP_ENABLE_BENCHMARKS`
+- [ ] `check_install` verifies `libncpds4.so` when `+pds4`
+- [ ] `check_install` verifies `libncfits.so` when `+fits`
+- [ ] CI spec job passes for pds4 and parallel variants
+- [ ] CI install job passes for pds4 variant (with `|| true`)
+
+## Testing Requirements
+
+- **Spec checks**: `nep@2.4.0+pds4`, `nep@main+pds4`, `nep@2.4.0+parallel`, `nep@main+parallel`
+- **Install checks**: `nep@2.4.0+pds4~docs~fortran`, `nep@main+pds4~docs~fortran`
+- **Post-install**: `check_install()` asserts `libncpds4.so` and `libncfits.so`
+- **No parallel install in CI** — validated via spec concretization only
+
+## Build System Integration
+
+- **Spack package only** — no changes to CMake or Autotools
+- All CMake option names already exist: `NEP_ENABLE_PDS4`, `NEP_ENABLE_PARALLEL_TESTS`, `NEP_BUILD_EXAMPLES`, `NEP_ENABLE_BENCHMARKS`
+
+## Dependencies and Blockers
+
+- Sprint 3 (CDF variant) must be merged first
+- `libxml2` is a Spack builtin package — no in-repo recipe needed
+- `mpi` is a Spack virtual package — any MPI implementation satisfies it
+
+## Documentation Updates
+
+- `docs/roadmap.md` — sprint expanded (done in this planning step)
+- No `README.md` changes needed (Spack usage instructions deferred to Sprint 5)
+- No `docs/prd.md` or `docs/design.md` changes (no new features, only packaging)
+
+## Definition of Done
+
+- All acceptance criteria pass
+- `spack.yml` CI workflow updated with spec and install steps
+- `spack/NEP/package.py` has all 4 new variants with correct deps and cmake_args
+- `check_install` covers pds4 and fits libraries
+- GitHub issue created and linked in roadmap

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,11 +60,25 @@
 **GitHub Issue:** #272
 
 #### Sprint 4: PDS4 + Parallel + Remaining Variants
-- Add variants: `pds4`, `parallel`, `examples`, `benchmarks`.
-- Add deps: `libxml2` (pds4), `mpi` (parallel).
-- Pass all remaining `NEP_ENABLE_*` / `NEP_BUILD_*` flags in `cmake_args`.
-- When `+parallel`, adjust `hdf5` dep to `+mpi`.
-- **Testing**: Add `spack spec -I nep@2.4.0+pds4`, `spack spec -I nep@main+pds4`, `spack spec -I nep@2.4.0+parallel`, and `spack spec -I nep@main+parallel` to spec job; add `spack install -v nep@2.4.0+pds4~docs~fortran` and `spack install -v nep@main+pds4~docs~fortran` to install job. Parallel install-test optional (requires MPI).
+**Detailed Plan**: See `docs/plan/v2.5.0-sprint4-remaining-variants.md`
+
+- Add variants: `pds4` (default off), `parallel` (default off), `examples` (default off), `benchmarks` (default off).
+- Add deps: `depends_on("libxml2", when="+pds4")`, `depends_on("mpi", when="+parallel")`.
+- When `+parallel`, adjust `hdf5` dep to `+mpi` and `netcdf-c` dep to `+mpi` (parallel NEP requires both parallel HDF5 and parallel netcdf-c with `NC_HAS_PARALLEL4`).
+- Pass all remaining `NEP_ENABLE_*` / `NEP_BUILD_*` flags in `cmake_args`: `NEP_ENABLE_PDS4`, `NEP_ENABLE_PARALLEL_TESTS`, `NEP_BUILD_EXAMPLES`, `NEP_ENABLE_BENCHMARKS`.
+- Add `check_install` assertion for `libncpds4.so` when `+pds4`; add `libncfits.so` when `+fits` (missing from earlier sprints).
+- **Testing**: Add dedicated spec steps for `nep@2.4.0+pds4`, `nep@main+pds4`, `nep@2.4.0+parallel`, and `nep@main+parallel` to spec job. Add `spack install -v nep@2.4.0+pds4~docs~fortran` and `spack install -v nep@main+pds4~docs~fortran` to install job with `|| true` and log tailing. Parallel install-test skipped in CI (spec-only); MPI builds are slow and unreliable on GitHub runners.
+
+**Clarified decisions:**
+- `parallel` variant maps to `NEP_ENABLE_PARALLEL_TESTS` in `cmake_args`; parallel I/O itself is automatic when netcdf-c is built with MPI — the variant ensures the parallel stack is concretized and tests are enabled.
+- Split HDF5 dependency: base dep `depends_on("hdf5@1.12:+hl~mpi", when="~parallel")`, parallel dep `depends_on("hdf5@1.12:+hl+mpi", when="+parallel")`.
+- Add `depends_on("netcdf-c +mpi", when="+parallel")` so Spack concretizes with parallel netcdf-c.
+- `examples` and `benchmarks` default OFF, matching CMake defaults (`NEP_BUILD_EXAMPLES=OFF`, `NEP_ENABLE_BENCHMARKS=OFF`).
+- `check_install()` asserts `libncpds4.so` when `+pds4` (CMake target: `ncpds4`), consistent with all other format variant checks.
+- Also add missing `libncfits.so` check when `+fits` (CMake target: `ncfits`).
+- Parallel: spec-only in CI (no install step) due to MPI build complexity on runners.
+
+**GitHub Issue:** #274
 
 #### Sprint 5: Polish, CI, and Integration Testing
 - Add `conflicts()` for known incompatibilities.

--- a/spack/NEP/package.py
+++ b/spack/NEP/package.py
@@ -47,12 +47,18 @@ class Nep(CMakePackage):
     variant("geotiff", default=False, description="Enable GeoTIFF reader support via libgeotiff")
     variant("grib2", default=False, description="Enable GRIB2 reader support via NCEPLIBS-g2c")
     variant("cdf", default=False, description="Enable NASA CDF reader support")
+    variant("pds4", default=False, description="Enable PDS4 reader support via libxml2")
+    variant("parallel", default=False, description="Enable parallel I/O tests (requires MPI-enabled HDF5 and netcdf-c)")
+    variant("examples", default=False, description="Build example programs")
+    variant("benchmarks", default=False, description="Build performance benchmark programs")
 
     depends_on("c", type="build")
     depends_on("fortran", when="+fortran", type="build")
 
     depends_on("netcdf-c@4.10.1:", type=("build", "link"))
-    depends_on("hdf5@1.12:+hl~mpi", type=("build", "link"))
+    depends_on("netcdf-c +mpi", when="+parallel", type=("build", "link"))
+    depends_on("hdf5@1.12:+hl~mpi", when="~parallel", type=("build", "link"))
+    depends_on("hdf5@1.12:+hl+mpi", when="+parallel", type=("build", "link"))
     depends_on("lz4", when="+lz4", type=("build", "link"))
     depends_on("bzip2", when="+bzip2", type=("build", "link"))
     depends_on("netcdf-fortran", when="+fortran", type=("build", "link"))
@@ -60,6 +66,8 @@ class Nep(CMakePackage):
     depends_on("libgeotiff", when="+geotiff", type=("build", "link"))
     depends_on("g2c", when="+grib2", type=("build", "link"))
     depends_on("cdf", when="+cdf", type=("build", "link"))
+    depends_on("libxml2", when="+pds4", type=("build", "link"))
+    depends_on("mpi", when="+parallel", type=("build", "link", "run"))
     depends_on("libtiff", when="+geotiff", type=("build", "link"))
     depends_on("doxygen", when="+docs", type="build")
 
@@ -73,6 +81,10 @@ class Nep(CMakePackage):
             self.define_from_variant("NEP_ENABLE_GEOTIFF", "geotiff"),
             self.define_from_variant("NEP_ENABLE_GRIB2", "grib2"),
             self.define_from_variant("NEP_ENABLE_CDF", "cdf"),
+            self.define_from_variant("NEP_ENABLE_PDS4", "pds4"),
+            self.define_from_variant("NEP_ENABLE_PARALLEL_TESTS", "parallel"),
+            self.define_from_variant("NEP_BUILD_EXAMPLES", "examples"),
+            self.define_from_variant("NEP_ENABLE_BENCHMARKS", "benchmarks"),
         ]
         return args
 
@@ -93,3 +105,7 @@ class Nep(CMakePackage):
             assert os.path.exists(join_path(self.prefix.lib, "libncgrib2.so"))
         if "+cdf" in self.spec:
             assert os.path.exists(join_path(self.prefix.lib, "libnccdf.so"))
+        if "+pds4" in self.spec:
+            assert os.path.exists(join_path(self.prefix.lib, "libncpds4.so"))
+        if "+fits" in self.spec:
+            assert os.path.exists(join_path(self.prefix.lib, "libncfits.so"))


### PR DESCRIPTION
## Summary

Adds the remaining Spack variants (`pds4`, `parallel`, `examples`, `benchmarks`) to `spack/NEP/package.py`, wires up dependency constraints for the parallel stack, and extends CI coverage.

Closes #274

## Changes

### `spack/NEP/package.py`
- Add `variant("pds4", default=False)` with `depends_on("libxml2", when="+pds4")`
- Add `variant("parallel", default=False)` with `depends_on("mpi", when="+parallel")`
- Split HDF5 dep: `hdf5@1.12:+hl~mpi` when `~parallel`, `hdf5@1.12:+hl+mpi` when `+parallel`
- Add `depends_on("netcdf-c +mpi", when="+parallel")` for parallel netcdf-c
- Add `variant("examples", default=False)` and `variant("benchmarks", default=False)`
- Extend `cmake_args`: `NEP_ENABLE_PDS4`, `NEP_ENABLE_PARALLEL_TESTS`, `NEP_BUILD_EXAMPLES`, `NEP_ENABLE_BENCHMARKS`
- Extend `check_install`: assert `libncpds4.so` when `+pds4`, assert `libncfits.so` when `+fits`

### `.github/workflows/spack.yml`
- Add spec steps for `+pds4` and `+parallel` variants (both `@2.4.0` and `@main`)
- Add install steps for `+pds4` (`@2.4.0` and `@main`, with `|| true`)
- No install step for `+parallel` (spec-only; MPI builds too slow for runners)
- Add log tailing for PDS4 install logs

### `docs/`
- Expanded sprint description in `docs/roadmap.md` with clarified decisions
- Created `docs/plan/v2.5.0-sprint4-remaining-variants.md`

## Design Decisions
- `parallel` variant maps to `NEP_ENABLE_PARALLEL_TESTS` — parallel I/O itself is automatic when netcdf-c is built with MPI
- All new variants default OFF, matching CMake defaults
- `libxml2` is a Spack builtin; `mpi` is a Spack virtual package