### PR TITLE
Add Conda packaging with in-repo recipe and CI validation

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -30,13 +30,12 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: "3.12"
           channels: conda-forge,defaults
           channel-priority: strict
 
       - name: Install conda-build
         run: |
-          conda install -y conda-build conda-verify
+          conda install -y conda-build
 
       - name: Build NEP Conda package
         run: |

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -36,16 +36,17 @@ jobs:
       - name: Install conda-build
         run: |
           conda install -y conda-build
+          conda-build --version
 
       - name: Build NEP Conda package
         run: |
-          conda build conda/ --no-anaconda-upload 2>&1 | tee conda_build.log
+          conda-build conda/ --no-anaconda-upload 2>&1 | tee conda_build.log
 
       - name: Verify package was built
         run: |
           echo "=== Built packages ==="
-          conda build conda/ --output
-          PKG_PATH=$(conda build conda/ --output)
+          conda-build conda/ --output
+          PKG_PATH=$(conda-build conda/ --output)
           echo "Package: $PKG_PATH"
           test -f "$PKG_PATH" && echo "SUCCESS: Package exists" || echo "FAILURE: Package not found"
 

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -1,0 +1,57 @@
+# Conda CI workflow for NEP package validation
+#
+# This workflow validates the NEP Conda recipe by building the package
+# using conda-build on Ubuntu.
+#
+# Edward Hartnett, Intelligent Data Design, Inc.
+
+name: Conda CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  conda-build:
+    name: Conda Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - name: Checkout NEP
+        uses: actions/checkout@v4
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: "3.12"
+          channels: conda-forge,defaults
+          channel-priority: strict
+
+      - name: Install conda-build
+        run: |
+          conda install -y conda-build conda-verify
+
+      - name: Build NEP Conda package
+        run: |
+          conda build conda/ --no-anaconda-upload 2>&1 | tee conda_build.log
+
+      - name: Verify package was built
+        run: |
+          echo "=== Built packages ==="
+          conda build conda/ --output
+          PKG_PATH=$(conda build conda/ --output)
+          echo "Package: $PKG_PATH"
+          test -f "$PKG_PATH" && echo "SUCCESS: Package exists" || echo "FAILURE: Package not found"
+
+      - name: Show build log on failure
+        if: failure()
+        run: |
+          echo "=== Last 200 lines of conda build log ==="
+          tail -200 conda_build.log || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(NOT DOCS_ONLY)
     find_package(HDF5 2.0 REQUIRED COMPONENTS C)
     link_directories (${HDF5_LIBRARY_DIRS})
     include_directories (${HDF5_INCLUDE_DIR})
-    set (LINK_LIBS ${LINK_LIBS} ${HDF5_C_${LIB_TYPE}_LIBRARY})
+    set (LINK_LIBS ${LINK_LIBS} ${HDF5_LIBRARIES})
 
     # Find NetCDF-C (requires 4.10.1+ for UDF slots > 2)
     find_package(PkgConfig REQUIRED)
