### PR TITLE
v2.7.0 Sprint 2: Add New Horizons Alice ali_0400644769 PDS4 regression test

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -224,8 +224,9 @@ NEP's PDS4 reader is validated against a mix of small synthetic labels and real 
 | **MESSENGER** | Mercury thermal neutron map (Peplowski et al., 2015) | `messenger_tnmap/thermal_neutron_map.xml`, `thermal_neutron_map.img` | `Array_2D_Image` | `UnsignedByte` |
 | **LCS-9P / McDonald Observatory** | Comet 9P/Tempel 1 CN photometry and column densities | `lcs_9p/20050706_000.xml`, `20050706_000.tab` | `Table_Character` | `ASCII_Integer`, `ASCII_Real` |
 | **New Horizons** | Alice Jupiter encounter pixel-list product | `new_horizons/ali_0030420276_0x4b0_sci_1.lblx`, `ali_0030420276_0x4b0_sci_1.fit` | `Array_2D_Spectrum`, `Table_Binary` | `IEEE754MSBSingle`, `SignedMSB2`, `IEEE754MSBDouble` |
+| **New Horizons** | Alice KEM1 calibrated histogram product | `new_horizons/ali_0400644769_0x4b2_sci.lblx`, `ali_0400644769_0x4b2_sci.fit` | `Array_2D_Spectrum`, `Array_1D`, `Table_Binary` | `IEEE754MSBSingle`, `SignedMSB4`, `UnsignedByte` |
 
-These mission products exercise data types and structures not covered by the synthetic tests, including unsigned byte images, date/time strings, integer ASCII fields, real-world table layouts, spectrum arrays, and FITS-backed PDS4 payloads.
+These mission products exercise data types and structures not covered by the synthetic tests, including unsigned byte images, date/time strings, integer ASCII fields, real-world table layouts, spectrum arrays, 1D spectra, housekeeping tables, and FITS-backed PDS4 payloads.
 
 ---
 

--- a/docs/pds4.md
+++ b/docs/pds4.md
@@ -304,3 +304,4 @@ The following real mission datasets have been validated:
 | Mars 2020 / Perseverance | Mastcam-Z (ZCAM) | Sol 1738 calibrated radiance image | `.IMG` (Array_3D_Image, Band=3 × Line=1200 × Sample=1648, `SignedMSB2`) |
 | Mars 2020 / Perseverance | Mastcam-Z (ZCAM) | Sol 1737 calibrated radiance image | `.IMG` (Array_3D_Image, Band=3 × Line=1200 × Sample=1648, `SignedMSB2`) |
 | New Horizons | Alice ultraviolet imaging spectrograph | Jupiter encounter partially processed pixel-list product | `.lblx` label + `.fit` container (Array_2D_Spectrum and Table_Binary) |
+| New Horizons | Alice ultraviolet imaging spectrograph | KEM1 calibrated histogram/PHD/housekeeping product | `.lblx` label + `.fit` container (Array_2D_Spectrum, Array_1D, and Table_Binary) |

