### PR TITLE
Add New Horizons Alice ali_0284461348 PDS4 test with Array_2D_Spectrum, Array_1D, and Table_Binary support

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -225,6 +225,7 @@ NEP's PDS4 reader is validated against a mix of small synthetic labels and real 
 | **LCS-9P / McDonald Observatory** | Comet 9P/Tempel 1 CN photometry and column densities | `lcs_9p/20050706_000.xml`, `20050706_000.tab` | `Table_Character` | `ASCII_Integer`, `ASCII_Real` |
 | **New Horizons** | Alice Jupiter encounter pixel-list product | `new_horizons/ali_0030420276_0x4b0_sci_1.lblx`, `ali_0030420276_0x4b0_sci_1.fit` | `Array_2D_Spectrum`, `Table_Binary` | `IEEE754MSBSingle`, `SignedMSB2`, `IEEE754MSBDouble` |
 | **New Horizons** | Alice KEM1 calibrated histogram product | `new_horizons/ali_0400644769_0x4b2_sci.lblx`, `ali_0400644769_0x4b2_sci.fit` | `Array_2D_Spectrum`, `Array_1D`, `Table_Binary` | `IEEE754MSBSingle`, `SignedMSB4`, `UnsignedByte` |
+| **New Horizons** | Alice Pluto encounter compressed histogram product | `new_horizons/ali_0284461348_0x4b2_eng.lblx`, `ali_0284461348_0x4b2_eng.fit` | `Array_2D_Spectrum`, `Array_1D`, `Table_Binary` | `SignedMSB4`, `UnsignedByte` |
 
 These mission products exercise data types and structures not covered by the synthetic tests, including unsigned byte images, date/time strings, integer ASCII fields, real-world table layouts, spectrum arrays, 1D spectra, housekeeping tables, and FITS-backed PDS4 payloads.
 

--- a/docs/pds4.md
+++ b/docs/pds4.md
@@ -305,3 +305,4 @@ The following real mission datasets have been validated:
 | Mars 2020 / Perseverance | Mastcam-Z (ZCAM) | Sol 1737 calibrated radiance image | `.IMG` (Array_3D_Image, Band=3 × Line=1200 × Sample=1648, `SignedMSB2`) |
 | New Horizons | Alice ultraviolet imaging spectrograph | Jupiter encounter partially processed pixel-list product | `.lblx` label + `.fit` container (Array_2D_Spectrum and Table_Binary) |
 | New Horizons | Alice ultraviolet imaging spectrograph | KEM1 calibrated histogram/PHD/housekeeping product | `.lblx` label + `.fit` container (Array_2D_Spectrum, Array_1D, and Table_Binary) |
+| New Horizons | Alice ultraviolet imaging spectrograph | Pluto encounter compressed histogram/PHD/housekeeping product | `.lblx` label + `.fit` container (Array_2D_Spectrum, Array_1D, and Table_Binary) |