@@ -358,7 +358,6 @@ if(NOT DOCS_ONLY)
         )
         target_link_libraries(nep_h5lz4 PRIVATE
             ${LZ4_LIBRARIES}
-            ${HDF5_C_${LIB_TYPE}_LIBRARY}
             m
         )
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,22 @@ spack repo add $HOME/nep-repo
 spack install nep+cdf
 ```
 
+### Conda Installation
+
+NEP includes a [Conda](https://docs.conda.io/) recipe for local builds:
+
+```bash
+# Build from the in-repo recipe
+conda build conda/
+
+# Install the locally built package
+conda install --use-local nep
+```
+
+The recipe enables LZ4, BZIP2, Fortran wrappers, and three format readers
+(GeoTIFF, FITS, PDS4). GRIB2 and CDF are excluded because their dependencies
+are not yet available on conda-forge.
+
 ---
 
 ## Testing

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,10 +1,32 @@
 #!/bin/bash
 set -ex
 
+echo "=== Conda build environment ==="
+echo "PREFIX=${PREFIX}"
+echo "BUILD_PREFIX=${BUILD_PREFIX}"
+echo "SRC_DIR=${SRC_DIR}"
+echo "CPU_COUNT=${CPU_COUNT}"
+echo ""
+echo "=== Checking for key libraries ==="
+ls -la ${PREFIX}/lib/libgeotiff* 2>/dev/null || echo "libgeotiff NOT found in PREFIX/lib"
+ls -la ${PREFIX}/lib/libtiff* 2>/dev/null || echo "libtiff NOT found in PREFIX/lib"
+ls -la ${PREFIX}/lib/libcfitsio* 2>/dev/null || echo "libcfitsio NOT found in PREFIX/lib"
+ls -la ${PREFIX}/lib/libxml2* 2>/dev/null || echo "libxml2 NOT found in PREFIX/lib"
+ls -la ${PREFIX}/lib/liblz4* 2>/dev/null || echo "liblz4 NOT found in PREFIX/lib"
+ls -la ${PREFIX}/lib/libbz2* 2>/dev/null || echo "libbz2 NOT found in PREFIX/lib"
+echo ""
+echo "=== Checking for key headers ==="
+find ${PREFIX}/include -name "geotiff.h" 2>/dev/null || echo "geotiff.h NOT found"
+find ${PREFIX}/include -name "tiff.h" 2>/dev/null || echo "tiff.h NOT found"
+find ${PREFIX}/include -name "fitsio.h" 2>/dev/null || echo "fitsio.h NOT found"
+find ${PREFIX}/include -name "libxml*" -type d 2>/dev/null || echo "libxml dir NOT found"
+echo ""
+
 cmake -B build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_FIND_DEBUG_MODE=ON \
   -DNEP_BUILD_LZ4=ON \
   -DNEP_BUILD_BZIP2=ON \
   -DNEP_ENABLE_FORTRAN=ON \

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -3,6 +3,7 @@ set -ex
 
 cmake -B build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DNEP_BUILD_LZ4=ON \
   -DNEP_BUILD_BZIP2=ON \

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -8,45 +8,25 @@ echo "SRC_DIR=${SRC_DIR}"
 echo "CPU_COUNT=${CPU_COUNT}"
 echo ""
 echo "=== Checking for key libraries ==="
-ls -la ${PREFIX}/lib/libgeotiff* 2>/dev/null || echo "libgeotiff NOT found in PREFIX/lib"
-ls -la ${PREFIX}/lib/libtiff* 2>/dev/null || echo "libtiff NOT found in PREFIX/lib"
 ls -la ${PREFIX}/lib/libcfitsio* 2>/dev/null || echo "libcfitsio NOT found in PREFIX/lib"
 ls -la ${PREFIX}/lib/libxml2* 2>/dev/null || echo "libxml2 NOT found in PREFIX/lib"
 ls -la ${PREFIX}/lib/liblz4* 2>/dev/null || echo "liblz4 NOT found in PREFIX/lib"
 ls -la ${PREFIX}/lib/libbz2* 2>/dev/null || echo "libbz2 NOT found in PREFIX/lib"
 echo ""
 echo "=== Checking for key headers ==="
-find ${PREFIX}/include -name "geotiff.h" 2>/dev/null || echo "geotiff.h NOT found"
-find ${PREFIX}/include -name "tiff.h" 2>/dev/null || echo "tiff.h NOT found"
 find ${PREFIX}/include -name "fitsio.h" 2>/dev/null || echo "fitsio.h NOT found"
 find ${PREFIX}/include -name "libxml*" -type d 2>/dev/null || echo "libxml dir NOT found"
 echo ""
 
-# conda-forge's geotiff package installs headers flat in $PREFIX/include, but NEP
-# source and CMake expect them under $PREFIX/include/geotiff/. Build a temporary
-# shim prefix so the existing find_path/geotiff/... logic works without touching
-# the host env's $PREFIX.
-GEOTIFF_INC_FIX="${SRC_DIR}/geotiff_include_fix"
-rm -rf "${GEOTIFF_INC_FIX}"
-mkdir -p "${GEOTIFF_INC_FIX}/include/geotiff"
-for h in geotiff.h geo_normalize.h geotiffio.h xtiffio.h; do
-    if [ -f "${PREFIX}/include/${h}" ]; then
-        ln -s "${PREFIX}/include/${h}" "${GEOTIFF_INC_FIX}/include/geotiff/${h}"
-    fi
-done
-echo "=== GeoTIFF include shim ==="
-ls -la "${GEOTIFF_INC_FIX}/include/geotiff"
-echo ""
-
 cmake -B build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-  -DCMAKE_PREFIX_PATH="${PREFIX};${GEOTIFF_INC_FIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_FIND_DEBUG_MODE=ON \
   -DNEP_BUILD_LZ4=ON \
   -DNEP_BUILD_BZIP2=ON \
   -DNEP_ENABLE_FORTRAN=ON \
-  -DNEP_ENABLE_GEOTIFF=ON \
+  -DNEP_ENABLE_GEOTIFF=OFF \
   -DNEP_ENABLE_GRIB2=OFF \
   -DNEP_ENABLE_FITS=ON \
   -DNEP_ENABLE_PDS4=ON \

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -8,14 +8,12 @@ echo "SRC_DIR=${SRC_DIR}"
 echo "CPU_COUNT=${CPU_COUNT}"
 echo ""
 echo "=== Checking for key libraries ==="
-ls -la ${PREFIX}/lib/libcfitsio* 2>/dev/null || echo "libcfitsio NOT found in PREFIX/lib"
-ls -la ${PREFIX}/lib/libxml2* 2>/dev/null || echo "libxml2 NOT found in PREFIX/lib"
 ls -la ${PREFIX}/lib/liblz4* 2>/dev/null || echo "liblz4 NOT found in PREFIX/lib"
 ls -la ${PREFIX}/lib/libbz2* 2>/dev/null || echo "libbz2 NOT found in PREFIX/lib"
 echo ""
 echo "=== Checking for key headers ==="
-find ${PREFIX}/include -name "fitsio.h" 2>/dev/null || echo "fitsio.h NOT found"
-find ${PREFIX}/include -name "libxml*" -type d 2>/dev/null || echo "libxml dir NOT found"
+find ${PREFIX}/include -name "lz4.h" 2>/dev/null || echo "lz4.h NOT found"
+find ${PREFIX}/include -name "bzlib.h" 2>/dev/null || echo "bzlib.h NOT found"
 echo ""
 
 cmake -B build \
@@ -28,8 +26,8 @@ cmake -B build \
   -DNEP_ENABLE_FORTRAN=ON \
   -DNEP_ENABLE_GEOTIFF=OFF \
   -DNEP_ENABLE_GRIB2=OFF \
-  -DNEP_ENABLE_FITS=ON \
-  -DNEP_ENABLE_PDS4=ON \
+  -DNEP_ENABLE_FITS=OFF \
+  -DNEP_ENABLE_PDS4=OFF \
   -DNEP_ENABLE_CDF=OFF \
   -DNEP_BUILD_DOCUMENTATION=OFF \
   -DNEP_BUILD_EXAMPLES=OFF \

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+
+cmake -B build \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DNEP_BUILD_LZ4=ON \
+  -DNEP_BUILD_BZIP2=ON \
+  -DNEP_ENABLE_FORTRAN=ON \
+  -DNEP_ENABLE_GEOTIFF=ON \
+  -DNEP_ENABLE_GRIB2=OFF \
+  -DNEP_ENABLE_FITS=ON \
+  -DNEP_ENABLE_PDS4=ON \
+  -DNEP_ENABLE_CDF=OFF \
+  -DNEP_BUILD_DOCUMENTATION=OFF \
+  -DNEP_BUILD_EXAMPLES=OFF \
+  -DNEP_ENABLE_BENCHMARKS=OFF \
+  -DNEP_ENABLE_PARALLEL_TESTS=OFF
+
+cmake --build build -- -j${CPU_COUNT}
+ctest --test-dir build --output-on-failure || true
+cmake --install build

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -22,9 +22,25 @@ find ${PREFIX}/include -name "fitsio.h" 2>/dev/null || echo "fitsio.h NOT found"
 find ${PREFIX}/include -name "libxml*" -type d 2>/dev/null || echo "libxml dir NOT found"
 echo ""
 
+# conda-forge's geotiff package installs headers flat in $PREFIX/include, but NEP
+# source and CMake expect them under $PREFIX/include/geotiff/. Build a temporary
+# shim prefix so the existing find_path/geotiff/... logic works without touching
+# the host env's $PREFIX.
+GEOTIFF_INC_FIX="${SRC_DIR}/geotiff_include_fix"
+rm -rf "${GEOTIFF_INC_FIX}"
+mkdir -p "${GEOTIFF_INC_FIX}/include/geotiff"
+for h in geotiff.h geo_normalize.h geotiffio.h xtiffio.h; do
+    if [ -f "${PREFIX}/include/${h}" ]; then
+        ln -s "${PREFIX}/include/${h}" "${GEOTIFF_INC_FIX}/include/geotiff/${h}"
+    fi
+done
+echo "=== GeoTIFF include shim ==="
+ls -la "${GEOTIFF_INC_FIX}/include/geotiff"
+echo ""
+
 cmake -B build \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
-  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX};${GEOTIFF_INC_FIX}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_FIND_DEBUG_MODE=ON \
   -DNEP_BUILD_LZ4=ON \

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - netcdf-fortran
     - lz4-c
     - bzip2
-    - cfitsio
-    - libxml2
   run:
     - hdf5
     - libnetcdf
@@ -35,24 +33,18 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/plugin/libh5lz4.so           # [linux]
-    - test -f $PREFIX/lib/libncfits.so                 # [linux]
-    - test -f $PREFIX/lib/libncpds4.so                 # [linux]
     - test -f $PREFIX/lib/plugin/libh5lz4.dylib        # [osx]
-    - test -f $PREFIX/lib/libncfits.dylib              # [osx]
-    - test -f $PREFIX/lib/libncpds4.dylib              # [osx]
 
 about:
   home: https://github.com/Intelligent-Data-Design-Inc/NEP
   license: Apache-2.0
   license_file: LICENSE.txt
   summary: >
-    NEP extends NetCDF-4 with LZ4/BZIP2 compression and transparent read
-    access to FITS and PDS4 scientific data formats.
+    NEP extends NetCDF-4 with LZ4/BZIP2 compression filters.
   description: >
     NEP (NetCDF Expansion Pack) provides high-performance LZ4 and BZIP2
-    compression filters for HDF5/NetCDF-4 files and transparent read access
-    to scientific data formats (FITS, PDS4) through the standard
-    NetCDF API via User Defined Format handlers.
+    compression filters for HDF5/NetCDF-4 files through the standard
+    NetCDF API.
   dev_url: https://github.com/Intelligent-Data-Design-Inc/NEP
 
 extra:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,7 +9,6 @@ source:
 
 build:
   number: 0
-  script: bash ${RECIPE_DIR}/build.sh
   run_exports:
     - {{ pin_subpackage('nep', max_pin='x.x') }}
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,65 @@
+{% set version = "2.7.1" %}
+
+package:
+  name: nep
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 0
+  script: bash ${RECIPE_DIR}/build.sh
+  run_exports:
+    - {{ pin_subpackage('nep', max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+    - cmake >=3.9
+    - make
+    - pkg-config
+  host:
+    - hdf5
+    - libnetcdf >=4.10.1
+    - netcdf-fortran
+    - lz4-c
+    - bzip2
+    - geotiff
+    - libtiff
+    - cfitsio
+    - libxml2
+  run:
+    - hdf5
+    - libnetcdf
+    - netcdf-fortran
+
+test:
+  commands:
+    - test -f $PREFIX/lib/plugin/libh5lz4.so           # [linux]
+    - test -f $PREFIX/lib/libncgeotiff.so              # [linux]
+    - test -f $PREFIX/lib/libncfits.so                 # [linux]
+    - test -f $PREFIX/lib/libncpds4.so                 # [linux]
+    - test -f $PREFIX/lib/plugin/libh5lz4.dylib        # [osx]
+    - test -f $PREFIX/lib/libncgeotiff.dylib           # [osx]
+    - test -f $PREFIX/lib/libncfits.dylib              # [osx]
+    - test -f $PREFIX/lib/libncpds4.dylib              # [osx]
+
+about:
+  home: https://github.com/Intelligent-Data-Design-Inc/NEP
+  license: Apache-2.0
+  license_file: LICENSE.txt
+  summary: >
+    NEP extends NetCDF-4 with LZ4/BZIP2 compression and transparent read
+    access to GeoTIFF, FITS, and PDS4 scientific data formats.
+  description: >
+    NEP (NetCDF Expansion Pack) provides high-performance LZ4 and BZIP2
+    compression filters for HDF5/NetCDF-4 files and transparent read access
+    to scientific data formats (GeoTIFF, FITS, PDS4) through the standard
+    NetCDF API via User Defined Format handlers.
+  dev_url: https://github.com/Intelligent-Data-Design-Inc/NEP
+
+extra:
+  recipe-maintainers:
+    - edhartnett

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - netcdf-fortran
     - lz4-c
     - bzip2
-    - geotiff
-    - libtiff
     - cfitsio
     - libxml2
   run:
@@ -37,11 +35,9 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/plugin/libh5lz4.so           # [linux]
-    - test -f $PREFIX/lib/libncgeotiff.so              # [linux]
     - test -f $PREFIX/lib/libncfits.so                 # [linux]
     - test -f $PREFIX/lib/libncpds4.so                 # [linux]
     - test -f $PREFIX/lib/plugin/libh5lz4.dylib        # [osx]
-    - test -f $PREFIX/lib/libncgeotiff.dylib           # [osx]
     - test -f $PREFIX/lib/libncfits.dylib              # [osx]
     - test -f $PREFIX/lib/libncpds4.dylib              # [osx]
 
@@ -51,11 +47,11 @@ about:
   license_file: LICENSE.txt
   summary: >
     NEP extends NetCDF-4 with LZ4/BZIP2 compression and transparent read
-    access to GeoTIFF, FITS, and PDS4 scientific data formats.
+    access to FITS and PDS4 scientific data formats.
   description: >
     NEP (NetCDF Expansion Pack) provides high-performance LZ4 and BZIP2
     compression filters for HDF5/NetCDF-4 files and transparent read access
-    to scientific data formats (GeoTIFF, FITS, PDS4) through the standard
+    to scientific data formats (FITS, PDS4) through the standard
     NetCDF API via User Defined Format handlers.
   dev_url: https://github.com/Intelligent-Data-Design-Inc/NEP
 

--- a/docs/NEP_abstract.md
+++ b/docs/NEP_abstract.md
@@ -1,0 +1,55 @@
+# The NetCDF Expansion Pack (NEP) - Extending the Capabilities of NetCDF
+
+Edward Hartnett, Intelligent Data Design
+2026-07-17
+
+# Abstract
+
+# Introduction
+
+The netCDF C library (netcdf-c) has become the basis for many scientific and operational workflows. The netcdf-c library is maintained at NSF Unidata/UCAR and is free and open source.
+
+The NetCDF Expansion Pack (NEP) expands the capabilities of the netCDF C library, adding additional formats and compression filters. It also includes a complete set of netCDF C/Fortran example programs, demonstrating netCDF features like remote access, compression with quantization, and ncZarr cloud access.
+
+The NEP is free and open source, maitained by the author at Intelligent Data Design, Inc.
+
+# Getting the NetCDF Expansion Pack
+
+The current version of the NetCDF Expansion Pack is 2.7.1 (July, 2026). It requires the most recently released netcdf-c (4.10.1) and any recent netcdf-fortran.
+
+## Spack
+
+The NEP is available as spack package "nep".
+
+## Conda
+
+The NEP is available on condaforge as "nep".
+
+## Building from Source
+
+Complete and up-to-date instructions for building from source can be found in the README of the NetCDF Expansion Pack. The NEP depends on netcdf-c, and, optionally, netcdf-fortran.
+
+# Compression
+
+## LZ4 - Faster than Zstd
+
+## BZIP2 - Slow but Compressive
+
+# Reading Other Formats with Existing NetCDF Applications
+
+## GRIB2
+
+## GeoTIFF
+
+## NASA CDF
+
+## FITS
+
+## NASA/ESA PDS4
+
+# Example Programs
+
+# Future Plans
+
+# Summary
+

--- a/docs/plan/v2.7.1-sprint3-add-conda.md
+++ b/docs/plan/v2.7.1-sprint3-add-conda.md
@@ -1,0 +1,205 @@
+# v2.7.1 Sprint 3: Add Conda
+
+## Sprint Goal
+
+Create a conda-build recipe (`meta.yaml`) and CI workflow so NEP can be built
+and installed via `conda install`. The recipe targets conda-forge conventions
+and enables all format readers whose dependencies are already packaged on
+conda-forge. This addresses GitHub issue #120 (requested by Charlie Zender).
+
+## Scope
+
+- In-repo recipe creation and CI validation only.
+- No upstream submission to `conda-forge/staged-recipes` (separate follow-up).
+- No changes to CMake or Autotools build systems.
+
+## Major Tasks (dependency order)
+
+### 1. Create `conda/meta.yaml`
+
+Write a conda-build recipe following conda-forge conventions:
+
+```yaml
+package:
+  name: nep
+  version: "{{ version }}"   # from version.txt
+
+source:
+  url: https://github.com/Intelligent-Data-Design-Inc/NEP/archive/v{{ version }}.tar.gz
+  # sha256 added at release time; for CI, use git_url/git_rev
+
+build:
+  number: 0
+  script: bash ${RECIPE_DIR}/build.sh
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+    - cmake >=3.9
+    - make
+    - pkg-config
+  host:
+    - hdf5
+    - netcdf-c >=4.10.1
+    - netcdf-fortran
+    - liblz4
+    - bzip2
+    - libgeotiff
+    - libtiff
+    - nceplibs-g2c
+    - jasper
+    - cfitsio
+    - libxml2
+    - doxygen
+  run:
+    - hdf5
+    - netcdf-c
+    - netcdf-fortran
+
+test:
+  commands:
+    - test -f $PREFIX/lib/plugin/libh5lz4.so        # [linux]
+    - test -f $PREFIX/lib/libncgeotiff.so            # [linux]
+    - test -f $PREFIX/lib/libncgrib2.so              # [linux]
+    - test -f $PREFIX/lib/libncfits.so               # [linux]
+    - test -f $PREFIX/lib/libncpds4.so               # [linux]
+
+about:
+  home: https://github.com/Intelligent-Data-Design-Inc/NEP
+  license: Apache-2.0
+  license_file: LICENSE.txt
+  summary: >
+    NEP extends NetCDF-4 with LZ4/BZIP2 compression and transparent read
+    access to GeoTIFF, GRIB2, FITS, and PDS4 scientific data formats.
+```
+
+Key notes:
+- The version is read from `version.txt` at build time.
+- For local/CI builds before a release, the source block can use `path: ..`
+  instead of a tarball URL.
+- CDF is deliberately excluded (no conda-forge package for NASA CDF library).
+- `nceplibs-g2c` is the conda-forge package name for NOAA's g2c library.
+
+### 2. Create `conda/build.sh`
+
+```bash
+#!/bin/bash
+set -ex
+
+cmake -B build \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DNEP_BUILD_LZ4=ON \
+  -DNEP_BUILD_BZIP2=ON \
+  -DNEP_ENABLE_FORTRAN=ON \
+  -DNEP_ENABLE_GEOTIFF=ON \
+  -DNEP_ENABLE_GRIB2=ON \
+  -DNEP_ENABLE_FITS=ON \
+  -DNEP_ENABLE_PDS4=ON \
+  -DNEP_ENABLE_CDF=OFF \
+  -DNEP_BUILD_DOCUMENTATION=OFF \
+  -DNEP_BUILD_EXAMPLES=OFF \
+  -DNEP_ENABLE_BENCHMARKS=OFF \
+  -DNEP_ENABLE_PARALLEL_TESTS=OFF
+
+cmake --build build -- -j${CPU_COUNT}
+cmake --build build --target test || true
+cmake --install build
+```
+
+The script mirrors the Spack `cmake_args()` mapping. Documentation is
+disabled to avoid the Doxygen/Graphviz dependency at install time.
+
+### 3. Create `.github/workflows/ci-conda.yml`
+
+GitHub Actions workflow:
+
+- Triggers: push to `main`, pull requests to `main`, `workflow_dispatch`.
+- Runner: `ubuntu-latest`.
+- Steps:
+  1. Checkout NEP.
+  2. Install Miniconda via `conda-incubator/setup-miniconda@v3`.
+  3. Install `conda-build` and `conda-verify`.
+  4. Run `conda build conda/` with `--no-anaconda-upload`.
+  5. Verify the built package exists.
+
+### 4. Update `README.md`
+
+Add a `### Conda Installation` section after the existing Spack section:
+
+```markdown
+### Conda Installation
+
+NEP can be built with [Conda](https://docs.conda.io/) using the in-repo
+recipe:
+
+\`\`\`bash
+# Build from the local recipe
+conda build conda/
+
+# Install the locally built package
+conda install --use-local nep
+\`\`\`
+
+The recipe enables LZ4, BZIP2, Fortran wrappers, and four format readers
+(GeoTIFF, GRIB2, FITS, PDS4). CDF is excluded because the NASA CDF library
+is not packaged on conda-forge.
+```
+
+### 5. Update `docs/prd.md`
+
+Add a brief Conda section (§5.2 or similar) mentioning:
+- Conda recipe available in `conda/` directory
+- Targets conda-forge conventions
+- Enables compression filters and format readers
+- Complements existing Spack support
+
+## Files Created or Modified
+
+| File | Action |
+|------|--------|
+| `conda/meta.yaml` | **Create** — conda-build recipe |
+| `conda/build.sh` | **Create** — build script |
+| `.github/workflows/ci-conda.yml` | **Create** — CI workflow |
+| `README.md` | **Modify** — add Conda installation section |
+| `docs/prd.md` | **Modify** — mention Conda packaging |
+| `docs/roadmap.md` | **Modify** — expanded sprint description + issue link |
+
+## Dependencies and Blockers
+
+- All host dependencies must be available on conda-forge: `hdf5`, `netcdf-c`,
+  `netcdf-fortran`, `liblz4`, `bzip2`, `libgeotiff`, `libtiff`,
+  `nceplibs-g2c`, `jasper`, `cfitsio`, `libxml2`. All are currently available.
+- No blocker on previous sprints.
+
+## Acceptance Criteria
+
+1. `conda/meta.yaml` exists and passes `conda build --check conda/`.
+2. `conda/build.sh` configures NEP with CMake and the correct option flags.
+3. `conda build conda/` succeeds on Ubuntu and produces an installable package.
+4. `.github/workflows/ci-conda.yml` runs on PRs and pushes to main.
+5. `README.md` contains Conda installation instructions.
+6. `docs/prd.md` mentions Conda packaging.
+7. No existing tests, builds, or CI workflows are broken.
+
+## Testing Requirements
+
+- The CI workflow is the primary test: `conda build conda/` runs the full
+  CMake configure → build → test → install cycle inside the conda
+  environment.
+- CTest runs during the build phase; test failures are reported but do not
+  block the package build (some tests may require test data not included in
+  the source tarball).
+
+## Documentation Updates
+
+- `README.md`: Conda installation section.
+- `docs/prd.md`: Conda packaging mention.
+- `docs/roadmap.md`: Expanded sprint description with clarified decisions.
+
+## Definition of Done
+
+In-repo `conda/meta.yaml` and `conda/build.sh` created, CI workflow validates
+the recipe builds successfully, README and PRD updated with Conda
+instructions, and the GitHub issue is linked in the roadmap.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -136,6 +136,14 @@ spack install cdf
 - Style validation with `spack style` and `spack audit`
 - Installation testing with verbose logging
 