--- a/docs/plan/v2.7.0-sprint2-new-horizons-ali-0400644769.md
+++ b/docs/plan/v2.7.0-sprint2-new-horizons-ali-0400644769.md
@@ -1,0 +1,123 @@
+# v2.7.0 Sprint 2: New Horizons Alice `ali_0400644769_0x4b2_sci` PDS4 Product
+
+## Sprint Goal
+
+Add a regression test for the second New Horizons Alice PDS4 product
+`ali_0400644769_0x4b2_sci.lblx` and extend the PDS4 reader only where the
+build reveals a gap needed to expose and read its PDS4-defined data objects
+through the standard NetCDF API.
+
+## Scope
+
+The product is a PDS4 `.lblx` XML label paired with a FITS binary container.
+The PDS4 handler remains authoritative for the NetCDF model and uses its
+existing label-defined byte-offset data path; this sprint does not delegate to
+the FITS UDF or introduce a PDS4 dependency on CFITSIO.
+
+The label contains:
+
+- Three `Array_2D_Spectrum` objects (`Observational Data`, `Histogram
+  Uncertainties`, `Wavelength Image`) with dimensions `[32, 1024]` and type
+  `IEEE754MSBSingle`.
+- One `Array_1D` object (`Pulse Height Distribution (PHD)`) with dimension
+  `[64]` and type `SignedMSB4`.
+- One `Table_Binary` object (`Housekeeping (HK)`) with 102 records and 117
+  flat `Field_Binary` fields.
+
+The starting assumption is that the existing generic array reader and flat
+binary-table reader already handle these objects, but reader fixes are in
+scope if the build/run exposes a gap.
+
+## Implementation Plan
+
+1. Inspect `src/pds4file.c` and run the PDS4 test build to confirm that
+   `Array_1D` and the 117-field `Table_Binary` are handled. Apply minimal
+   reader fixes if needed.
+2. Add the `.lblx` label and companion `.fit` payload to CMake and Autotools
+   out-of-tree test-data copy/distribution rules under
+   `data/PDS4/new_horizons/`.
+3. Add two test functions to `test/tst_pds4_udf.c`:
+   - `test_mission_new_horizons_0400644769_metadata()` — open the label,
+     locate the file-area group `ali_0400644769_0x4b2_sci.fit`, and verify
+     representative metadata:
+       - `Observational Data`: `NC_FLOAT`, `ndims=2`, dims `[32, 1024]`,
+         `units="PHOTON CM**-2 S**-1"`, `scaling_factor="1.00000000000"`,
+         `value_offset="0.00000000000"`.
+       - `Pulse Height Distribution (PHD)`: `NC_INT`, `ndims=1`, dim `64`,
+         `units="COUNT"`.
+       - `Table_Binary`: `record` dimension length 102, a representative
+         field such as `SAFETY_ACTIVE` exists and is `NC_UBYTE` / `ndims=1`.
+   - `test_mission_new_horizons_0400644769_data()` — perform successful
+     data reads:
+       - `Observational Data[0, 0:4]` as `NC_FLOAT`.
+       - `Pulse Height Distribution (PHD)[0]` as `NC_INT`.
+       - `SAFETY_ACTIVE[0]` as `NC_UBYTE`.
+     Assertions verify `NC_NOERR` and label-consistent value invariants.
+4. Wire both test functions into `main()` after the existing Sprint 1 New
+   Horizons call.
+5. Update `docs/pds4.md` to add the second New Horizons Alice product to
+   the tested-mission table.
+6. Update `docs/formats.md` with the corresponding mission-test inventory
+   entry.
+7. Update `docs/roadmap.md` with the clarified scope, detailed plan
+   reference, acceptance criteria, testing notes, build-system integration,
+   dependencies, definition of done, and GitHub issue link.
+
+## Acceptance Criteria
+
+- `nc_open()` successfully opens `ali_0400644769_0x4b2_sci.lblx` through
+  the PDS4 UDF.
+- The file-area group for `ali_0400644769_0x4b2_sci.fit` exists.
+- The three `Array_2D_Spectrum` objects are represented as `NC_FLOAT`
+  variables with dimensions `[32, 1024]`, correct units, and raw
+  `scaling_factor` / `value_offset` attributes when present.
+- The `Array_1D` object is represented as an `NC_INT` variable with
+  dimension `[64]` and correct units.
+- The `Table_Binary` `record` dimension has length 102 and representative
+  fields are accessible.
+- Successful data reads for one `Array_2D_Spectrum` hyperslab, one
+  `Array_1D` element, and one `Table_Binary` field.
+- The `.lblx` and `.fit` files are available to out-of-tree CMake and
+  Autotools test runs and included in source distributions.
+- Existing PDS4 reader behavior and tests remain compatible.
+
+## Testing
+
+- Run `tst_pds4_udf` with PDS4 enabled under both CMake and Autotools.
+- Validate metadata and data reads for the new New Horizons label.
+- Run the existing PDS4 CI job to cover the supported PDS4 configuration.
+
+## Build System Integration
+
+- `test/CMakeLists.txt`: add explicit `configure_file` copy rules for
+  `ali_0400644769_0x4b2_sci.lblx` and `ali_0400644769_0x4b2_sci.fit` into
+  `data/PDS4/new_horizons/`.
+- `test/Makefile.am`: add `cp` rules in `check-local` and entries in
+  `EXTRA_DIST` for the same files.
+
+No new external dependency or build option is required.
+
+## Documentation Updates
+
+- `docs/pds4.md`: add the second New Horizons Alice product to the
+  tested-mission table.
+- `docs/formats.md`: add the corresponding mission-test inventory entry.
+- `docs/roadmap.md`: expanded sprint description, detailed plan reference,
+  acceptance criteria, testing, build integration, dependencies, definition
+  of done, and GitHub issue link.
+
+## Dependencies and Blockers
+
+- PDS4 support enabled with libxml2.
+- Existing generic PDS4 array reader and byte-offset data path.
+- The New Horizons `.lblx` label and companion `.fit` payload already
+  present in the source tree under `test/data/PDS4/new_horizons/`.
+- No FITS-UDF delegation is required.
+
+## Definition of Done
+
+The second New Horizons Alice label and payload are included in both test
+build systems; `tst_pds4_udf` validates metadata plus data reads for an
+`Array_2D_Spectrum`, the `Array_1D`, and a `Table_Binary` field; any reader
+gaps exposed by this product are fixed; documentation is updated; and all
+PDS4 tests pass.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,41 @@ Test `test/data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.lblx`, a New Horizo
 **GitHub Issue:** #293
 
 #### Sprint 2: Build Test around: ali_0400644769_0x4b2_sci.lblx