--- a/docs/plan/v2.7.0-sprint3-new-horizons-ali-0284461348.md
+++ b/docs/plan/v2.7.0-sprint3-new-horizons-ali-0284461348.md
@@ -1,0 +1,128 @@
+# v2.7.0 Sprint 3: New Horizons Alice `ali_0284461348_0x4b2_eng` PDS4 Product
+
+## Sprint Goal
+
+Add a regression test for the third New Horizons Alice PDS4 product
+`ali_0284461348_0x4b2_eng.lblx` and extend the PDS4 reader only where the
+build reveals a gap needed to expose and read its PDS4-defined data objects
+through the standard NetCDF API.
+
+## Scope
+
+The product is a PDS4 `.lblx` XML label paired with a FITS binary container.
+The PDS4 handler remains authoritative for the NetCDF model and uses its
+existing label-defined byte-offset data path; this sprint does not delegate to
+the FITS UDF or introduce a PDS4 dependency on CFITSIO.
+
+The label contains:
+
+- One `Array_2D_Spectrum` object (`Observational Data`) with dimensions
+  `[32, 1024]` and type `SignedMSB4`.
+- One `Array_1D` object (`Pulse Height Distribution (PHD) Array`) with
+  dimension `[64]` and type `SignedMSB4`.
+- One `Table_Binary` object (`Housekeeping (HK) Table`) with 31 records and
+  117 flat `Field_Binary` fields.
+
+The starting assumption is that the existing generic array reader and flat
+binary-table reader already handle these objects, but reader fixes are in
+scope if the build/run exposes a gap.
+
+## Implementation Plan
+
+1. Inspect `src/pds4file.c` and run the PDS4 test build to confirm that
+   `Array_2D_Spectrum`, `Array_1D`, and the 117-field `Table_Binary` are
+   handled. Apply minimal reader fixes if needed.
+2. Add the `.lblx` label and companion `.fit` payload to CMake and Autotools
+   out-of-tree test-data copy/distribution rules under
+   `data/PDS4/new_horizons/`.
+3. Add two test functions to `test/tst_pds4_udf.c`:
+   - `test_mission_new_horizons_0284461348_metadata()` — open the label,
+     locate the file-area group `ali_0284461348_0x4b2_eng.fit`, and verify
+     representative metadata:
+       - `Observational Data`: `NC_INT`, `ndims=2`, dims `[32, 1024]`,
+         `units="COUNT"`, `scaling_factor="1.00000000000"`,
+         `value_offset="0.00000000000"`.
+       - `Pulse Height Distribution (PHD) Array`: `NC_INT`, `ndims=1`,
+         dim `64`.
+       - `Table_Binary`: `record` dimension length 31, a representative
+         field such as `SAFETY_ACTIVE` exists and is `NC_UBYTE` /
+         `ndims=1`.
+   - `test_mission_new_horizons_0284461348_data()` — perform successful
+     data reads:
+       - `Observational Data[0, 0:4]` as `NC_INT`.
+       - `Pulse Height Distribution (PHD) Array[0]` as `NC_INT`.
+       - `SAFETY_ACTIVE[0]` as `NC_UBYTE`.
+     Assertions verify `NC_NOERR` and label-consistent value invariants.
+4. Wire both test functions into `main()` after the existing Sprint 2 New
+   Horizons calls.
+5. Update `docs/pds4.md` to add the third New Horizons Alice product to
+   the tested-mission table.
+6. Update `docs/formats.md` with the corresponding mission-test inventory
+   entry.
+7. Update `docs/roadmap.md` with the clarified scope, detailed plan
+   reference, acceptance criteria, testing notes, build-system integration,
+   dependencies, definition of done, and GitHub issue link.
+
+## Acceptance Criteria
+
+- `nc_open()` successfully opens `ali_0284461348_0x4b2_eng.lblx` through
+  the PDS4 UDF.
+- The file-area group for `ali_0284461348_0x4b2_eng.fit` exists.
+- The `Array_2D_Spectrum` object is represented as an `NC_INT` variable
+  with dimensions `[32, 1024]`, correct units, and raw
+  `scaling_factor` / `value_offset` attributes when present.
+- The `Array_1D` object is represented as an `NC_INT` variable with
+  dimension `[64]` and correct units.
+- The `Table_Binary` `record` dimension has length 31 and representative
+  fields are accessible.
+- Successful data reads for one `Array_2D_Spectrum` hyperslab, one
+  `Array_1D` element, and one `Table_Binary` field.
+- Every PDS4 label used by `tst_pds4_udf` has at least one successful
+  `nc_get_vara_*()` assertion.
+- The `.lblx` and `.fit` files are available to out-of-tree CMake and
+  Autotools test runs and included in source distributions.
+- Existing PDS4 reader behavior and tests remain compatible.
+
+## Testing
+
+- Run `tst_pds4_udf` with PDS4 enabled under both CMake and Autotools.
+- Validate metadata and data reads for the new New Horizons label.
+- Run the existing PDS4 CI job to cover the supported PDS4 configuration.
+
+## Build System Integration
+
+- `test/CMakeLists.txt`: add explicit `configure_file` copy rules for
+  `ali_0284461348_0x4b2_eng.lblx` and `ali_0284461348_0x4b2_eng.fit` into
+  `data/PDS4/new_horizons/`.
+- `test/Makefile.am`: add `cp` rules in `check-local` and entries in
+  `EXTRA_DIST` for the same files.
+
+No new external dependency or build option is required.
+
+## Documentation Updates
+
+- `docs/pds4.md`: add the third New Horizons Alice product to the
+  tested-mission table.
+- `docs/formats.md`: add the corresponding mission-test inventory entry.
+- `docs/roadmap.md`: expanded sprint description, detailed plan reference,
+  acceptance criteria, testing, build integration, dependencies, definition
+  of done, and GitHub issue link.
+
+## Dependencies and Blockers
+
+- PDS4 support enabled with libxml2.
+- Existing generic PDS4 array reader and byte-offset data path.
+- Sprint 2 (`#295`) is the logical predecessor because it established the
+  New Horizons split-function test pattern; this sprint can be planned
+  independently but should be implemented after Sprint 2 is merged.
+- The New Horizons `.lblx` label and companion `.fit` payload already
+  present in the source tree under `test/data/PDS4/new_horizons/`.
+- No FITS-UDF delegation is required.
+
+## Definition of Done
+
+The third New Horizons Alice label and payload are included in both test
+build systems; `tst_pds4_udf` validates metadata plus data reads for the
+`Array_2D_Spectrum`, the `Array_1D`, and a `Table_Binary` field; any reader
+gaps exposed by this product are fixed; the per-label data-read invariant is
+maintained; documentation is updated; and all PDS4 tests pass.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,6 +77,47 @@ Test `test/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx`, a New Horizons
 **GitHub Issue:** #295
 
 #### Sprint 3: Build Test around: ali_0284461348_0x4b2_eng.lblx