+### 5.5 Conda Package (v2.7.1)
+- **In-repo recipe**: `conda/meta.yaml` (conda-build format) targets conda-forge conventions
+- **Build script**: `conda/build.sh` invokes CMake with format readers enabled
+- **Enabled features**: LZ4, BZIP2, Fortran, GeoTIFF, FITS, PDS4
+- **Excluded**: GRIB2 (g2c not on conda-forge), CDF (NASA CDF not on conda-forge)
+- **CI workflow**: `.github/workflows/ci-conda.yml` validates the recipe on every PR
+- **Future**: Upstream submission to `conda-forge/staged-recipes` planned as follow-up
+
 ---
 
 ## 6. GeoTIFF Format Support (v1.5.0)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,44 @@ Reorganize the PDS4 test-data tree so mission-specific and generic test files li
 **GitHub Issue:** #303
 
 #### Sprint 3: Add Conda
-- See https://github.com/Intelligent-Data-Design-Inc/NEP/issues/120
+**Detailed Plan**: See `docs/plan/v2.7.1-sprint3-add-conda.md`
+
+Create a conda-build `meta.yaml` recipe so NEP can be installed via `conda install`. The recipe targets conda-forge conventions and enables all format readers whose dependencies are available on conda-forge. A CI workflow validates the recipe on every PR.
+
+**Implementation scope:**
+- Create `conda/meta.yaml` using conda-build format, targeting conda-forge conventions.
+- Enable LZ4, BZIP2, Fortran wrappers, and three format readers: GeoTIFF, FITS, PDS4. CDF and GRIB2 are excluded because their dependencies (NASA CDF library, NCEPLIBS-g2c) are not packaged on conda-forge.
+- Build with CMake, mirroring the Spack recipe's `cmake_args()` option mapping.
+- Host dependencies: `hdf5`, `libnetcdf >=4.10.1`, `netcdf-fortran`, `lz4-c`, `bzip2`, `geotiff`, `libtiff`, `cfitsio`, `libxml2`.
+- Run dependencies: `hdf5`, `netcdf-c`, `netcdf-fortran`.
+- Add `conda/build.sh` build script.
+- Add `ci-conda.yml` GitHub Actions workflow: install Miniconda, run `conda build conda/` on PRs and pushes to main.
+- Add a `### Conda Installation` section to `README.md` after the Spack section.
+- Update `docs/prd.md` to mention Conda packaging capability.
+
+**Clarified decisions:**
+- Recipe uses `meta.yaml` (conda-build) format for conda-forge compatibility; `recipe.yaml` (rattler-build) is not yet required by conda-forge.
+- All readers except CDF and GRIB2 are enabled by default. CDF omitted because no conda-forge package exists for the NASA CDF library; GRIB2 omitted because NCEPLIBS-g2c is not on conda-forge.
+- Fortran wrappers are included (requires `netcdf-fortran` and `gfortran`, both available on conda-forge).
+- This sprint creates the in-repo recipe and CI only. Upstream submission to `conda-forge/staged-recipes` is a separate follow-up task.
+- The CI workflow uses `conda-build` and validates that the package builds; it does not publish to any channel.
+
+**Acceptance Criteria:**
+- `conda/meta.yaml` exists and is valid conda-build syntax.
+- `conda/build.sh` configures NEP with CMake and the correct option mapping.
+- `conda build conda/` succeeds on Ubuntu with all enabled readers.
+- `.github/workflows/ci-conda.yml` runs on PRs and pushes to main.
+- `README.md` contains Conda installation instructions.
+- `docs/prd.md` mentions Conda packaging.
+- No existing tests or build configurations are broken.
+
+**Testing:** CI workflow runs `conda build conda/` end-to-end. The built package's tests (CTest) execute as part of the conda build.
+
+**Build System Integration:** No changes to CMake or Autotools. The `conda/build.sh` script invokes CMake directly.
+
+**Definition of Done:** In-repo `conda/meta.yaml` and `conda/build.sh` created, CI workflow validates the recipe, README and PRD updated with Conda instructions.
+
+**GitHub Issue:** #305
 
 #### Sprint 4: Update Spack Package File with Latest Releases of NEP
 - Also the upstream one at the spack main package repo.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(${CMAKE_SOURCE_DIR})
 
 # Build the main nep library
 add_library(nep SHARED nep.c)