+**Detailed Plan**: See `docs/plan/v2.7.0-sprint2-new-horizons-ali-0400644769.md`
+
+Test `test/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx`, a New Horizons Alice PDS4 `Product_Observational` label paired with the FITS container `ali_0400644769_0x4b2_sci.fit`. The label contains three `Array_2D_Spectrum` objects, one `Array_1D` object, and one `Table_Binary` object with 102 records and 117 fields.
+
+**Implementation scope:**
+- Confirm the existing generic PDS4 array reader and flat `Table_Binary` reader handle this label; apply minimal reader fixes if the build exposes a gap.
+- Add the `.lblx` / `.fit` pair to the CMake and Autotools out-of-tree test-data copy and distribution rules.
+- Add `test_mission_new_horizons_0400644769_metadata()` and `test_mission_new_horizons_0400644769_data()` to `test/tst_pds4_udf.c`, following the Maven/Perseverance split-function pattern.
+- Metadata test: verify the file-area group, the three `Array_2D_Spectrum` variables (NC_FLOAT, dims `[32, 1024]`, units, raw scaling attributes), the `Array_1D` variable (NC_INT, dim 64), and a representative `Table_Binary` field.
+- Data test: read `Observational Data[0,0:4]`, `Pulse Height Distribution (PHD)[0]`, and `SAFETY_ACTIVE[0]`; assert successful reads and label-consistent values.
+- Update `docs/pds4.md` for the second New Horizons product and `docs/formats.md` mission-test inventory.
+
+**Clarified decisions:**
+- Reader fixes are allowed if the build reveals a gap, but the starting assumption is that the existing generic array and flat `Table_Binary` readers are sufficient.
+- Test functions are split into `_metadata()` and `_data()` following the Maven/Perseverance pattern.
+- Every structure class in this label gets a data-read assertion: one `Array_2D_Spectrum` hyperslab, the `Array_1D` element, and one `Table_Binary` field.
+- Specific data reads: `Observational Data[0,0:4]`, `Pulse Height Distribution (PHD)[0]`, and `SAFETY_ACTIVE[0]`.
+- Copy rules are per-file in CMake/Autotools to match the existing explicit pattern.
+- Documentation updates for `docs/pds4.md` and `docs/formats.md` are in scope.
+
+**Acceptance Criteria:**
+- `nc_open()` opens the `.lblx` label and exposes the `ali_0400644769_0x4b2_sci.fit` file-area group.
+- `Array_2D_Spectrum` objects have label-defined dimensions, native type, units, raw scaling attributes when present, and successful hyperslab reads.
+- The `Array_1D` object has label-defined dimensions, native type, units, and a successful element read.
+- A representative `Table_Binary` field reads successfully.
+- The `.lblx` / `.fit` pair is available in CMake and Autotools out-of-tree builds and source distributions.
+- Existing PDS4 tests continue to pass.
+
+**Testing:** Run `tst_pds4_udf` with PDS4 enabled under CMake and Autotools; run the existing PDS4 CI configuration.
+
+**Build System Integration:** `test/CMakeLists.txt` and `test/Makefile.am`; no new dependencies or configuration options.
+
+**Definition of Done:** Reader verified/fixed as needed, New Horizons metadata and data-read coverage for all structure classes, build-system data staging, documentation updates, and passing PDS4 tests are in place.
+
+**GitHub Issue:** #295
 
 #### Sprint 3: Build Test around: ali_0284461348_0x4b2_eng.lblx
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -187,6 +187,12 @@ if(HAVE_PDS4)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.fit
                    ${CMAKE_CURRENT_BINARY_DIR}/data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.fit
                    COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx
