### PR TITLE
Fix pds4.md Doxygen page showing empty: remove {#pds4_mapping} label

### DIFF
--- a/docs/pds4.md
+++ b/docs/pds4.md
@@ -1,4 +1,4 @@
-# PDS4-to-NetCDF Mapping {#pds4_mapping}
+# PDS4-to-NetCDF Mapping
 
 This page describes how the NEP PDS4 reader maps the Planetary Data System
 version 4 (PDS4) information model to the NetCDF-4 (enhanced) data model.


### PR DESCRIPTION
The {#pds4_mapping} anchor on the top-level heading caused Doxygen 1.9.x to register the page under that id but not render the body content, resulting in an empty page in the HTML output. Removing the label (which was not cross-referenced anywhere) lets Doxygen render the full page normally, consistent with the other docs/*.md pages.