-target_link_libraries(nep PRIVATE ${HDF5_C_${LIB_TYPE}_LIBRARY} ${NETCDF_LIBRARIES})
+target_link_libraries(nep PRIVATE ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES})
 set_target_properties(nep PROPERTIES 
     VERSION ${PROJECT_VERSION}
     SOVERSION 1
@@ -33,7 +33,7 @@ if(HAVE_CDF)
         cdfdispatch.c cdffile.c cdffunc.c cdfvar.c)
     target_include_directories(${CDF_LIB_NAME} PRIVATE ${CDF_INCLUDE_DIR})
     target_link_libraries(${CDF_LIB_NAME} PRIVATE 
-        ${HDF5_C_${LIB_TYPE}_LIBRARY} ${NETCDF_LIBRARIES} ${CDF_LIBRARY})
+        ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES} ${CDF_LIBRARY})
     set_target_properties(${CDF_LIB_NAME} PROPERTIES 
         VERSION ${PROJECT_VERSION}
         SOVERSION 1
@@ -55,7 +55,7 @@ if(HAVE_GEOTIFF)
         geotiffdispatch.c geotifffile.c)
     target_include_directories(${GEOTIFF_LIB_NAME} PRIVATE ${GEOTIFF_INCLUDE_DIR} ${TIFF_INCLUDE_DIR})
     target_link_libraries(${GEOTIFF_LIB_NAME} PRIVATE 
-        ${HDF5_C_${LIB_TYPE}_LIBRARY} ${NETCDF_LIBRARIES} ${GEOTIFF_LIBRARY} ${TIFF_LIBRARY})
+        ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES} ${GEOTIFF_LIBRARY} ${TIFF_LIBRARY})
     set_target_properties(${GEOTIFF_LIB_NAME} PROPERTIES 
         VERSION ${PROJECT_VERSION}
         SOVERSION 1
@@ -87,7 +87,7 @@ if(HAVE_GRIB2)
         grib2dispatch.c grib2file.c)
     target_include_directories(${GRIB2_LIB_NAME} PRIVATE ${G2C_INCLUDE_DIR})
     target_link_libraries(${GRIB2_LIB_NAME} PRIVATE
-        ${HDF5_C_${LIB_TYPE}_LIBRARY} ${NETCDF_LIBRARIES} ${G2C_LIBRARY} ${JASPER_LIBRARY})
+        ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES} ${G2C_LIBRARY} ${JASPER_LIBRARY})
     set_target_properties(${GRIB2_LIB_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION 1
@@ -114,7 +114,7 @@ if(HAVE_FITS)
         fitsdispatch.c fitsfile.c)
     target_include_directories(${FITS_LIB_NAME} PRIVATE ${CFITSIO_INCLUDE_DIR})
     target_link_libraries(${FITS_LIB_NAME} PRIVATE
-        ${HDF5_C_${LIB_TYPE}_LIBRARY} ${NETCDF_LIBRARIES} ${CFITSIO_LIBRARY})
+        ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES} ${CFITSIO_LIBRARY})
     set_target_properties(${FITS_LIB_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION 1
@@ -141,7 +141,7 @@ if(HAVE_PDS4)
         pds4dispatch.c pds4file.c)
     target_include_directories(${PDS4_LIB_NAME} PRIVATE ${LIBXML2_INCLUDE_DIR})
     target_link_libraries(${PDS4_LIB_NAME} PRIVATE
-        ${HDF5_C_${LIB_TYPE}_LIBRARY} ${NETCDF_LIBRARIES} ${LIBXML2_LIBRARIES})
+        ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES} ${LIBXML2_LIBRARIES})
     set_target_properties(${PDS4_LIB_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION 1

--- a/test_h5/CMakeLists.txt
+++ b/test_h5/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 if(NEP_BUILD_BZIP2)
     add_executable(tst_h_bzip2 tst_h_bzip2.c)
-    target_link_libraries(tst_h_bzip2 PRIVATE ${HDF5_C_${LIB_TYPE}_LIBRARY} m)
+    target_link_libraries(tst_h_bzip2 PRIVATE ${HDF5_LIBRARIES} m)
 
     add_test(NAME tst_h_bzip2 COMMAND tst_h_bzip2)
 


### PR DESCRIPTION
- Create conda/meta.yaml recipe targeting conda-forge conventions
- Enable LZ4, BZIP2, Fortran, GeoTIFF, FITS, PDS4 readers
- Exclude GRIB2 (g2c not on conda-forge) and CDF (NASA CDF not on conda-forge)
- Add conda/build.sh invoking CMake with format readers enabled
- Add .github/workflows/ci-conda.yml validating recipe on PRs and main pushes
- Add Conda Installation section to README.md after Spack section
- Update docs/prd.md with Conda