+                   ${CMAKE_CURRENT_BINARY_DIR}/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx
+                   COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit
+                   ${CMAKE_CURRENT_BINARY_DIR}/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit
+                   COPYONLY)
 
     # Maven IUVS periapse mission data (nested Group_Field_Binary, FITS-backed PDS4)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108.xml

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -99,6 +99,8 @@ check-local:
 		$(MKDIR_P) $(builddir)/data/PDS4/new_horizons; \
 		cp $(srcdir)/data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.lblx $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.fit $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
+		cp $(srcdir)/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
+		cp $(srcdir)/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.xml $(builddir)/data/PDS4/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.IMG $(builddir)/data/PDS4/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/ZLF_1737_0821123689_910RAD_N0830000ZCAM00091_1100LMJ01.xml $(builddir)/data/PDS4/ 2>/dev/null || true; \
@@ -123,6 +125,7 @@ data/PDS4/mvn_ngi_l3_res-sht-58942_20250101T010116_v06_r03.xml data/PDS4/mvn_ngi
 data/PDS4/mvn_iuv_l2_corona-orbit00407-fuv_20141214T192758.xml data/PDS4/mvn_iuv_l2_corona-orbit00407-fuv_20141214T192758_v07_r01.fits \
 data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108.xml data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108_v13_r01.fits \
 data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.lblx data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.fit \
+data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit \
 data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.xml data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.IMG \
 data/PDS4/ZLF_1737_0821123689_910RAD_N0830000ZCAM00091_1100LMJ01.xml data/PDS4/ZLF_1737_0821123689_910RAD_N0830000ZCAM00091_1100LMJ01.IMG
 

--- a/test/tst_pds4_udf.c
+++ b/test/tst_pds4_udf.c
@@ -46,6 +46,8 @@
 #define PDS4_MAVEN_PERIAPSE_FILE "data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108.xml"
 #define PDS4_NEW_HORIZONS_FILE \
     "data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.lblx"
+#define PDS4_NEW_HORIZONS_0400644769_FILE \
+    "data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx"
 #define PDS4_PERSEVERANCE_FILE \
     "data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.xml"
 #define PDS4_PERSEVERANCE_1737_FILE \
@@ -1702,6 +1704,300 @@ test_mission_new_horizons(void)
     return 0;
 }
 
