### PR TITLE
v2.5.0 Sprint 5: Polish, CI, and Integration Testing

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -190,6 +190,13 @@ jobs:
           spack spec -I nep@2.4.0+parallel
           spack spec -I nep@main+parallel
 
+      - name: Check package concretization (all format variants)
+        run: |
+          echo "=== Concretizing NEP with all format variants ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs
+          spack spec -I nep@main+geotiff+grib2+cdf+fits+pds4+fortran+docs
+
   # Full install test - only runs on pushes to main
   install:
     name: Spack Install Test
@@ -414,6 +421,20 @@ jobs:
           spack install -v --fail-fast nep@main+pds4~docs~fortran 2>&1 | tee spack_install_main_pds4.log || true
           echo "=== nep@main+pds4 installation attempt complete ==="
 
+      - name: Install NEP 2.4.0 with Spack (all format variants)
+        run: |
+          echo "=== Installing nep@2.4.0 with all format variants ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@2.4.0+geotiff+grib2+cdf+fits+pds4~docs~fortran 2>&1 | tee spack_install_2.4.0_all.log
+          echo "=== nep@2.4.0 all-format-variants installation complete ==="
+
+      - name: Install NEP main with Spack (all format variants)
+        run: |
+          echo "=== Installing nep@main with all format variants ==="
+          . $HOME/spack/share/spack/setup-env.sh
+          spack install -v --fail-fast nep@main+geotiff+grib2+cdf+fits+pds4~docs~fortran 2>&1 | tee spack_install_main_all.log
+          echo "=== nep@main all-format-variants installation complete ==="
+
       - name: Show build logs (always runs)
         run: |
           echo "=== Showing build logs for manual review ==="
@@ -435,6 +456,10 @@ jobs:
           tail -200 spack_install_2.4.0_pds4.log || true
           echo "=== Spack install main pds4 log (last 200 lines) ==="
           tail -200 spack_install_main_pds4.log || true
+          echo "=== Spack install 2.4.0 all-variants log (last 200 lines) ==="
+          tail -200 spack_install_2.4.0_all.log || true
+          echo "=== Spack install main all-variants log (last 200 lines) ==="
+          tail -200 spack_install_main_all.log || true
           echo "=== Finding build directories ==="
           find $HOME/spack/var/spack/stage -name '*.log' -o -name 'spack-build-out.txt' 2>/dev/null | head -10 || true
           echo "=== Showing any build output files ==="

--- a/README.md
+++ b/README.md
@@ -199,6 +199,73 @@ LZ4 and BZIP2 compression are provided as HDF5 filter plugins. Simply set the `H
 export HDF5_PLUGIN_PATH=/usr/local/lib/plugin
 ```
 