+**Detailed Plan**: See `docs/plan/v2.7.0-sprint3-new-horizons-ali-0284461348.md`
+
+Test `test/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.lblx`, a New Horizons Alice PDS4 `Product_Observational` label paired with the FITS container `ali_0284461348_0x4b2_eng.fit`. The label contains one `Array_2D_Spectrum` object, one `Array_1D` object, and one `Table_Binary` object with 31 records and 117 fields.
+
+**Implementation scope:**
+- Confirm the existing generic PDS4 array reader and flat `Table_Binary` reader handle this label; apply minimal reader fixes if the build exposes a gap.
+- Add the `.lblx` / `.fit` pair to the CMake and Autotools out-of-tree test-data copy and distribution rules.
+- Add `test_mission_new_horizons_0284461348_metadata()` and `test_mission_new_horizons_0284461348_data()` to `test/tst_pds4_udf.c`, following the Sprint 2 split-function pattern.
+- Metadata test: verify the file-area group, the `Array_2D_Spectrum` variable `Observational Data` (`NC_INT`, dims `[32, 1024]`, units `"COUNT"`, raw `scaling_factor`/`value_offset` attributes), the `Array_1D` variable `Pulse Height Distribution (PHD) Array` (`NC_INT`, dim `64`), and a representative `Table_Binary` field such as `SAFETY_ACTIVE` (`NC_UBYTE`, `ndims=1`).
+- Data test: read `Observational Data[0,0:4]`, `Pulse Height Distribution (PHD) Array[0]`, and `SAFETY_ACTIVE[0]`; assert successful reads and label-consistent value invariants.
+- Update `docs/pds4.md` for the third New Horizons product and `docs/formats.md` mission-test inventory.
+
+**Clarified decisions:**
+- Reader fixes are allowed if the build reveals a gap, but the starting assumption is that the existing generic array and flat `Table_Binary` readers are sufficient.
+- Test functions are split into `_metadata()` and `_data()` following the Sprint 2 / Maven/Perseverance pattern.
+- `Observational Data` is `SignedMSB4` → `NC_INT`; `Pulse Height Distribution (PHD) Array` is `SignedMSB4` → `NC_INT`.
+- The `Array_1D` variable name is asserted exactly as it appears in the label: `Pulse Height Distribution (PHD) Array`.
+- Every structure class in this label gets a data-read assertion: one `Array_2D_Spectrum` hyperslab, the `Array_1D` element, and one `Table_Binary` field.
+- Specific data reads: `Observational Data[0,0:4]`, `Pulse Height Distribution (PHD) Array[0]`, and `SAFETY_ACTIVE[0]`.
+- Data-read assertions verify `NC_NOERR` plus lightweight invariants; exact known values are not required.
+- The per-label data-read invariant is enforced: every PDS4 label used by `tst_pds4_udf` must have at least one successful data-read assertion.
+- FITS `Header` elements remain outside the NetCDF model and are not exposed as variables or attributes.
+- Copy rules are per-file in CMake/Autotools to match the existing explicit pattern.
+- Documentation updates for `docs/pds4.md` and `docs/formats.md` are in scope.
+
+**Acceptance Criteria:**
+- `nc_open()` opens the `.lblx` label and exposes the `ali_0284461348_0x4b2_eng.fit` file-area group.
+- `Array_2D_Spectrum` object has label-defined dimensions, native type (`NC_INT`), units, and raw scaling attributes when present.
+- `Array_1D` object has label-defined dimension, native type, and units.
+- A representative `Table_Binary` field reads successfully.
+- The `.lblx` / `.fit` pair is available in CMake and Autotools out-of-tree builds and source distributions.
+- Every PDS4 label exercised by `tst_pds4_udf` has at least one successful data-read assertion.
+- Existing PDS4 tests continue to pass.
+
+**Testing:** Run `tst_pds4_udf` with PDS4 enabled under CMake and Autotools; run the existing PDS4 CI configuration.
+
+**Build System Integration:** `test/CMakeLists.txt` and `test/Makefile.am`; no new dependencies or configuration options.
+
+**Definition of Done:** Reader verified/fixed as needed, New Horizons metadata and data-read coverage for all structure classes, build-system data staging, the per-label data-read invariant maintained, documentation updates, and passing PDS4 tests are in place.
+
+**GitHub Issue:** #297
 
 #### Sprint 4: Build Test around: ali_0002845457_0x4b2_sci_1.lblx
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,6 +193,12 @@ if(HAVE_PDS4)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit
                    ${CMAKE_CURRENT_BINARY_DIR}/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit
                    COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.lblx