+/**
+ * @internal Test New Horizons Alice ali_0400644769_0x4b2_sci metadata.
+ *
+ * Opens the PDS4 label and verifies:
+ * - File-area group "ali_0400644769_0x4b2_sci.fit" exists.
+ * - One "record" dimension of length 102 for the Table_Binary.
+ * - Three Array_2D_Spectrum variables: Observational Data, Histogram
+ *   Uncertainties, Wavelength Image (all NC_FLOAT, [32, 1024], correct units).
+ * - Observational Data has raw scaling_factor="1.00000000000" and
+ *   value_offset="0.00000000000".
+ * - One Array_1D variable: Pulse Height Distribution (PHD) (NC_INT, [64],
+ *   units="COUNT").
+ * - One representative Table_Binary field: SAFETY_ACTIVE (NC_UBYTE, 1D).
+ */
+static int
+test_mission_new_horizons_0400644769_metadata(void)
+{
+    int ncid, grp_ncid, varid, retval;
+    int ndims, nvars, dimids[NC_MAX_DIMS];
+    nc_type xtype;
+    size_t len;
+    char att_buf[128];
+
+    printf("\n--- Mission: New Horizons Alice ali_0400644769 metadata ---\n");
+
+    if ((retval = nc_open(PDS4_NEW_HORIZONS_0400644769_FILE, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq_ncid(ncid, "ali_0400644769_0x4b2_sci.fit", &grp_ncid)))
+        ERR(retval);
+
+    if ((retval = nc_inq(grp_ncid, &ndims, &nvars, NULL, NULL)))
+        ERR(retval);
+    if (ndims != 8)
+    {
+        fprintf(stderr, "Expected 8 group dimensions, got %d\n", ndims);
+        nc_close(ncid);
+        return 1;
+    }
+    if (nvars != 121)
+    {
+        fprintf(stderr, "Expected 121 group variables, got %d\n", nvars);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_inq_dimid(grp_ncid, "record", dimids)))
+        ERR(retval);
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)))
+        ERR(retval);
+    if (len != 102)
+    {
+        fprintf(stderr, "Expected record length 102, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* Observational Data: Array_2D_Spectrum. */
+    if ((retval = nc_inq_varid(grp_ncid, "Observational Data", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, dimids, NULL)))
+        ERR(retval);
+    if (xtype != NC_FLOAT || ndims != 2)
+    {
+        fprintf(stderr, "Observational Data: expected 2D NC_FLOAT, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)) || len != 32)
+    {
+        fprintf(stderr, "Observational Data Line length: expected 32, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[1], NULL, &len)) || len != 1024)
+    {
+        fprintf(stderr, "Observational Data Sample length: expected 1024, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "units", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "PHOTON CM**-2 S**-1") != 0)
+    {
+        fprintf(stderr, "Observational Data units: expected 'PHOTON CM**-2 S**-1', got '%s'\n",
+                att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "scaling_factor", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "1.00000000000") != 0)
+    {
+        fprintf(stderr, "Observational Data scaling_factor mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "value_offset", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "0.00000000000") != 0)
+    {
+        fprintf(stderr, "Observational Data value_offset mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* Histogram Uncertainties: Array_2D_Spectrum. */
+    if ((retval = nc_inq_varid(grp_ncid, "Histogram Uncertainties", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, dimids, NULL)))
+        ERR(retval);
+    if (xtype != NC_FLOAT || ndims != 2)
+    {
+        fprintf(stderr, "Histogram Uncertainties: expected 2D NC_FLOAT, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)) || len != 32)
+    {
+        fprintf(stderr, "Histogram Uncertainties Line length: expected 32, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[1], NULL, &len)) || len != 1024)
+    {
+        fprintf(stderr, "Histogram Uncertainties Sample length: expected 1024, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "units", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "PHOTON CM**-2 S**-1") != 0)
+    {
+        fprintf(stderr, "Histogram Uncertainties units mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* Wavelength Image: Array_2D_Spectrum. */
+    if ((retval = nc_inq_varid(grp_ncid, "Wavelength Image", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, dimids, NULL)))
+        ERR(retval);
+    if (xtype != NC_FLOAT || ndims != 2)
+    {
+        fprintf(stderr, "Wavelength Image: expected 2D NC_FLOAT, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)) || len != 32)
+    {
+        fprintf(stderr, "Wavelength Image Line length: expected 32, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[1], NULL, &len)) || len != 1024)
+    {
+        fprintf(stderr, "Wavelength Image Sample length: expected 1024, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "units", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "ANGSTROM") != 0)
+    {
+        fprintf(stderr, "Wavelength Image units mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* Pulse Height Distribution (PHD): Array_1D. */
+    if ((retval = nc_inq_varid(grp_ncid, "Pulse Height Distribution (PHD)", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, dimids, NULL)))
+        ERR(retval);
+    if (xtype != NC_INT || ndims != 1)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD): expected 1D NC_INT, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)) || len != 64)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD) length: expected 64, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "units", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "COUNT") != 0)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD) units mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* SAFETY_ACTIVE: representative Table_Binary field. */
+    if ((retval = nc_inq_varid(grp_ncid, "SAFETY_ACTIVE", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, NULL, NULL)))
+        ERR(retval);
+    if (xtype != NC_UBYTE || ndims != 1)
+    {
+        fprintf(stderr, "SAFETY_ACTIVE: expected 1D NC_UBYTE, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+    printf("PASS: New Horizons Alice ali_0400644769 metadata tests PASSED.\n");
+    return 0;
+}
+
+/**
+ * @internal Test New Horizons Alice ali_0400644769_0x4b2_sci data reads.
+ *
+ * Reads:
+ * - Observational Data[0, 0:4] as NC_FLOAT (verify finite values).
+ * - Pulse Height Distribution (PHD)[0] as NC_INT (verify non-negative).
+ * - SAFETY_ACTIVE[0] as NC_UBYTE (verify 0 or 1).
+ */
+static int
+test_mission_new_horizons_0400644769_data(void)
+{
+    int ncid, grp_ncid, varid, retval;
+    float spectrum[4];
+    int phd;
+    unsigned char safety;
+    size_t array_start[2] = {0, 0};
+    size_t array_count[2] = {1, 4};
+    size_t start[1] = {0};
+    size_t count[1] = {1};
+    int i;
+
+    printf("\n--- Mission: New Horizons Alice ali_0400644769 data reads ---\n");
+
+    if ((retval = nc_open(PDS4_NEW_HORIZONS_0400644769_FILE, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq_ncid(ncid, "ali_0400644769_0x4b2_sci.fit", &grp_ncid)))
+        ERR(retval);
+
+    if ((retval = nc_inq_varid(grp_ncid, "Observational Data", &varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_float(grp_ncid, varid, array_start, array_count, spectrum)))
+        ERR(retval);
+    for (i = 0; i < 4; i++)
+    {
+        if (!isfinite(spectrum[i]))
+        {
+            fprintf(stderr, "Observational Data[0,%d] is not finite: %f\n", i, spectrum[i]);
+            nc_close(ncid);
+            return 1;
+        }
+    }
+
+    if ((retval = nc_inq_varid(grp_ncid, "Pulse Height Distribution (PHD)", &varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_int(grp_ncid, varid, start, count, &phd)))
+        ERR(retval);
+    if (phd < 0)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD)[0] negative: %d\n", phd);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_inq_varid(grp_ncid, "SAFETY_ACTIVE", &varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_uchar(grp_ncid, varid, start, count, &safety)))
+        ERR(retval);
+    if (safety > 1)
+    {
+        fprintf(stderr, "SAFETY_ACTIVE[0] out of expected range: %u\n", (unsigned)safety);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+    printf("PASS: New Horizons Alice ali_0400644769 data reads PASSED.\n");
+    return 0;
+}
+
 int
 main(void)
 {
@@ -1873,6 +2169,10 @@ main(void)
 
     /* Mission data validation tests. */
     if (test_mission_new_horizons())
+        return 1;
+    if (test_mission_new_horizons_0400644769_metadata())
+        return 1;
+    if (test_mission_new_horizons_0400644769_data())
         return 1;
     if (test_mission_cassini_hrd())
         return 1;


### PR DESCRIPTION
Implements v2.7.0 Sprint 2 for the New Horizons Alice product `ali_0400644769_0x4b2_sci.lblx`.

Changes:
- Add `test_mission_new_horizons_0400644769_metadata()` verifying the file-area group, the three `Array_2D_Spectrum` variables (Observational Data, Histogram Uncertainties, Wavelength Image), the `Array_1D` Pulse Height Distribution variable, and the `Table_Binary` field `SAFETY_ACTIVE`.
- Add `test_mission_new_horizons_0400644769_data()` reading `Observational Data[0,0:4]`, `Pulse Height Distribution (PHD)[0]`, and `SAFETY_ACTIVE[0]`.
- Add the `.lblx` / `.fit` pair to the CMake and Autotools test-data copy/distribution rules.
- Update `docs/pds4.md` and `docs/formats.md` mission-test tables.

No PDS4 reader changes were required; the existing generic array reader and flat `Table_Binary` reader already handle this label.

Closes #295.