+### Spack Installation
+
+NEP can be installed using the [Spack](https://spack.io) package manager.
+
+#### Default install
+
+```bash
+spack install nep
+```
+
+This builds NEP with LZ4, BZIP2, Fortran wrappers, and documentation — no format readers.
+
+#### Variant reference
+
+| Variant | Default | Description |
+|---------|---------|-------------|
+| `docs` | ON | Build Doxygen documentation (requires Doxygen) |
+| `lz4` | ON | LZ4 compression filter (requires liblz4) |
+| `bzip2` | ON | BZIP2 compression filter (requires libbz2) |
+| `fortran` | ON | Fortran wrappers and tests (requires NetCDF-Fortran) |
+| `fits` | OFF | FITS reader — HST, JWST, Chandra (requires CFITSIO) |
+| `geotiff` | OFF | GeoTIFF reader — CF-1.8 CRS metadata (requires libgeotiff) |
+| `grib2` | OFF | GRIB2 reader — NWP model output (requires NCEPLIBS-g2c) |
+| `cdf` | OFF | NASA CDF reader — space physics (requires local Spack repo, see below) |
+| `pds4` | OFF | PDS4 reader — planetary science (requires libxml2) |
+| `parallel` | OFF | Parallel I/O tests (requires MPI, HDF5+mpi, netcdf-c+mpi) |
+| `examples` | OFF | Example programs |
+| `benchmarks` | OFF | Performance benchmark programs |
+
+#### Common combinations
+
+```bash
+# GeoTIFF + GRIB2 (geospatial and NWP workflows)
+spack install nep+geotiff+grib2
+
+# All format readers
+spack install nep+geotiff+grib2+cdf+fits+pds4
+
+# Minimal build (no docs, no Fortran) for CI/containers
+spack install nep~docs~fortran
+
+# Parallel I/O (requires MPI stack)
+spack install nep+parallel
+```
+
+#### Installing the NASA CDF variant (`+cdf`)
+
+The NASA CDF library is not a Spack builtin. The in-repo `spack/cdf/package.py` recipe must be registered in a local Spack repository before concretizing `+cdf`:
+
+```bash
+# 1. Create a local Spack repository containing both NEP and CDF recipes
+mkdir -p $HOME/nep-repo/packages/nep
+mkdir -p $HOME/nep-repo/packages/cdf
+cp spack/NEP/package.py $HOME/nep-repo/packages/nep/
+cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
+cat > $HOME/nep-repo/repo.yaml << 'EOF'
+repo:
+  namespace: nep-local
+EOF
+
+# 2. Register the repository with Spack
+spack repo add $HOME/nep-repo
+
+# 3. Install with +cdf
+spack install nep+cdf
+```
+
 ---
 
 ## Documentation

--- a/docs/plan/v2.5.0-sprint5-polish-ci.md
+++ b/docs/plan/v2.5.0-sprint5-polish-ci.md
@@ -1,0 +1,136 @@
+# v2.5.0 Sprint 5: Polish, CI, and Integration Testing
+
+## Sprint Goal
+
+Complete the v2.5.0 Spack packaging work by adding all-variants integration CI steps, updating `README.md` with comprehensive Spack installation instructions, and verifying that `nep+geotiff+grib2+cdf+fits+pds4` concretizes and installs cleanly from both the `2.4.0` release and the `main` branch.
+
+## Scope
+
+- Add all-variants spec steps to `.github/workflows/spack.yml` spec job
+- Add all-variants install steps to `.github/workflows/spack.yml` install job (hard failure)
+- Update `README.md` with a comprehensive Spack installation section
+- No changes to `spack/NEP/package.py` — all variants are complete from Sprints 1–4
+- No `conflicts()` declarations — no CMake-level incompatibilities exist
+- No `spack test()` method — functional post-install testing deferred
+
+## Major Tasks (Dependency Order)
+
+### 1. Add all-variants spec step to `spack.yml` spec job
+
+Add after the existing `parallel` spec step:
+
+```yaml
+- name: Check package concretization (all format variants)
+  run: |
+    echo "=== Concretizing NEP with all format variants ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs
+    spack spec -I nep@main+geotiff+grib2+cdf+fits+pds4+fortran+docs
+```
+
+`+parallel` is intentionally excluded from the combined spec — it forces `hdf5+mpi` and `netcdf-c+mpi` throughout the tree and is already covered by the dedicated parallel spec step from Sprint 4.
+
+### 2. Add all-variants install steps to `spack.yml` install job
+
+Add after the existing PDS4 install steps. These use **hard failure** — no `|| true`:
+
+```yaml
+- name: Install NEP 2.4.0 with Spack (all format variants)
+  run: |
+    echo "=== Installing nep@2.4.0 with all format variants ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@2.4.0+geotiff+grib2+cdf+fits+pds4~docs~fortran 2>&1 | tee spack_install_2.4.0_all.log
+
+- name: Install NEP main with Spack (all format variants)
+  run: |
+    echo "=== Installing nep@main with all format variants ==="
+    . $HOME/spack/share/spack/setup-env.sh
+    spack install -v --fail-fast nep@main+geotiff+grib2+cdf+fits+pds4~docs~fortran 2>&1 | tee spack_install_main_all.log
+```
+
+Add `spack_install_2.4.0_all.log` and `spack_install_main_all.log` to the "Show build logs" step.
+
+### 3. Update `README.md` with comprehensive Spack section
+
+Add a **Spack Installation** section covering:
+
+- One-liner for default install: `spack install nep`
+- Full variant table (all variants, defaults, descriptions)
+- Common combination examples
+- Step-by-step local repo setup for `+cdf` (required because `spack/cdf/package.py` is not a Spack builtin)
+- Notes on `+parallel` requirements
+
+#### Variant table to include
+
+| Variant | Default | Description |
+|---------|---------|-------------|
+| `docs` | ON | Build Doxygen documentation |
+| `lz4` | ON | LZ4 compression filter |
+| `bzip2` | ON | BZIP2 compression filter |
+| `fortran` | ON | Fortran wrappers |
+| `fits` | OFF | FITS reader (requires CFITSIO) |
+| `geotiff` | OFF | GeoTIFF reader (requires libgeotiff) |
+| `grib2` | OFF | GRIB2 reader (requires NCEPLIBS-g2c) |
+| `cdf` | OFF | NASA CDF reader (requires local Spack repo) |
+| `pds4` | OFF | PDS4 reader (requires libxml2) |
+| `parallel` | OFF | Parallel I/O tests (requires MPI HDF5 + netcdf-c) |
+| `examples` | OFF | Example programs |
+| `benchmarks` | OFF | Performance benchmarks |
+
+#### CDF local repo setup steps
+
+```bash
+# Create a local Spack repository
+mkdir -p $HOME/nep-repo/packages/nep
+mkdir -p $HOME/nep-repo/packages/cdf
+cp spack/NEP/package.py $HOME/nep-repo/packages/nep/
+cp spack/cdf/package.py $HOME/nep-repo/packages/cdf/
+cat > $HOME/nep-repo/repo.yaml << 'EOF'
+repo:
+  namespace: nep-local
+EOF
+spack repo add $HOME/nep-repo
+
+# Then install with +cdf
+spack install nep+cdf
+```
+
+## Acceptance Criteria
+
+- [ ] `spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs` concretizes
+- [ ] `spack spec -I nep@main+geotiff+grib2+cdf+fits+pds4+fortran+docs` concretizes
+- [ ] `spack install -v --fail-fast nep@2.4.0+geotiff+grib2+cdf+fits+pds4~docs~fortran` succeeds
+- [ ] `spack install -v --fail-fast nep@main+geotiff+grib2+cdf+fits+pds4~docs~fortran` succeeds
+- [ ] `README.md` has a Spack section with variant table and CDF local-repo setup
+- [ ] All-variants log files captured in "Show build logs" step
+- [ ] No `conflicts()` added (confirmed no CMake-level incompatibilities)
+
+## Testing Requirements
+
+- **Spec checks**: `nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs` and `nep@main` equivalent
+- **Install checks**: All-format-variants install for both `2.4.0` and `main` — hard failure
+- **`+parallel` spec check**: Retained from Sprint 4 (dedicated step, not combined with all-variants)
+- **No `spack test`**: Post-install functional testing deferred to a future sprint
+
+## Build System Integration
+
+- **`spack/NEP/package.py`** — no changes required; all variants complete from Sprints 1–4
+- **`.github/workflows/spack.yml`** — add all-variants spec step and two install steps
+- **`README.md`** — new Spack section added
+
+## Dependencies and Blockers
+
+- Sprint 4 (PDS4 + Parallel + Remaining Variants) must be merged first
+- All format variant packages must be available in the Spack repo (GeoTIFF, GRIB2, CDF, FITS, PDS4 are all Spack builtins except CDF)
+
+## Documentation Updates
+
+- `README.md` — new comprehensive Spack installation section
+- `docs/roadmap.md` — sprint expanded (done in this planning step)
+
+## Definition of Done
+
+- All acceptance criteria pass
+- `spack.yml` has all-variants spec and install steps
+- `README.md` Spack section is complete with variant table and CDF local-repo setup
+- GitHub issue created and linked in `docs/roadmap.md`

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -1,0 +1,118 @@
+# NEP v2.5.0 - Complete Spack Variant Coverage and Integration Testing
+
+> Adds Spack variants for every optional NEP capability (GeoTIFF, GRIB2, CDF, PDS4, parallel, examples, benchmarks), pins `v2.4.0` and `main` in the Spack package, and introduces all-variants CI integration testing with comprehensive installation documentation.
+
+---
+
+## Highlights
+
+- **Every Optional Reader is Now a Spack Variant** (#269, #271, #273, #275) — `geotiff`, `grib2`, `cdf`, `pds4`, and `fits` each have dedicated variants defaulting OFF, with correct conditional dependencies and `check_install()` assertions for their dispatch libraries
+- **Build & Test Utilities as Variants** (#275) — `examples` and `benchmarks` are now selectable Spack variants, and `parallel` triggers the MPI-enabled HDF5/netcdf-c stack and `NEP_ENABLE_PARALLEL_TESTS`
+- **v2.4.0 and `main` Pinned in Spack** (#269) — `spack/NEP/package.py` adds `version("2.4.0", ...)` with the published SHA256 and `version("main", branch="main")` so CI can concretize and install both pinned releases and the development branch
+- **All-Variants CI Integration Testing** (#276) — `.github/workflows/spack.yml` adds hard-failure install steps for `nep@2.4.0+geotiff+grib2+cdf+fits+pds4` and `nep@main+...`, plus parallel spec-only checks
+- **Comprehensive README Spack Section** (#276) — full variant table, common combination examples, and step-by-step local-repo setup for the non-builtin `+cdf` NASA CDF variant
+
+---
+
+## Features
+
+### Spack Format Variants — GeoTIFF, GRIB2, CDF, PDS4, and FITS (#269, #271, #273, #275)
+
+- `spack/NEP/package.py` now declares one variant per optional format reader, all defaulting OFF to match CMake defaults:
+  - `geotiff` → `depends_on("libgeotiff")` and `depends_on("libtiff")` (#269)
+  - `grib2` → `depends_on("g2c")` (NCEPLIBS-g2c) (#271)
+  - `cdf` → `depends_on("cdf")` via the in-repo `spack/cdf/package.py` (#273)
+  - `pds4` → `depends_on("libxml2")` (#275)
+  - `fits` dependency on `cfitsio` was already present; `check_install()` now asserts `libncfits.so` (#275)
+- Each variant wires the corresponding `NEP_ENABLE_*` CMake option through `self.define_from_variant(...)`
+- `check_install()` asserts the correct dispatch library for every enabled variant: `libncgeotiff.so`, `libncgrib2.so`, `libnccdf.so`, `libncpds4.so`, `libncfits.so`
+
+### Spack Parallel Stack Variant (#275)
+
+- New `parallel` variant (default OFF) maps to `NEP_ENABLE_PARALLEL_TESTS`
+- Splits the HDF5 dependency: `hdf5@1.12:+hl~mpi` when `~parallel`, `hdf5@1.12:+hl+mpi` when `+parallel`
+- Adds `depends_on("netcdf-c +mpi", when="+parallel")` so Spack concretizes a parallel-capable netcdf-c automatically
+- Spec-only CI step for `+parallel` because MPI builds are too slow for standard GitHub runners
+
+### Build & Example Utilities as Variants (#275)
+
+- `examples` variant → `NEP_BUILD_EXAMPLES`
+- `benchmarks` variant → `NEP_ENABLE_BENCHMARKS`
+- Both default OFF to match CMake defaults
+
+### Integration Testing and CI Polish (#276)
+
+- All-variants spec checks: `spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs` and the same for `nep@main`
+- All-variants install checks run as hard failures (`--fail-fast`, no `|| true`) so real incompatibilities surface immediately
+- `+parallel` retained as a dedicated spec step to avoid forcing MPI on the full format-variants tree
+
+---
+
+## Bug Fixes
+
+None.
+
+---
+
+## API Changes
+
+None.
+
+---
+
+## Build System
+
+- `spack/NEP/package.py` gained 8 new variants and their conditional dependencies, plus `version("2.4.0")` and `version("main")` entries
+- `cmake_args()` now emits the full set of `NEP_ENABLE_*` and `NEP_BUILD_*` options for all variants
+- `check_install()` verifies the expected dispatch library for every enabled format reader
+- HDF5 and netcdf-c dependencies are now conditional on the `+parallel` variant
+- `.github/workflows/spack.yml` registers `spack/cdf/package.py` in the same local repo as `spack/NEP/package.py` so the non-builtin `+cdf` variant resolves
+
+---
+
+## Testing
+
+- Dedicated Spack spec and install steps for `+geotiff`, `+grib2`, `+cdf`, and `+pds4` (both `@2.4.0` and `@main`)
+- All-variants integration install is a hard CI failure for both `@2.4.0` and `@main`
+- `+parallel` is spec-only in CI due to MPI build times on GitHub runners
+- `check_install()` assertions catch missing dispatch libraries immediately after install
+
+---
+
+## Documentation
+
+- `README.md`: new **Spack Installation** subsection with default install one-liner, full 12-variant reference table, common combination examples, and step-by-step local-repo setup for `+cdf`
+- `docs/roadmap.md`: v2.5.0 section expanded with clarified decisions, issue links, and plan references for all five sprints
+- `docs/plan/v2.5.0-sprint1-geotiff-variant.md`, `v2.5.0-sprint2-grib2-variant.md`, `v2.5.0-sprint3-cdf-variant.md`, `v2.5.0-sprint4-remaining-variants.md`, `v2.5.0-sprint5-polish-ci.md`: detailed sprint plans
+
+---
+
+## Dependencies
+
+- New Spack-only dependencies for optional variants: `libgeotiff`, `libtiff`, `g2c`, `cdf` (in-repo), `libxml2`, and the `mpi` virtual package
+- `netcdf-c >= 4.10.1` remains the minimum required version
+- No new library dependencies required for a default NEP build
+
+---
+
+## Known Limitations
+
+- `nc_get_vars()` and `nc_get_varm()` rely on default dispatch fallbacks (no strided native reads)
+- PDS4: `Table_Delimited` row-count derived from label `<records>` only
+- Grouped fields (`Group_Field_Binary`, etc.) and bit fields not yet supported in the PDS4 reader
+
+---
+
+## Breaking Changes
+
+None. All new Spack variants default OFF, so existing `spack install nep` behavior and default CMake builds are unchanged. The `NEP_*` CMake option names introduced in v2.4.0 remain in effect.
+
+---
+
+## Release Summary
+
+- **Released**: 2026-07-11
+- **Scope**: v2.5.0 — More Spack Improvements
+- **Issues**: #268, #270, #272, #274, #276
+- **Pull Requests**: #269, #271, #273, #275
+- **Contributors**: captainkirk99 (Edward Hartnett)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,11 +81,23 @@
 **GitHub Issue:** #274
 
 #### Sprint 5: Polish, CI, and Integration Testing
-- Add `conflicts()` for known incompatibilities.
-- Add spack CI smoke test or documentation.
-- Verify full `spack install nep +geotiff +grib2 +cdf +fits +pds4` resolves and builds.
-- Update `README.md` spack installation instructions.
-- **Testing**: All-variants spec check: `spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs` and `spack spec -I nep@main+geotiff+grib2+cdf+fits+pds4+fortran+docs`. Full install with all format variants enabled for both versions. Verify `spack spec` correctly rejects invalid combinations from `conflicts()` declarations.
+**Detailed Plan**: See `docs/plan/v2.5.0-sprint5-polish-ci.md`
+
+- No `conflicts()` declarations added — no CMake-level incompatibilities exist across format variants; Spack `depends_on` constraints already guard the parallel stack.
+- Update `README.md` with a comprehensive Spack installation section: full variant table with descriptions, common combination examples (e.g., `nep+geotiff+grib2`), and step-by-step local repo setup for `+cdf` (non-obvious requirement).
+- Add all-variants spec steps to `spack.yml` spec job: `spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs` and `spack spec -I nep@main+geotiff+grib2+cdf+fits+pds4+fortran+docs`. Keep `+parallel` in a dedicated separate spec step (mixing it into all-variants forces MPI on the entire tree).
+- Add all-variants install steps to `spack.yml` install job as **hard failures** (no `|| true`): `spack install -v --fail-fast nep@2.4.0+geotiff+grib2+cdf+fits+pds4~docs~fortran` and `nep@main+geotiff+grib2+cdf+fits+pds4~docs~fortran`. Sprint 5 is the integration milestone; hard failures surface real breakage.
+- No `spack test` method added — functional post-install testing deferred to a future sprint.
+- **Testing**: All-variants spec check (both `2.4.0` and `main`); all-variants install (hard fail); `+parallel` spec-only check retained from Sprint 4.
+
+**Clarified decisions:**
+- No `conflicts()` added: all format variants are independent at the CMake level; the parallel stack is guarded by conditional `depends_on` constraints already in place.
+- All-variants install uses hard `--fail-fast` without `|| true`; Sprint 5 is the final integration milestone for the Spack packaging work.
+- `+parallel` kept as a dedicated spec step; it is not combined with the all-format-variants spec because it requires `hdf5+mpi` and `netcdf-c+mpi` throughout, which inflates the dependency tree.
+- `README.md` Spack section is comprehensive: full variant table, common usage examples, and inline CDF local-repo setup steps.
+- No `spack test` / `test()` method — functional post-install testing is out of scope for this sprint.
+
+**GitHub Issue:** #276
 
 
 ### V2.4.0 Spack Improvements


### PR DESCRIPTION
Implements [v2.5.0 Sprint 5](https://github.com/Intelligent-Data-Design-Inc/NEP/issues/276): all-variants Spack CI integration and comprehensive Spack installation documentation.

## Changes

### `.github/workflows/spack.yml`
- **Spec job**: new step `Check package concretization (all format variants)` — runs `spack spec -I nep@2.4.0+geotiff+grib2+cdf+fits+pds4+fortran+docs` and `nep@main` equivalent on every PR and push
- **Install job**: new step `Install NEP 2.4.0 with Spack (all format variants)` — hard fail (`--fail-fast`, no `|| true`)
- **Install job**: new step `Install NEP main with Spack (all format variants)` — hard fail
- **Show build logs**: added `spack_install_2.4.0_all.log` and `spack_install_main_all.log` to log-tailing step
- `+parallel` remains in its own dedicated spec step (not merged into all-variants — would force MPI on entire tree)

### `README.md`
- New **Spack Installation** section with:
  - Default install one-liner
  - Full 12-variant reference table with defaults and descriptions
  - Common combination examples (GeoTIFF+GRIB2, all-formats, minimal, parallel)
  - Step-by-step local repo setup for `+cdf` (NASA CDF is not a Spack builtin)

### No `conflicts()` added
All format variants are independent at the CMake level. The parallel stack is already guarded by conditional `depends_on` constraints from Sprint 4.

## Detailed Plan
See `docs/plan/v2.5.0-sprint5-polish-ci.md`