+                   ${CMAKE_CURRENT_BINARY_DIR}/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.lblx
+                   COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.fit
+                   ${CMAKE_CURRENT_BINARY_DIR}/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.fit
+                   COPYONLY)
 
     # Maven IUVS periapse mission data (nested Group_Field_Binary, FITS-backed PDS4)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108.xml

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -101,6 +101,8 @@ check-local:
 		cp $(srcdir)/data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.fit $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
+		cp $(srcdir)/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.lblx $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
+		cp $(srcdir)/data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.fit $(builddir)/data/PDS4/new_horizons/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.xml $(builddir)/data/PDS4/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.IMG $(builddir)/data/PDS4/ 2>/dev/null || true; \
 		cp $(srcdir)/data/PDS4/ZLF_1737_0821123689_910RAD_N0830000ZCAM00091_1100LMJ01.xml $(builddir)/data/PDS4/ 2>/dev/null || true; \
@@ -126,6 +128,7 @@ data/PDS4/mvn_iuv_l2_corona-orbit00407-fuv_20141214T192758.xml data/PDS4/mvn_iuv
 data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108.xml data/PDS4/mvn_iuv_l2_periapse-orbit00124_20141021T132108_v13_r01.fits \
 data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.lblx data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.fit \
 data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.fit \
+data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.lblx data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.fit \
 data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.xml data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.IMG \
 data/PDS4/ZLF_1737_0821123689_910RAD_N0830000ZCAM00091_1100LMJ01.xml data/PDS4/ZLF_1737_0821123689_910RAD_N0830000ZCAM00091_1100LMJ01.IMG
 

--- a/test/tst_pds4_udf.c
+++ b/test/tst_pds4_udf.c
@@ -48,6 +48,8 @@
     "data/PDS4/new_horizons/ali_0030420276_0x4b0_sci_1.lblx"
 #define PDS4_NEW_HORIZONS_0400644769_FILE \
     "data/PDS4/new_horizons/ali_0400644769_0x4b2_sci.lblx"
+#define PDS4_NEW_HORIZONS_0284461348_FILE \
+    "data/PDS4/new_horizons/ali_0284461348_0x4b2_eng.lblx"
 #define PDS4_PERSEVERANCE_FILE \
     "data/PDS4/ZLF_1738_0821212185_707RAD_N0830000ZCAM00091_1100LMJ01.xml"
 #define PDS4_PERSEVERANCE_1737_FILE \
@@ -1998,6 +2000,228 @@ test_mission_new_horizons_0400644769_data(void)
     return 0;
 }
 
+/**
+ * @internal Test New Horizons Alice ali_0284461348_0x4b2_eng metadata.
+ *
+ * Opens the PDS4 label and verifies:
+ * - File-area group "ali_0284461348_0x4b2_eng.fit" exists.
+ * - One "record" dimension of length 31 for the Table_Binary.
+ * - One Array_2D_Spectrum variable: Observational Data (NC_INT, [32, 1024],
+ *   units="COUNT", scaling_factor="1.00000000000", value_offset="0.00000000000").
+ * - One Array_1D variable: Pulse Height Distribution (PHD) Array (NC_INT, [64]).
+ * - One representative Table_Binary field: SAFETY_ACTIVE (NC_UBYTE, 1D).
+ */
+static int
+test_mission_new_horizons_0284461348_metadata(void)
+{
+    int ncid, grp_ncid, varid, retval;
+    int ndims, nvars, dimids[NC_MAX_DIMS];
+    nc_type xtype;
+    size_t len;
+    char att_buf[128];
+
+    printf("\n--- Mission: New Horizons Alice ali_0284461348 metadata ---\n");
+
+    if ((retval = nc_open(PDS4_NEW_HORIZONS_0284461348_FILE, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq_ncid(ncid, "ali_0284461348_0x4b2_eng.fit", &grp_ncid)))
+        ERR(retval);
+
+    if ((retval = nc_inq(grp_ncid, &ndims, &nvars, NULL, NULL)))
+        ERR(retval);
+    if (ndims != 4)
+    {
+        fprintf(stderr, "Expected 4 group dimensions, got %d\n", ndims);
+        nc_close(ncid);
+        return 1;
+    }
+    if (nvars != 119)
+    {
+        fprintf(stderr, "Expected 119 group variables, got %d\n", nvars);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_inq_dimid(grp_ncid, "record", dimids)))
+        ERR(retval);
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)))
+        ERR(retval);
+    if (len != 31)
+    {
+        fprintf(stderr, "Expected record length 31, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* Observational Data: Array_2D_Spectrum. */
+    if ((retval = nc_inq_varid(grp_ncid, "Observational Data", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, dimids, NULL)))
+        ERR(retval);
+    if (xtype != NC_INT || ndims != 2)
+    {
+        fprintf(stderr, "Observational Data: expected 2D NC_INT, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)) || len != 32)
+    {
+        fprintf(stderr, "Observational Data Line length: expected 32, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[1], NULL, &len)) || len != 1024)
+    {
+        fprintf(stderr, "Observational Data Sample length: expected 1024, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "units", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "COUNT") != 0)
+    {
+        fprintf(stderr, "Observational Data units: expected 'COUNT', got '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "scaling_factor", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "1.00000000000") != 0)
+    {
+        fprintf(stderr, "Observational Data scaling_factor mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "value_offset", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "0.00000000000") != 0)
+    {
+        fprintf(stderr, "Observational Data value_offset mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* Pulse Height Distribution (PHD) Array: Array_1D. */
+    if ((retval = nc_inq_varid(grp_ncid, "Pulse Height Distribution (PHD) Array", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, dimids, NULL)))
+        ERR(retval);
+    if (xtype != NC_INT || ndims != 1)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD) Array: expected 1D NC_INT, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+    if ((retval = nc_inq_dim(grp_ncid, dimids[0], NULL, &len)) || len != 64)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD) Array length: expected 64, got %zu\n", len);
+        nc_close(ncid);
+        return 1;
+    }
+    memset(att_buf, 0, sizeof(att_buf));
+    if ((retval = nc_get_att_text(grp_ncid, varid, "units", att_buf)))
+        ERR(retval);
+    if (strcmp(att_buf, "COUNT") != 0)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD) Array units mismatch: '%s'\n", att_buf);
+        nc_close(ncid);
+        return 1;
+    }
+
+    /* SAFETY_ACTIVE: representative Table_Binary field. */
+    if ((retval = nc_inq_varid(grp_ncid, "SAFETY_ACTIVE", &varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(grp_ncid, varid, NULL, &xtype, &ndims, NULL, NULL)))
+        ERR(retval);
+    if (xtype != NC_UBYTE || ndims != 1)
+    {
+        fprintf(stderr, "SAFETY_ACTIVE: expected 1D NC_UBYTE, got ndims=%d type=%d\n",
+                ndims, xtype);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+    printf("PASS: New Horizons Alice ali_0284461348 metadata tests PASSED.\n");
+    return 0;
+}
+
+/**
+ * @internal Test New Horizons Alice ali_0284461348_0x4b2_eng data reads.
+ *
+ * Reads:
+ * - Observational Data[0, 0:4] as NC_INT (verify non-negative).
+ * - Pulse Height Distribution (PHD) Array[0] as NC_INT (verify non-negative).
+ * - SAFETY_ACTIVE[0] as NC_UBYTE (verify 0 or 1).
+ */
+static int
+test_mission_new_horizons_0284461348_data(void)
+{
+    int ncid, grp_ncid, varid, retval;
+    int spectrum[4];
+    int phd;
+    unsigned char safety;
+    size_t array_start[2] = {0, 0};
+    size_t array_count[2] = {1, 4};
+    size_t start[1] = {0};
+    size_t count[1] = {1};
+    int i;
+
+    printf("\n--- Mission: New Horizons Alice ali_0284461348 data reads ---\n");
+
+    if ((retval = nc_open(PDS4_NEW_HORIZONS_0284461348_FILE, NC_NOWRITE, &ncid)))
+        ERR(retval);
+    if ((retval = nc_inq_ncid(ncid, "ali_0284461348_0x4b2_eng.fit", &grp_ncid)))
+        ERR(retval);
+
+    if ((retval = nc_inq_varid(grp_ncid, "Observational Data", &varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_int(grp_ncid, varid, array_start, array_count, spectrum)))
+        ERR(retval);
+    for (i = 0; i < 4; i++)
+    {
+        if (spectrum[i] < 0)
+        {
+            fprintf(stderr, "Observational Data[0,%d] negative: %d\n", i, spectrum[i]);
+            nc_close(ncid);
+            return 1;
+        }
+    }
+
+    if ((retval = nc_inq_varid(grp_ncid, "Pulse Height Distribution (PHD) Array", &varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_int(grp_ncid, varid, start, count, &phd)))
+        ERR(retval);
+    if (phd < 0)
+    {
+        fprintf(stderr, "Pulse Height Distribution (PHD) Array[0] negative: %d\n", phd);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_inq_varid(grp_ncid, "SAFETY_ACTIVE", &varid)))
+        ERR(retval);
+    if ((retval = nc_get_vara_uchar(grp_ncid, varid, start, count, &safety)))
+        ERR(retval);
+    if (safety > 1)
+    {
+        fprintf(stderr, "SAFETY_ACTIVE[0] out of expected range: %u\n", (unsigned)safety);
+        nc_close(ncid);
+        return 1;
+    }
+
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+    printf("PASS: New Horizons Alice ali_0284461348 data reads PASSED.\n");
+    return 0;
+}
+
 int
 main(void)
 {
@@ -2173,6 +2397,10 @@ main(void)
     if (test_mission_new_horizons_0400644769_metadata())
         return 1;
     if (test_mission_new_horizons_0400644769_data())
+        return 1;
+    if (test_mission_new_horizons_0284461348_metadata())
+        return 1;
+    if (test_mission_new_horizons_0284461348_data())
         return 1;
     if (test_mission_cassini_hrd())
         return 1;


### PR DESCRIPTION
Closes #297.

This PR implements v2.7.0 Sprint 3 by adding regression test coverage for the New Horizons Alice PDS4 product `ali_0284461348_0x4b2_eng.lblx` and its FITS companion.

## Changes

- Add the `.lblx` / `.fit` pair to CMake and Autotools test-data copy/distribution rules under `test/data/PDS4/new_horizons/`.
- Add `test_mission_new_horizons_0284461348_metadata()` to `test/tst_pds4_udf.c`, verifying:
  - `Array_2D_Spectrum` `Observational Data` (`NC_INT`, `[32, 1024]`, `units="COUNT"`, raw `scaling_factor`/`value_offset` attributes)
  - `Array_1D` `Pulse Height Distribution (PHD) Array` (`NC_INT`, `[64]`)
  - Representative `Table_Binary` field `SAFETY_ACTIVE` (`NC_UBYTE`, 1D)
- Add `test_mission_new_horizons_0284461348_data()` to read representative hyperslab/element/field values and assert label-consistent invariants.
- Wire both test functions into `main()` of `test/tst_pds4_udf.c`.
- Update `docs/pds4.md` and `docs/formats.md` mission-test inventory with the third New Horizons Alice product.
- Fix the repo-root `.ncrc` PDS4 library path so local UDF autoload points to the current CMake build output.

No reader code changes were required; the existing generic PDS4 array reader and flat `Table_Binary` reader already handled this product.

## Testing

- `ctest -R tst_pds4_udf --output-on-failure` passes (1/1).
