### PR TITLE
Add JPEG Lossless (Process 14) decode support via GDCM's bundled IJG …

### DIFF
--- a/.github/workflows/ci-dicom.yml
+++ b/.github/workflows/ci-dicom.yml
@@ -3,11 +3,16 @@
 # V3.0.0 Sprint 2: DICOM dispatch layer with encapsulated JPEG Baseline
 # decompression and multi-frame support.
 #
+# V3.2.0 Sprint 2: JPEG Lossless (Process 14) decode support via GDCM's
+# bundled IJG lossless codec, and Fortran DICOM test coverage.
+#
 # This workflow builds NEP with NEP_ENABLE_DICOM=ON using:
 # - HDF5 2.1.1 (built from source, cached)
 # - NetCDF-C 4.10.1 (built from source, cached)
+# - NetCDF-Fortran (built from source, cached)
 # - libdicom (built from source, main branch)
 # - libjpeg (system package)
+# - libgdcm-dev (system package; provides gdcmjpeg8/12/16 for JPEG Lossless)
 #
 # Edward Hartnett, Intelligent Data Design, Inc.
 name: ci_dicom
@@ -23,8 +28,8 @@ jobs:
     name: DICOM Build (CMake)
     runs-on: ubuntu-latest
     env:
-      LD_LIBRARY_PATH: ${{ github.workspace }}/hdf5-install/lib:${{ github.workspace }}/netcdf-c-install/lib:${{ github.workspace }}/libdicom-install/lib/x86_64-linux-gnu:${{ github.workspace }}/libdicom-install/lib
-      PKG_CONFIG_PATH: ${{ github.workspace }}/netcdf-c-install/lib/pkgconfig:${{ github.workspace }}/hdf5-install/lib/pkgconfig:${{ github.workspace }}/libdicom-install/lib/x86_64-linux-gnu/pkgconfig:${{ github.workspace }}/libdicom-install/lib/pkgconfig
+      LD_LIBRARY_PATH: ${{ github.workspace }}/hdf5-install/lib:${{ github.workspace }}/netcdf-c-install/lib:${{ github.workspace }}/netcdf-fortran-install/lib:${{ github.workspace }}/libdicom-install/lib/x86_64-linux-gnu:${{ github.workspace }}/libdicom-install/lib
+      PKG_CONFIG_PATH: ${{ github.workspace }}/netcdf-c-install/lib/pkgconfig:${{ github.workspace }}/hdf5-install/lib/pkgconfig:${{ github.workspace }}/netcdf-fortran-install/lib/pkgconfig:${{ github.workspace }}/libdicom-install/lib/x86_64-linux-gnu/pkgconfig:${{ github.workspace }}/libdicom-install/lib/pkgconfig
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,7 +37,7 @@ jobs:
       - name: Install base dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake make wget zlib1g-dev pkg-config gfortran libzstd-dev meson ninja-build libjpeg-dev python3-venv python3-pip
+          sudo apt-get install -y cmake make wget zlib1g-dev pkg-config gfortran libzstd-dev meson ninja-build libjpeg-dev libgdcm-dev python3-venv python3-pip
 
       - name: Cache HDF5 install
         id: cache-hdf5-dicom
@@ -73,6 +78,27 @@ jobs:
           make -j$(nproc)
           make install
 
+      - name: Cache NetCDF-Fortran install
+        id: cache-netcdf-fortran-dicom
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/netcdf-fortran-install
+          key: netcdf-fortran-4.6.2-hdf5-2.1.1-netcdf-c-4.10.1-dicom-${{ runner.os }}-refresh-1
+
+      - name: Download and build NetCDF-Fortran
+        if: steps.cache-netcdf-fortran-dicom.outputs.cache-hit != 'true'
+        run: |
+          wget -q https://github.com/Unidata/netcdf-fortran/archive/v4.6.2.tar.gz -O netcdf-fortran-4.6.2.tar.gz
+          tar -xzf netcdf-fortran-4.6.2.tar.gz
+          cd netcdf-fortran-4.6.2
+          export PATH="$GITHUB_WORKSPACE/hdf5-install/bin:$GITHUB_WORKSPACE/netcdf-c-install/bin:$PATH"
+          export CPPFLAGS="-I$GITHUB_WORKSPACE/hdf5-install/include -I$GITHUB_WORKSPACE/netcdf-c-install/include"
+          export LDFLAGS="-L$GITHUB_WORKSPACE/hdf5-install/lib -L$GITHUB_WORKSPACE/netcdf-c-install/lib"
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$LD_LIBRARY_PATH"
+          ./configure --prefix=$GITHUB_WORKSPACE/netcdf-fortran-install
+          make -j$(nproc)
+          make install
+
       - name: Cache libdicom install
         id: cache-libdicom-dicom
         uses: actions/cache@v4
@@ -100,12 +126,13 @@ jobs:
       - name: Configure with CMake and DICOM enabled
         run: |
           mkdir -p build && cd build
-          export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/netcdf-c-install/lib/pkgconfig:$GITHUB_WORKSPACE/hdf5-install/lib/pkgconfig:$GITHUB_WORKSPACE/libdicom-install/lib/pkgconfig:${PKG_CONFIG_PATH}"
+          export PKG_CONFIG_PATH="$GITHUB_WORKSPACE/netcdf-c-install/lib/pkgconfig:$GITHUB_WORKSPACE/hdf5-install/lib/pkgconfig:$GITHUB_WORKSPACE/netcdf-fortran-install/lib/pkgconfig:$GITHUB_WORKSPACE/libdicom-install/lib/pkgconfig:${PKG_CONFIG_PATH}"
           cmake .. \
             -DCMAKE_C_FLAGS="-Wall -Werror" \
-            -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/libdicom-install" \
+            -DCMAKE_Fortran_FLAGS="-Wall -Werror" \
+            -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/hdf5-install;$GITHUB_WORKSPACE/netcdf-c-install;$GITHUB_WORKSPACE/netcdf-fortran-install;$GITHUB_WORKSPACE/libdicom-install" \
             -DNEP_ENABLE_DICOM=ON \
-            -DNEP_ENABLE_FORTRAN=OFF \
+            -DNEP_ENABLE_FORTRAN=ON \
             -DNEP_ENABLE_FITS=OFF \
             -DNEP_ENABLE_GRIB2=OFF \
             -DNEP_ENABLE_CDF=OFF \
@@ -118,17 +145,19 @@ jobs:
             -DBUILD_TESTING=ON
           echo "=== Checking config.h for HAVE_DICOM ==="
           grep "define HAVE_DICOM" config.h && echo "SUCCESS: HAVE_DICOM is defined" || (echo "FAILURE: HAVE_DICOM not defined"; exit 1)
+          echo "=== Checking config.h for HAVE_DICOM_LOSSLESS ==="
+          grep "define HAVE_DICOM_LOSSLESS" config.h && echo "SUCCESS: HAVE_DICOM_LOSSLESS is defined" || (echo "FAILURE: HAVE_DICOM_LOSSLESS not defined"; exit 1)
 
       - name: Build (CMake)
         working-directory: build
         run: |
-          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/libdicom-install/lib:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/netcdf-fortran-install/lib:$GITHUB_WORKSPACE/libdicom-install/lib:$LD_LIBRARY_PATH"
           make -j$(nproc)
 
       - name: Test (CMake)
         working-directory: build
         run: |
-          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/libdicom-install/lib:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/hdf5-install/lib:$GITHUB_WORKSPACE/netcdf-c-install/lib:$GITHUB_WORKSPACE/netcdf-fortran-install/lib:$GITHUB_WORKSPACE/libdicom-install/lib:$LD_LIBRARY_PATH"
           ctest --verbose
 
       - name: Summary
@@ -138,4 +167,6 @@ jobs:
           echo "Build System: CMake"
           echo "HDF5: 2.1.1"
           echo "NetCDF-C: 4.10.1"
+          echo "NetCDF-Fortran: 4.6.2"
           echo "libdicom: main"
+          echo "JPEG Lossless codec: libgdcm-dev (gdcmjpeg8/12/16)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,11 @@ jobs:
         run: |
           sudo apt-get install -y cmake make wget zlib1g-dev libjpeg-dev libjpeg-turbo8-dev liblz4-dev libbz2-dev liblzf-dev libzstd-dev meson ninja-build
 
+      - name: Install DICOM JPEG Lossless dependency
+        if: matrix.fortran == 'on' && matrix.compression == 'all'
+        run: |
+          sudo apt-get install -y libgdcm-dev
+
       - name: Install documentation dependencies
         if: matrix.fortran == 'on' && matrix.compression == 'all'
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,28 @@ if(NOT DOCS_ONLY)
         else()
             message(FATAL_ERROR "libdicom and libjpeg are required for the DICOM reader. Install libdicom/libjpeg or use -DNEP_ENABLE_DICOM=OFF")
         endif()
+
+        # JPEG Lossless (Process 14) codec detection via GDCM's bundled IJG
+        # libjpeg 6b + lossless patch (v3.2.0 Sprint 2). Optional: mainline
+        # libjpeg/libjpeg-turbo has no JPEG Lossless support, so this is a
+        # separate, narrowly-scoped dependency (libgdcm-dev) used only for
+        # decoding JPEG Lossless (.4.57/.4.70) DICOM pixel data. If not
+        # found, DICOM still builds, but JPEG Lossless files are rejected.
+        find_path(GDCMJPEG_INCLUDE_DIR gdcmjpeg/8/jpeglib.h
+            PATH_SUFFIXES gdcm-3.0 gdcm-3.1 gdcm-3.2)
+        find_library(GDCMJPEG8_LIBRARY NAMES gdcmjpeg8)
+        find_library(GDCMJPEG12_LIBRARY NAMES gdcmjpeg12)
+        find_library(GDCMJPEG16_LIBRARY NAMES gdcmjpeg16)
+
+        if(GDCMJPEG_INCLUDE_DIR AND GDCMJPEG8_LIBRARY AND GDCMJPEG12_LIBRARY AND GDCMJPEG16_LIBRARY)
+            message(STATUS "Found GDCM lossless JPEG codec headers: ${GDCMJPEG_INCLUDE_DIR}")
+            message(STATUS "  gdcmjpeg8: ${GDCMJPEG8_LIBRARY}")
+            message(STATUS "  gdcmjpeg12: ${GDCMJPEG12_LIBRARY}")
+            message(STATUS "  gdcmjpeg16: ${GDCMJPEG16_LIBRARY}")
+            set(HAVE_DICOM_LOSSLESS TRUE)
+        else()
+            message(STATUS "GDCM lossless JPEG codec (libgdcm-dev) not found; JPEG Lossless DICOM files will be rejected")
+        endif()
     endif()
 
     # Parallel I/O test support (v1.9.0)

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -35,6 +35,10 @@
 /* Define if libdicom library is found */
 #cmakedefine HAVE_DICOM
 
+/* Define if GDCM's lossless JPEG codec (gdcmjpeg8/12/16) is found, enabling
+ * JPEG Lossless (Process 14) DICOM decode support (v3.2.0 Sprint 2) */
+#cmakedefine HAVE_DICOM_LOSSLESS
+
 /* Defined if you have HDF5 support */
 #cmakedefine HAVE_HDF5
 

--- a/docs/dicom.md
+++ b/docs/dicom.md
@@ -29,7 +29,12 @@ DICOM (Digital Imaging and Communications in Medicine) is the standard format fo
 cmake -S . -B build -DNEP_ENABLE_DICOM=ON
 ```
 
-**Dependencies**: libdicom, libjpeg or libjpeg-turbo.
+**Dependencies**: libdicom, libjpeg or libjpeg-turbo. Optionally, `libgdcm-dev` (providing `gdcmjpeg8`/`gdcmjpeg12`/`gdcmjpeg16`) enables JPEG Lossless (Process 14) decode; without it, JPEG Lossless files are rejected cleanly with `NC_EINVAL`.
+
+**Supported Transfer Syntaxes**:
+- Native: Implicit VR Little Endian, Explicit VR Little Endian, Explicit VR Big Endian.
+- Encapsulated: JPEG Baseline (`1.2.840.10008.1.2.4.50`), JPEG Lossless (`1.2.840.10008.1.2.4.57`, `1.2.840.10008.1.2.4.70`, requires `libgdcm-dev`).
+- Rejected: all other encapsulated transfer syntaxes (e.g. JPEG 2000, RLE), and DICOM streams without a 128-byte preamble/`DICM` magic (legacy ACR-NEMA-style files).
 
 **Resources**: [libdicom on GitHub](https://github.com/ImagingDataCommons/libdicom) · [DICOM Standard](https://www.dicomstandard.org/)
 

--- a/docs/plan/v3.2.0-sprint2-dicom-sample-coverage.md
+++ b/docs/plan/v3.2.0-sprint2-dicom-sample-coverage.md
@@ -1,0 +1,77 @@
+# v3.2.0 Sprint 2: DICOM Sample Coverage Plan
+
+## Sprint Goal
+
+Verify that the NEP DICOM UDF reader (`src/dicomfile.c`, UDF slot 6) correctly reads the OME public-domain samples added in v3.1.0 Sprint 1, and add JPEG Lossless (Process 14) decode support where the baseline investigation found a genuine capability gap.
+
+## Baseline Investigation (superseded original test-only premise)
+
+Direct `libdicom` probing (bypassing the NEP reader) found the sprint's original premise — "test/doc only, no reader changes needed" — was wrong for 3 of the 5 new OME samples:
+
+| File | Modality | Actual Transfer Syntax UID | Documented (before fix) | Status |
+|------|----------|------------------------------|--------------------------|--------|
+| `CT-MONO2-16-brain.dcm` | CT | `1.2.840.10008.1.2.1` (Explicit VR LE) | Explicit VR LE | Matches — opens fine |
+| `MR-MONO2-16-head.dcm` | MR | `1.2.840.10008.1.2` (Implicit VR LE) | Explicit VR LE | Mislabeled but opens fine (native) |
+| `CT-MONO2-16-chest.dcm` | CT | `1.2.840.10008.1.2.4.70` (JPEG Lossless, First-Order Prediction) | Explicit VR LE | **Wrong; rejected today** |
+| `MR-MONO2-12-shoulder.dcm` | MR | `1.2.840.10008.1.2.4.57` (JPEG Lossless, Process 14) | Explicit VR LE | **Wrong; rejected today** |
+| `CR-MONO1-10-chest.dcm` | CR | N/A — no 128-byte preamble/"DICM" magic; `dcm_filehandle_get_file_meta()` fails with "prefix DICM not found" | Implicit VR LE | **Descoped**; unrelated failure mode |
+
+`CR-MONO1-10-chest.dcm` is explicitly descoped from this sprint (see roadmap Clarified Decisions) — it is a different, unrelated capability gap (no-preamble/legacy ACR-NEMA-style DICOM) that would require bypassing libdicom's standard parsing entirely.
+
+A second, independent issue surfaced during test implementation: `MR-MONO2-16-head.dcm` opens and reports correct metadata, but `dcm_filehandle_read_frame()` (libdicom's own pixel-data read function) fails with "getting data element '00280008' [NumberOfFrames] from data set failed". `MRBRAIN.DCM` and `CT-MONO2-16-brain.dcm` also lack a `NumberOfFrames` tag but read pixel data successfully, so this is a libdicom internal limitation specific to this file (likely tied to its Implicit VR Little Endian transfer syntax), not a JPEG issue. Fixing it would require bypassing libdicom's frame API for native reads entirely. This was also descoped: the test verifies open/metadata mapping for `MR-MONO2-16-head.dcm` but does not assert a pixel-data read for it.
+
+## Codec Research
+
+- Mainline `libjpeg`/`libjpeg-turbo` (used for the existing JPEG Baseline path) has **no support** for JPEG Lossless (SOF3/Process 14) — confirmed via header inspection (no `jpeg12_*`, no lossless API in `/usr/include/jpeglib.h`).
+- GDCM (`libgdcm-dev`, installed locally for development) ships `gdcmjpeg8`/`gdcmjpeg12`/`gdcmjpeg16`: three separately-compiled variants of the classic IJG libjpeg 6b source patched with the lossless/Process 14 extension (the same codec lineage DCMTK's `dcmjpeg` module uses). Headers under `/usr/include/gdcm-3.0/gdcmjpeg/{8,12,16}/` use a mangled symbol namespace (`gdcmjpeg8_*`, `gdcmjpeg12_*`, `gdcmjpeg16_*`) so all three can be linked into the same binary without symbol collisions.
+- These libraries expose the classic pre-8.x IJG `jpeglib.h` API (`jpeg_read_header`, `jpeg_start_decompress`, `jpeg_read_scanlines`) — no `jpeg_mem_src`, so a small custom memory-based `jpeg_source_mgr` (the standard `jdatasrc.c`-style boilerplate) is required, one per precision variant since each variant's headers cannot be included in the same translation unit (incompatible `JSAMPLE` types).
+- The three codec variants correspond to JPEG data precision (bits per sample as encoded in the SOF3 marker, not necessarily equal to DICOM's `BitsAllocated`): 8-bit → `gdcmjpeg8`, 9–12-bit → `gdcmjpeg12`, 13–16-bit → `gdcmjpeg16`. Precision must be read from the compressed stream to select the correct codec.
+
+## Major Tasks (dependency order)
+
+1. **Baseline verification** — done; see table above.
+2. **Precision detection**: Determine each target file's actual JPEG-frame sample precision (parse SOF3 marker or use `jpeg_read_header` return before scanline decode).
+3. **Memory source manager + per-precision decode wrappers**: New source file(s) (e.g. `src/dicomjpeglossless8.c`, `dicomjpeglossless12.c`, `dicomjpeglossless16.c`), each including its own `gdcmjpeg/N/mangle_jpegNbits.h` + `jpeglib.h`, implementing a common decode entry point.
+4. **Reader integration** (`src/dicomfile.c`): Recognize `1.2.840.10008.1.2.4.57` and `.4.70` as supported encapsulated transfer syntaxes; route `NC_DICOM_get_vara()`'s JPEG decode branch to the lossless path when applicable.
+5. **CMake integration**: Detect `gdcmjpeg8`/`gdcmjpeg12`/`gdcmjpeg16` headers/libraries under `NEP_ENABLE_DICOM`, matching the existing `libdicom`/`libjpeg` `find_library`/`find_path` pattern.
+6. **C test expansion** (`test/tst_dicom_udf.c`): Add blocks for `CT-MONO2-16-brain.dcm`, `MR-MONO2-16-head.dcm` (native), `CT-MONO2-16-chest.dcm`, `MR-MONO2-12-shoulder.dcm` (lossless), and a clean-rejection assertion (`NC_EINVAL`) for `CR-MONO1-10-chest.dcm`.
+7. **Fortran smoke check** (`ftest/ftst_dicom_udf.F90`): Open/close-only check for one confirmed-working native file.
+8. **CI update** (`.github/workflows/ci-dicom.yml`): Install `libgdcm-dev`, add NetCDF-Fortran build/cache step, set `NEP_ENABLE_FORTRAN=ON`.
+9. **Documentation update**: Correct `test/data/DICOM/README.md` transfer-syntax labels; update `docs/dicom.md` with JPEG Lossless support and the `CR-MONO1-10-chest.dcm` rejection note.
+
+## Acceptance Criteria
+
+- `test/tst_dicom_udf.c` opens, inspects, and reads pixel data from `CT-MONO2-16-brain.dcm`, `MR-MONO2-16-head.dcm`, `CT-MONO2-16-chest.dcm`, and `MR-MONO2-12-shoulder.dcm`.
+- `CR-MONO1-10-chest.dcm` open attempt returns `NC_EINVAL` and this is asserted as expected behavior.
+- `ftest/ftst_dicom_udf.F90` opens and closes at least one confirmed-working new sample without error.
+- `docs/dicom.md` and `test/data/DICOM/README.md` accurately describe JPEG Lossless support, correct transfer-syntax labels, and the `CR-MONO1-10-chest.dcm` rejection.
+- `.github/workflows/ci-dicom.yml` installs `libgdcm-dev`, builds NetCDF-Fortran, enables `NEP_ENABLE_FORTRAN`, and runs `ftst_dicom_udf` alongside `tst_dicom_udf`.
+- Full test suite remains regression-free with DICOM disabled.
+
+## Testing Requirements
+
+- `ctest --test-dir build -R dicom --output-on-failure` with `-DNEP_ENABLE_DICOM=ON -DNEP_ENABLE_FORTRAN=ON`.
+- Confirm `tst_dicom_udf` passes for all covered files (including the expected `CR-MONO1-10-chest.dcm` rejection) and `ftst_dicom_udf` passes for its smoke check.
+- Confirm `ci-dicom.yml` is green with the new dependency and Fortran step enabled.
+- Run a DICOM-disabled configuration to confirm no regressions.
+
+## Build System Integration
+
+- `src/CMakeLists.txt`: detect and link `gdcmjpeg8`/`gdcmjpeg12`/`gdcmjpeg16`.
+- `test/CMakeLists.txt` and `ftest/CMakeLists.txt`: no new test targets; existing `tst_dicom_udf` and `ftst_dicom_udf` gain assertions only.
+- `.github/workflows/ci-dicom.yml`: install `libgdcm-dev`, add NetCDF-Fortran build/cache steps, set `NEP_ENABLE_FORTRAN=ON`.
+
+## Dependencies and Blockers
+
+- New optional build dependency: `libgdcm-dev` (provides `gdcmjpeg8/12/16`), required only when `NEP_ENABLE_DICOM=ON`.
+- `CR-MONO1-10-chest.dcm` (no-preamble DICOM) remains unsupported; deferred to a future sprint if ever needed.
+
+## Documentation Updates Required
+
+- `docs/dicom.md`: JPEG Lossless support description, dependency note for `libgdcm-dev`.
+- `test/data/DICOM/README.md`: corrected transfer-syntax labels, `CR-MONO1-10-chest.dcm` rejection note.
+- `docs/roadmap.md`: Sprint 2 entry (already updated with revised scope).
+
+## Definition of Done
+
+JPEG Lossless (`.4.57`/`.4.70`) DICOM files decode correctly through the DICOM UDF reader, all four newly-supported OME samples are validated by the C and Fortran test suites, `CR-MONO1-10-chest.dcm` is documented as a clean, expected rejection, documentation accurately reflects transfer-syntax support, `ci-dicom.yml` runs the expanded Fortran coverage with the new dependency, and the full test suite remains green with DICOM enabled and disabled.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,42 @@ Reorganize format-specific visualization scripts into source directories for CDF
 **GitHub Issue:** #334
 
 #### Sprint 2: More DICOM Functionality
-- We need to be able to read all DICOM files in test/data/DICOM.
+**Detailed Plan**: See `docs/plan/v3.2.0-sprint2-dicom-sample-coverage.md`
+
+Verify and document that the NEP DICOM UDF reader correctly reads all sample files already present in `test/data/DICOM`. Baseline investigation found the sprint's original test-only premise was wrong: two of the five OME samples (`CT-MONO2-16-chest.dcm`, `MR-MONO2-12-shoulder.dcm`) use JPEG Lossless transfer syntaxes (`1.2.840.10008.1.2.4.70` and `.4.57`), not "Explicit VR Little Endian" as originally documented, and are currently rejected. A third (`CR-MONO1-10-chest.dcm`) has no DICOM preamble/File Meta Information at all and is unrelated to JPEG. This sprint adds JPEG Lossless decode support and descopes the no-preamble file.
+
+**Implementation scope:**
+- Add a memory-based `jpeg_source_mgr` and per-precision (8/12/16-bit) lossless JPEG decode wrappers using GDCM's `gdcmjpeg8`/`gdcmjpeg12`/`gdcmjpeg16` libraries (IJG libjpeg 6b + the classic lossless/Process 14 patch, mangled symbol namespace; new optional build dependency `libgdcm-dev`).
+- Detect the JPEG frame's data precision (SOF3 marker) at decode time to select the matching 8/12/16-bit codec.
+- Recognize `1.2.840.10008.1.2.4.57` and `1.2.840.10008.1.2.4.70` as supported encapsulated transfer syntaxes in `src/dicomfile.c`, alongside existing JPEG Baseline support.
+- Add CMake detection for `gdcmjpeg8`/`gdcmjpeg12`/`gdcmjpeg16` headers/libraries under `NEP_ENABLE_DICOM`.
+- Add test blocks to `test/tst_dicom_udf.c` for `CT-MONO2-16-brain.dcm` and `MR-MONO2-16-head.dcm` (native, already working) and for `CT-MONO2-16-chest.dcm` and `MR-MONO2-12-shoulder.dcm` (new lossless decode path), including pixel reads.
+- Add a test asserting `CR-MONO1-10-chest.dcm` is cleanly rejected (`NC_EINVAL`) and is out of scope for this sprint.
+- Add a lightweight open/close Fortran smoke check to `ftest/ftst_dicom_udf.F90` for one of the confirmed-working native files.
+- Correct `test/data/DICOM/README.md`'s transfer-syntax labels for all five OME samples to match their actual embedded UIDs, and update `docs/dicom.md`.
+- Update `.github/workflows/ci-dicom.yml` to install `libgdcm-dev`, build NetCDF-Fortran, and set `-DNEP_ENABLE_FORTRAN=ON` so `ftst_dicom_udf` runs in the focused DICOM workflow.
+
+**Clarified decisions:**
+- JPEG Lossless (`.4.57`, `.4.70`) decode is implemented via GDCM's bundled IJG lossless-JPEG codec (`gdcmjpeg8/12/16`), a new optional dependency, rather than vendoring the codec source or implementing a decoder from scratch.
+- `CR-MONO1-10-chest.dcm` (no preamble/File Meta Information) is explicitly descoped; it remains a clean-rejection case. No-preamble DICOM support is deferred to a future sprint if ever needed.
+- MONOCHROME1 pixel data (if encountered) is exposed as-is; the `PhotometricInterpretation` attribute remains the contract consumers use to invert for display.
+- Each sample gets its own explicit test block in `test/tst_dicom_udf.c`, matching the current per-file style.
+- Fortran coverage adds one smoke check (open/close only) rather than full parity with the C test.
+
+**Acceptance Criteria:**
+- `test/tst_dicom_udf.c` opens, inspects, and reads pixel data from `CT-MONO2-16-brain.dcm`, `CT-MONO2-16-chest.dcm`, and `MR-MONO2-12-shoulder.dcm`; opens and inspects metadata for `MR-MONO2-16-head.dcm` (pixel-data read is skipped due to an independent libdicom limitation with this file's missing `NumberOfFrames` tag, documented in the sprint plan); and asserts a clean `NC_EINVAL` rejection for `CR-MONO1-10-chest.dcm`.
+- `ftest/ftst_dicom_udf.F90` opens and closes at least one confirmed-working new sample without error.
+- `docs/dicom.md` and `test/data/DICOM/README.md` accurately describe JPEG Lossless support, correct transfer-syntax labels, and the `CR-MONO1-10-chest.dcm` rejection.
+- `.github/workflows/ci-dicom.yml` installs `libgdcm-dev`, builds NetCDF-Fortran, enables `NEP_ENABLE_FORTRAN`, and runs `ftst_dicom_udf` alongside `tst_dicom_udf`.
+- All DICOM tests pass with DICOM enabled; the full suite remains regression-free with DICOM disabled.
+
+**Testing:** Run `ctest --test-dir build -R dicom --output-on-failure` with `-DNEP_ENABLE_DICOM=ON -DNEP_ENABLE_FORTRAN=ON`; confirm `tst_dicom_udf` and `ftst_dicom_udf` both pass; confirm the updated `ci-dicom.yml` job is green.
+
+**Build System Integration:** `src/CMakeLists.txt` (gdcmjpeg8/12/16 detection and linking), `test/CMakeLists.txt`, `ftest/CMakeLists.txt`, `.github/workflows/ci-dicom.yml` (libgdcm-dev install, NetCDF-Fortran build step, `NEP_ENABLE_FORTRAN=ON`).
+
+**Definition of Done:** JPEG Lossless (`.4.57`/`.4.70`) DICOM files decode correctly through the DICOM UDF reader, all four newly-supported OME samples are validated by the C and Fortran test suites, `CR-MONO1-10-chest.dcm` is documented as a clean, expected rejection, documentation accurately reflects transfer-syntax support, `ci-dicom.yml` runs the expanded Fortran coverage with the new dependency, and the full test suite remains green with DICOM enabled and disabled.
+
+**GitHub Issue:** #338
 
 #### Sprint 3: Visualize All DICOM Files in test/data/DICOM
 - We need to create new examples/viz/DICOM examples for the new files we can now read.

--- a/ftest/ftst_dicom_udf.F90
+++ b/ftest/ftst_dicom_udf.F90
@@ -11,6 +11,7 @@ program ftst_dicom_udf
   end interface
 
   character (len = *), parameter :: FILE_NAME = "../test/data/DICOM/tst_dicom_uncompressed.dcm"
+  character (len = *), parameter :: CT_BRAIN_FILE_NAME = "../test/data/DICOM/CT-MONO2-16-brain.dcm"
 
   integer :: ncid
   integer :: retval
@@ -146,6 +147,24 @@ program ftst_dicom_udf
      stop 1
   endif
   print *, "PASS: nf90_close"
+
+  ! v3.2.0 Sprint 2: lightweight open/close smoke check for one of the OME
+  ! public-domain samples added in v3.1.0 Sprint 1 (native uncompressed,
+  ! Explicit VR Little Endian). Deep validation of this and the other new
+  ! samples is covered by test/tst_dicom_udf.c.
+  retval = nf90_open(CT_BRAIN_FILE_NAME, ior(NF90_NOWRITE, 4194304), ncid)
+  if (retval /= nf90_noerr) then
+     print *, "Error opening CT brain DICOM file: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  print *, "PASS: nf90_open ", CT_BRAIN_FILE_NAME
+
+  retval = nf90_close(ncid)
+  if (retval /= nf90_noerr) then
+     print *, "Error closing CT brain DICOM file: ", trim(nf90_strerror(retval))
+     stop 1
+  endif
+  print *, "PASS: nf90_close ", CT_BRAIN_FILE_NAME
 
   print *, "Success!"
 end program ftst_dicom_udf

--- a/include/dicomdispatch.h
+++ b/include/dicomdispatch.h
@@ -44,6 +44,7 @@ typedef struct NC_DICOM_FILE_INFO
     char *path;                 /**< Path to the open DICOM file */
     char *transfer_syntax_uid;  /**< Transfer Syntax UID string */
     int encapsulated;           /**< Non-zero for compressed transfer syntaxes */
+    int jpeg_lossless;          /**< Non-zero for JPEG Lossless (Process 14) */
     int nframes;                  /**< Number of frames (Sprint 1: always 1) */
     size_t rows;                /**< Image rows */
     size_t columns;               /**< Image columns */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,16 +166,39 @@ if(HAVE_DICOM)
 
     set(DICOM_LIB_NAME ncdicom)
     add_library(${DICOM_LIB_NAME} SHARED
-        dicomdispatch.c dicomfile.c)
+        dicomdispatch.c dicomfile.c
+        dicomjpeglossless8.c dicomjpeglossless12.c dicomjpeglossless16.c
+        dicomjpeglosslessprecision.c)
     target_include_directories(${DICOM_LIB_NAME} PRIVATE ${DICOM_INCLUDE_DIR})
     target_link_libraries(${DICOM_LIB_NAME} PRIVATE
         ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES} ${DICOM_LIBRARY} ${JPEG_LIBRARIES})
+    set(DICOM_RPATH_DIRS "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR};${DICOM_LIBRARY_DIR};${JPEG_LIBRARY_DIR}")
+    set(DICOM_BUILD_RPATH_DIRS "${DICOM_LIBRARY_DIR};${JPEG_LIBRARY_DIR}")
+
+    # JPEG Lossless (Process 14) decode wrappers each need their own
+    # precision-specific GDCM include directory (gdcmjpeg/8, /12, /16) set
+    # per-source-file, not on the target, so the mutually-incompatible
+    # 8/12/16-bit jpeglib.h variants do not collide within the same build.
+    if(HAVE_DICOM_LOSSLESS)
+        set_source_files_properties(dicomjpeglossless8.c PROPERTIES
+            INCLUDE_DIRECTORIES "${GDCMJPEG_INCLUDE_DIR}/gdcmjpeg/8")
+        set_source_files_properties(dicomjpeglossless12.c PROPERTIES
+            INCLUDE_DIRECTORIES "${GDCMJPEG_INCLUDE_DIR}/gdcmjpeg/12")
+        set_source_files_properties(dicomjpeglossless16.c PROPERTIES
+            INCLUDE_DIRECTORIES "${GDCMJPEG_INCLUDE_DIR}/gdcmjpeg/16")
+        target_link_libraries(${DICOM_LIB_NAME} PRIVATE
+            ${GDCMJPEG8_LIBRARY} ${GDCMJPEG12_LIBRARY} ${GDCMJPEG16_LIBRARY})
+        get_filename_component(GDCMJPEG_LIBRARY_DIR "${GDCMJPEG8_LIBRARY}" DIRECTORY)
+        string(APPEND DICOM_RPATH_DIRS ";${GDCMJPEG_LIBRARY_DIR}")
+        string(APPEND DICOM_BUILD_RPATH_DIRS ";${GDCMJPEG_LIBRARY_DIR}")
+    endif()
+
     set_target_properties(${DICOM_LIB_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
         SOVERSION 1
-        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR};${DICOM_LIBRARY_DIR};${JPEG_LIBRARY_DIR}"
+        INSTALL_RPATH "${DICOM_RPATH_DIRS}"
         INSTALL_RPATH_USE_LINK_PATH TRUE
-        BUILD_RPATH "${DICOM_LIBRARY_DIR};${JPEG_LIBRARY_DIR}"
+        BUILD_RPATH "${DICOM_BUILD_RPATH_DIRS}"
     )
     install(TARGETS ${DICOM_LIB_NAME}
         EXPORT NEPTargets
@@ -186,4 +209,9 @@ if(HAVE_DICOM)
     )
     message(STATUS "Building DICOM UDF library: ${DICOM_LIB_NAME}")
     message(STATUS "  libdicom: ${DICOM_LIBRARY}")
+    if(HAVE_DICOM_LOSSLESS)
+        message(STATUS "  JPEG Lossless support: enabled (gdcmjpeg8/12/16)")
+    else()
+        message(STATUS "  JPEG Lossless support: disabled (libgdcm-dev not found)")
+    endif()
 endif()

--- a/src/dicomfile.c
+++ b/src/dicomfile.c
@@ -3,9 +3,12 @@
  * @brief DICOM User-Defined Format (UDF) dispatch layer.
  *
  * Implements the NEP DICOM reader, which maps DICOM image SOP Instances
- * to the netCDF-4 data model via libdicom. This Sprint 2 implementation
- * supports native (uncompressed) and encapsulated JPEG Baseline images,
- * including multi-frame objects. Other transfer syntaxes may be rejected.
+ * to the netCDF-4 data model via libdicom. This implementation supports
+ * native (uncompressed), encapsulated JPEG Baseline, and encapsulated JPEG
+ * Lossless (Process 14) images, including multi-frame objects. JPEG
+ * Lossless decoding uses GDCM's bundled IJG libjpeg 6b codec (see
+ * dicomjpeglossless.h) since mainline libjpeg/libjpeg-turbo does not
+ * support it. Other transfer syntaxes may be rejected.
  *
  * - Primary image: exposed as a `pixel_data` variable in the root group
  *   with dimensions derived from NumberOfFrames, Rows, Columns,
@@ -34,6 +37,7 @@
 #include <dicom/dicom.h>
 #include <jpeglib.h>
 #include <setjmp.h>
+#include "dicomjpeglossless.h"
 #endif
 
 extern int nc4_var_list_add(NC_GRP_INFO_T *grp, const char *name, int ndims,
@@ -528,6 +532,64 @@ cleanup:
 }
 
 /**
+ * @internal Decompress a JPEG Lossless (Process 14) encapsulated DICOM
+ * frame.
+ *
+ * Mainline libjpeg/libjpeg-turbo does not support JPEG Lossless (SOF3), so
+ * decoding uses GDCM's bundled IJG libjpeg 6b codec with the classic
+ * lossless patch applied. GDCM ships three separately-compiled,
+ * symbol-mangled variants of this codec for 8/12/16-bit sample precision;
+ * the correct variant is selected here based on the precision encoded in
+ * the frame's own SOF3 marker.
+ *
+ * @param dicom_file DICOM file state (rows, columns, samples, type size).
+ * @param src JPEG encoded frame bytes.
+ * @param src_len Length of JPEG input.
+ * @param bufp Receives malloc'd decompressed frame buffer.
+ * @param buf_lenp Receives length of decompressed buffer.
+ *
+ * @return NC_NOERR on success.
+ * @return NC_EIO On decode failure, or if JPEG Lossless support (the
+ * optional libgdcm-dev dependency) was not built in.
+ */
+static int
+dicom_decompress_jpeg_lossless(NC_DICOM_FILE_INFO_T *dicom_file,
+                               const void *src, size_t src_len,
+                               void **bufp, size_t *buf_lenp)
+{
+    int precision;
+    int ret;
+
+    *bufp = NULL;
+    *buf_lenp = 0;
+
+    precision = dicom_jpeg_lossless_precision(src, src_len);
+    if (precision <= 0)
+        return NC_EIO;
+
+    if (precision <= 8)
+        ret = dicom_jpeg_lossless_decode8(src, src_len, dicom_file->columns,
+                                          dicom_file->rows,
+                                          (size_t)dicom_file->samples_per_pixel,
+                                          dicom_file->type_size, bufp,
+                                          buf_lenp);
+    else if (precision <= 12)
+        ret = dicom_jpeg_lossless_decode12(src, src_len, dicom_file->columns,
+                                           dicom_file->rows,
+                                           (size_t)dicom_file->samples_per_pixel,
+                                           dicom_file->type_size, bufp,
+                                           buf_lenp);
+    else
+        ret = dicom_jpeg_lossless_decode16(src, src_len, dicom_file->columns,
+                                           dicom_file->rows,
+                                           (size_t)dicom_file->samples_per_pixel,
+                                           dicom_file->type_size, bufp,
+                                           buf_lenp);
+
+    return ret == 0 ? NC_NOERR : NC_EIO;
+}
+
+/**
  * @internal Read or decompress one DICOM frame into a malloc'd buffer.
  *
  * The returned buffer must be freed by the caller.
@@ -588,8 +650,13 @@ dicom_read_frame_buffer(NC_DICOM_FILE_INFO_T *dicom_file,
 
     if (dicom_file->encapsulated)
     {
-        ret = dicom_decompress_jpeg(dicom_file, frame_data, frame_length,
-                                    bufp, buf_lenp);
+        if (dicom_file->jpeg_lossless)
+            ret = dicom_decompress_jpeg_lossless(dicom_file, frame_data,
+                                                 frame_length, bufp,
+                                                 buf_lenp);
+        else
+            ret = dicom_decompress_jpeg(dicom_file, frame_data, frame_length,
+                                        bufp, buf_lenp);
         dcm_frame_destroy(frame);
         return ret;
     }
@@ -650,6 +717,27 @@ dicom_is_jpeg_baseline_transfer_syntax(const char *uid)
         return 0;
 
     return (strcmp(uid, "1.2.840.10008.1.2.4.50") == 0);   /* JPEG Baseline */
+}
+
+/**
+ * @internal Determine whether the given Transfer Syntax UID is a JPEG
+ * Lossless (Process 14) transfer syntax.
+ *
+ * @param uid Transfer Syntax UID string.
+ *
+ * @return Non-zero if JPEG Lossless.
+ */
+static int
+dicom_is_jpeg_lossless_transfer_syntax(const char *uid)
+{
+    if (!uid)
+        return 0;
+
+    /* JPEG Lossless, Non-Hierarchical (Process 14) and JPEG Lossless,
+     * Non-Hierarchical, First-Order Prediction (Process 14 [Selection
+     * Value 1], the default transfer syntax for lossless JPEG). */
+    return (strcmp(uid, "1.2.840.10008.1.2.4.57") == 0 ||
+            strcmp(uid, "1.2.840.10008.1.2.4.70") == 0);
 }
 
 /**
@@ -726,10 +814,15 @@ dicom_read_image_metadata(NC_FILE_INFO_T *h5)
         return NC_ENOMEM;
 
     dicom_file->encapsulated = !dicom_is_native_transfer_syntax(transfer_syntax_uid);
+    dicom_file->jpeg_lossless =
+        dicom_is_jpeg_lossless_transfer_syntax(transfer_syntax_uid);
 
-    /* Sprint 2 only supports native syntaxes and JPEG Baseline. */
+    /* Native syntaxes, JPEG Baseline, and JPEG Lossless are supported;
+     * other encapsulated transfer syntaxes (e.g. JPEG 2000, RLE) are
+     * rejected. */
     if (dicom_file->encapsulated &&
-        !dicom_is_jpeg_baseline_transfer_syntax(transfer_syntax_uid))
+        !dicom_is_jpeg_baseline_transfer_syntax(transfer_syntax_uid) &&
+        !dicom_file->jpeg_lossless)
         return NC_EINVAL;
 
     /* Required image pixel module tags. */

--- a/src/dicomjpeglossless.h
+++ b/src/dicomjpeglossless.h
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * @brief Internal API for decoding encapsulated JPEG Lossless (Process 14)
+ * DICOM pixel data.
+ *
+ * JPEG Lossless (Transfer Syntax UIDs 1.2.840.10008.1.2.4.57 and
+ * 1.2.840.10008.1.2.4.70) is not supported by mainline libjpeg/libjpeg-turbo,
+ * which only implements baseline/sequential DCT-based JPEG. Decoding uses
+ * GDCM's bundled IJG libjpeg 6b codec, patched with the classic lossless
+ * (SOF3) extension. GDCM ships three separately-compiled, symbol-mangled
+ * variants of this codec (8/12/16-bit sample precision); the correct variant
+ * is selected at runtime based on the JPEG frame's own data precision, which
+ * is read directly from the compressed stream's SOF3 marker.
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-28
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+#ifndef _DICOMJPEGLOSSLESS_H
+#define _DICOMJPEGLOSSLESS_H
+
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @internal Determine the JPEG data precision (bits per sample) encoded in
+ * a JPEG Lossless (SOF3) frame's start-of-frame marker.
+ *
+ * @param src JPEG encoded frame bytes.
+ * @param src_len Length of JPEG input in bytes.
+ *
+ * @return The data precision (typically 8, 12, or 16), or -1 if no SOF3
+ * marker was found.
+ */
+int dicom_jpeg_lossless_precision(const void *src, size_t src_len);
+
+/**
+ * @internal Decompress a JPEG Lossless (8-bit precision) encapsulated
+ * DICOM frame.
+ *
+ * @param src JPEG encoded frame bytes.
+ * @param src_len Length of JPEG input in bytes.
+ * @param width Expected image width (columns).
+ * @param height Expected image height (rows).
+ * @param components Expected number of components (samples per pixel).
+ * @param sample_size Expected size in bytes of one decoded sample.
+ * @param bufp Receives a malloc'd decompressed frame buffer.
+ * @param buf_lenp Receives the length of the decompressed buffer.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int dicom_jpeg_lossless_decode8(const void *src, size_t src_len,
+                                 size_t width, size_t height,
+                                 size_t components, size_t sample_size,
+                                 void **bufp, size_t *buf_lenp);
+
+/**
+ * @internal Decompress a JPEG Lossless (9-12-bit precision) encapsulated
+ * DICOM frame. See dicom_jpeg_lossless_decode8() for parameter details.
+ */
+int dicom_jpeg_lossless_decode12(const void *src, size_t src_len,
+                                  size_t width, size_t height,
+                                  size_t components, size_t sample_size,
+                                  void **bufp, size_t *buf_lenp);
+
+/**
+ * @internal Decompress a JPEG Lossless (13-16-bit precision) encapsulated
+ * DICOM frame. See dicom_jpeg_lossless_decode8() for parameter details.
+ */
+int dicom_jpeg_lossless_decode16(const void *src, size_t src_len,
+                                  size_t width, size_t height,
+                                  size_t components, size_t sample_size,
+                                  void **bufp, size_t *buf_lenp);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* _DICOMJPEGLOSSLESS_H */

--- a/src/dicomjpeglossless12.c
+++ b/src/dicomjpeglossless12.c
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * @brief 9-12-bit precision JPEG Lossless decode wrapper.
+ *
+ * Compiled with GDCM's gdcmjpeg/12 headers on its include path (set via
+ * per-source-file CMake properties, not the target's global include
+ * directories, so the 8/12/16-bit variants do not collide). See
+ * dicomjpeglosslessimpl.inc.c for the shared implementation.
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-28
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+#include "config.h"
+
+#ifdef HAVE_DICOM_LOSSLESS
+
+/* The classic IJG jpeglib.h requires stdio.h (for FILE) and stddef.h (for
+ * size_t) to be included first; see IJG's libjpeg.txt. */
+#include <stdio.h>
+#include <stddef.h>
+#include <jpeglib.h>
+#include "dicomjpeglossless.h"
+
+#define DICOM_LL_DECODE_FUNC_NAME dicom_jpeg_lossless_decode12
+#include "dicomjpeglosslessimpl.inc.c"
+#undef DICOM_LL_DECODE_FUNC_NAME
+
+#else /* !HAVE_DICOM_LOSSLESS */
+
+#include "dicomjpeglossless.h"
+
+int
+dicom_jpeg_lossless_decode12(const void *src, size_t src_len,
+                              size_t width, size_t height, size_t components,
+                              size_t sample_size, void **bufp,
+                              size_t *buf_lenp)
+{
+    (void)src; (void)src_len; (void)width; (void)height; (void)components;
+    (void)sample_size;
+    *bufp = NULL;
+    *buf_lenp = 0;
+    return -1;
+}
+
+#endif /* HAVE_DICOM_LOSSLESS */

--- a/src/dicomjpeglossless16.c
+++ b/src/dicomjpeglossless16.c
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * @brief 13-16-bit precision JPEG Lossless decode wrapper.
+ *
+ * Compiled with GDCM's gdcmjpeg/16 headers on its include path (set via
+ * per-source-file CMake properties, not the target's global include
+ * directories, so the 8/12/16-bit variants do not collide). See
+ * dicomjpeglosslessimpl.inc.c for the shared implementation.
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-28
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+#include "config.h"
+
+#ifdef HAVE_DICOM_LOSSLESS
+
+/* The classic IJG jpeglib.h requires stdio.h (for FILE) and stddef.h (for
+ * size_t) to be included first; see IJG's libjpeg.txt. */
+#include <stdio.h>
+#include <stddef.h>
+#include <jpeglib.h>
+#include "dicomjpeglossless.h"
+
+#define DICOM_LL_DECODE_FUNC_NAME dicom_jpeg_lossless_decode16
+#include "dicomjpeglosslessimpl.inc.c"
+#undef DICOM_LL_DECODE_FUNC_NAME
+
+#else /* !HAVE_DICOM_LOSSLESS */
+
+#include "dicomjpeglossless.h"
+
+int
+dicom_jpeg_lossless_decode16(const void *src, size_t src_len,
+                              size_t width, size_t height, size_t components,
+                              size_t sample_size, void **bufp,
+                              size_t *buf_lenp)
+{
+    (void)src; (void)src_len; (void)width; (void)height; (void)components;
+    (void)sample_size;
+    *bufp = NULL;
+    *buf_lenp = 0;
+    return -1;
+}
+
+#endif /* HAVE_DICOM_LOSSLESS */

--- a/src/dicomjpeglossless8.c
+++ b/src/dicomjpeglossless8.c
@@ -1,0 +1,45 @@
+/**
+ * @file
+ * @brief 8-bit precision JPEG Lossless decode wrapper.
+ *
+ * Compiled with GDCM's gdcmjpeg/8 headers on its include path (set via
+ * per-source-file CMake properties, not the target's global include
+ * directories, so the 8/12/16-bit variants do not collide). See
+ * dicomjpeglosslessimpl.inc.c for the shared implementation.
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-28
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+#include "config.h"
+
+#ifdef HAVE_DICOM_LOSSLESS
+
+/* The classic IJG jpeglib.h requires stdio.h (for FILE) and stddef.h (for
+ * size_t) to be included first; see IJG's libjpeg.txt. */
+#include <stdio.h>
+#include <stddef.h>
+#include <jpeglib.h>
+#include "dicomjpeglossless.h"
+
+#define DICOM_LL_DECODE_FUNC_NAME dicom_jpeg_lossless_decode8
+#include "dicomjpeglosslessimpl.inc.c"
+#undef DICOM_LL_DECODE_FUNC_NAME
+
+#else /* !HAVE_DICOM_LOSSLESS */
+
+#include "dicomjpeglossless.h"
+
+int
+dicom_jpeg_lossless_decode8(const void *src, size_t src_len,
+                             size_t width, size_t height, size_t components,
+                             size_t sample_size, void **bufp, size_t *buf_lenp)
+{
+    (void)src; (void)src_len; (void)width; (void)height; (void)components;
+    (void)sample_size;
+    *bufp = NULL;
+    *buf_lenp = 0;
+    return -1;
+}
+
+#endif /* HAVE_DICOM_LOSSLESS */

--- a/src/dicomjpeglosslessimpl.inc.c
+++ b/src/dicomjpeglosslessimpl.inc.c
@@ -1,0 +1,193 @@
+/**
+ * @file
+ * @brief Shared implementation body for the per-precision JPEG Lossless
+ * decode wrappers (dicomjpeglossless8.c, dicomjpeglossless12.c,
+ * dicomjpeglossless16.c).
+ *
+ * This file is included, not compiled directly. Each wrapper defines
+ * DICOM_LL_DECODE_FUNC_NAME to its own externally-visible function name and
+ * includes this file after including the matching precision-specific
+ * GDCM jpeglib.h, so that all IJG symbols referenced below resolve through
+ * that precision's mangled namespace (e.g. gdcmjpeg12_jpeg_read_header).
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-28
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+
+#include <setjmp.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** @internal libjpeg error handler that uses longjmp instead of exit(). */
+struct dicom_ll_error_mgr
+{
+    struct jpeg_error_mgr pub;
+    jmp_buf setjmp_buffer;
+};
+
+/** @internal libjpeg error_exit replacement. */
+static void
+dicom_ll_error_exit(j_common_ptr cinfo)
+{
+    struct dicom_ll_error_mgr *myerr = (struct dicom_ll_error_mgr *)cinfo->err;
+    (*cinfo->err->output_message)(cinfo);
+    longjmp(myerr->setjmp_buffer, 1);
+}
+
+/**
+ * @internal Minimal memory-based source manager.
+ *
+ * These GDCM-bundled headers predate the standard IJG jpeg_mem_src() helper
+ * (added in libjpeg 8), so a small custom source manager is required,
+ * following the classic jdatasrc.c pattern: the entire compressed frame is
+ * already in memory, so fill_input_buffer() only needs to run if the decoder
+ * asks for more data than is available, in which case it is fed a synthetic
+ * End-Of-Image marker.
+ */
+struct dicom_ll_mem_source_mgr
+{
+    struct jpeg_source_mgr pub;
+};
+
+static void
+dicom_ll_init_source(j_decompress_ptr cinfo)
+{
+    (void)cinfo;
+}
+
+static boolean
+dicom_ll_fill_input_buffer(j_decompress_ptr cinfo)
+{
+    static JOCTET eoi_buffer[2] = { 0xFF, JPEG_EOI };
+    struct dicom_ll_mem_source_mgr *src =
+        (struct dicom_ll_mem_source_mgr *)cinfo->src;
+
+    src->pub.next_input_byte = eoi_buffer;
+    src->pub.bytes_in_buffer = 2;
+    return TRUE;
+}
+
+static void
+dicom_ll_skip_input_data(j_decompress_ptr cinfo, long num_bytes)
+{
+    struct dicom_ll_mem_source_mgr *src =
+        (struct dicom_ll_mem_source_mgr *)cinfo->src;
+
+    if (num_bytes <= 0)
+        return;
+
+    while ((size_t)num_bytes > src->pub.bytes_in_buffer)
+    {
+        num_bytes -= (long)src->pub.bytes_in_buffer;
+        (void)dicom_ll_fill_input_buffer(cinfo);
+    }
+    src->pub.next_input_byte += (size_t)num_bytes;
+    src->pub.bytes_in_buffer -= (size_t)num_bytes;
+}
+
+static void
+dicom_ll_term_source(j_decompress_ptr cinfo)
+{
+    (void)cinfo;
+}
+
+static void
+dicom_ll_mem_src(j_decompress_ptr cinfo, const unsigned char *buf, size_t len)
+{
+    struct dicom_ll_mem_source_mgr *src;
+
+    if (cinfo->src == NULL)
+        cinfo->src = (struct jpeg_source_mgr *)
+            (*cinfo->mem->alloc_small)((j_common_ptr)cinfo, JPOOL_PERMANENT,
+                                       sizeof(struct dicom_ll_mem_source_mgr));
+
+    src = (struct dicom_ll_mem_source_mgr *)cinfo->src;
+    src->pub.init_source = dicom_ll_init_source;
+    src->pub.fill_input_buffer = dicom_ll_fill_input_buffer;
+    src->pub.skip_input_data = dicom_ll_skip_input_data;
+    src->pub.resync_to_restart = jpeg_resync_to_restart;
+    src->pub.term_source = dicom_ll_term_source;
+    src->pub.bytes_in_buffer = len;
+    src->pub.next_input_byte = (const JOCTET *)buf;
+}
+
+int
+DICOM_LL_DECODE_FUNC_NAME(const void *src, size_t src_len,
+                          size_t width, size_t height, size_t components,
+                          size_t sample_size, void **bufp, size_t *buf_lenp)
+{
+    struct jpeg_decompress_struct cinfo;
+    struct dicom_ll_error_mgr jerr;
+    JSAMPARRAY scanline_buffer = NULL;
+    unsigned char *out = NULL;
+    unsigned char *out_ptr;
+    size_t row_stride, out_size;
+    int retval = 0;
+
+    *bufp = NULL;
+    *buf_lenp = 0;
+
+    cinfo.err = jpeg_std_error(&jerr.pub);
+    jerr.pub.error_exit = dicom_ll_error_exit;
+
+    if (setjmp(jerr.setjmp_buffer))
+    {
+        retval = -1;
+        goto cleanup;
+    }
+
+    jpeg_create_decompress(&cinfo);
+    cinfo.src = NULL;
+    dicom_ll_mem_src(&cinfo, (const unsigned char *)src, src_len);
+    jpeg_read_header(&cinfo, TRUE);
+
+    jpeg_start_decompress(&cinfo);
+
+    if ((size_t)cinfo.output_width != width ||
+        (size_t)cinfo.output_height != height ||
+        (size_t)cinfo.output_components != components)
+    {
+        retval = -2;
+        goto cleanup;
+    }
+
+    row_stride = width * components * sample_size;
+    out_size = row_stride * height;
+
+    if (!(out = malloc(out_size)))
+    {
+        retval = -3;
+        goto cleanup;
+    }
+
+    scanline_buffer = (*cinfo.mem->alloc_sarray)
+        ((j_common_ptr)&cinfo, JPOOL_IMAGE, (JDIMENSION)row_stride, 1);
+    if (!scanline_buffer)
+    {
+        retval = -3;
+        goto cleanup;
+    }
+
+    out_ptr = out;
+    while (cinfo.output_scanline < cinfo.output_height)
+    {
+        jpeg_read_scanlines(&cinfo, scanline_buffer, 1);
+        memcpy(out_ptr, scanline_buffer[0], row_stride);
+        out_ptr += row_stride;
+    }
+
+    jpeg_finish_decompress(&cinfo);
+
+cleanup:
+    jpeg_destroy_decompress(&cinfo);
+    if (retval != 0)
+    {
+        free(out);
+        return retval;
+    }
+
+    *bufp = out;
+    *buf_lenp = out_size;
+    return 0;
+}

--- a/src/dicomjpeglosslessprecision.c
+++ b/src/dicomjpeglosslessprecision.c
@@ -1,0 +1,38 @@
+/**
+ * @file
+ * @brief JPEG data-precision detection for JPEG Lossless frames.
+ *
+ * This is a plain byte scan of the raw JPEG stream for a Start-Of-Frame
+ * marker and does not depend on any JPEG decoding library, so it is
+ * always available whenever DICOM support is built, independent of
+ * whether the JPEG Lossless codec (HAVE_DICOM_LOSSLESS) is available.
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-28
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+#include "config.h"
+#include "dicomjpeglossless.h"
+
+int
+dicom_jpeg_lossless_precision(const void *src, size_t src_len)
+{
+    const unsigned char *data = (const unsigned char *)src;
+    size_t i;
+
+    if (!data || src_len < 5)
+        return -1;
+
+    /* Scan for a Start-Of-Frame marker (0xFFC0-0xFFCF), skipping the
+     * non-SOF markers in that range (DHT=0xC4, JPG=0xC8, DAC=0xCC). The
+     * data precision is the byte immediately following the 2-byte segment
+     * length field. */
+    for (i = 0; i + 4 < src_len; i++)
+    {
+        if (data[i] == 0xFF && data[i + 1] >= 0xC0 && data[i + 1] <= 0xCF &&
+            data[i + 1] != 0xC4 && data[i + 1] != 0xC8 && data[i + 1] != 0xCC)
+            return (int)data[i + 4];
+    }
+
+    return -1;
+}

--- a/test/data/DICOM/README.md
+++ b/test/data/DICOM/README.md
@@ -14,13 +14,17 @@ The following additional samples are from the Open Microscopy Environment
 (OME) DICOM sample collection, maintained by the OME team as freely usable test
 images. They are in the public domain and are free of patient identifiers.
 
-| File | Modality | Transfer Syntax | Size | Description |
-|------|----------|-----------------|------|-------------|
-| `CT-MONO2-16-chest.dcm` | CT | Explicit VR Little Endian | 145136 bytes | Chest CT slice. |
-| `CT-MONO2-16-brain.dcm` | CT | Explicit VR Little Endian | 525968 bytes | Brain CT slice. |
-| `MR-MONO2-16-head.dcm` | MR | Explicit VR Little Endian | 132876 bytes | Head MR slice. |
-| `CR-MONO1-10-chest.dcm` | CR | Implicit VR Little Endian | 387976 bytes | Chest X-ray. |
-| `MR-MONO2-12-shoulder.dcm` | MR | Explicit VR Little Endian | 720528 bytes | Shoulder MR slice. |
+Transfer syntax values below reflect the actual embedded Transfer Syntax UID
+of each file, verified directly via libdicom (v3.2.0 Sprint 2); some were
+mislabeled when these samples were first added.
+
+| File | Modality | Transfer Syntax | Size | Description | NEP Support |
+|------|----------|-----------------|------|-------------|-------------|
+| `CT-MONO2-16-brain.dcm` | CT | Explicit VR Little Endian | 525968 bytes | Brain CT slice. | Supported (native) |
+| `MR-MONO2-16-head.dcm` | MR | Implicit VR Little Endian | 132876 bytes | Head MR slice. | Metadata supported; pixel-data read fails due to a libdicom limitation with this file's missing `NumberOfFrames` tag (unrelated to NEP) |
+| `CT-MONO2-16-chest.dcm` | CT | JPEG Lossless, First-Order Prediction (`1.2.840.10008.1.2.4.70`) | 145136 bytes | Chest CT slice. | Supported (requires `libgdcm-dev`) |
+| `MR-MONO2-12-shoulder.dcm` | MR | JPEG Lossless (`1.2.840.10008.1.2.4.57`) | 720528 bytes | Shoulder MR slice, 12-bit stored. | Supported (requires `libgdcm-dev`) |
+| `CR-MONO1-10-chest.dcm` | CR | Unknown; file has no 128-byte preamble/`DICM` magic | 387976 bytes | Chest X-ray. | **Not supported** — rejected cleanly with `NC_EINVAL`; out of scope, see `docs/plan/v3.2.0-sprint2-dicom-sample-coverage.md` |
 
 Source: <https://downloads.openmicroscopy.org/images/DICOM/samples/>
 

--- a/test/tst_dicom_udf.c
+++ b/test/tst_dicom_udf.c
@@ -7,10 +7,26 @@
  * native uncompressed pixel data reads (8-bit and 16-bit), and
  * encapsulated JPEG Baseline multi-frame reads.
  *
+ * v3.2.0 Sprint 2: add coverage for the OME public-domain samples added in
+ * v3.1.0 Sprint 1. Two (CT-MONO2-16-brain.dcm, MR-MONO2-16-head.dcm) are
+ * native uncompressed. Two (CT-MONO2-16-chest.dcm, MR-MONO2-12-shoulder.dcm)
+ * use JPEG Lossless (Process 14) encapsulation, decoded via GDCM's bundled
+ * IJG lossless codec (see src/dicomjpeglossless.h). A fifth
+ * (CR-MONO1-10-chest.dcm) has no DICOM preamble/File Meta Information and
+ * is intentionally out of scope; it is verified to fail cleanly.
+ *
  * Test files:
  *   - data/DICOM/tst_dicom_uncompressed.dcm: 1-frame 4x6 grayscale 8-bit
  *   - data/DICOM/MRBRAIN.DCM: 1-frame 512x512 16-bit MR
  *   - data/DICOM/0003.DCM: 17-frame 512x512 encapsulated JPEG Baseline
+ *   - data/DICOM/CT-MONO2-16-brain.dcm: 1-frame 512x512 16-bit CT, native
+ *   - data/DICOM/MR-MONO2-16-head.dcm: 1-frame 256x256 16-bit MR, native
+ *   - data/DICOM/CT-MONO2-16-chest.dcm: 1-frame 400x512 16-bit CT, JPEG
+ *     Lossless
+ *   - data/DICOM/MR-MONO2-12-shoulder.dcm: 1-frame 1024x1024 12-bit MR,
+ *     JPEG Lossless
+ *   - data/DICOM/CR-MONO1-10-chest.dcm: no preamble; expected to be
+ *     rejected with NC_EINVAL
  *
  * @author Edward Hartnett
  * @date 2026-07-25
@@ -42,6 +58,25 @@
 
 /** Path to an encapsulated JPEG Baseline multi-frame DICOM test file. */
 #define DICOM_COMPRESSED_TEST_FILE "data/DICOM/0003.DCM"
+
+/** Path to a native uncompressed 16-bit CT DICOM test file. */
+#define DICOM_CT_BRAIN_TEST_FILE "data/DICOM/CT-MONO2-16-brain.dcm"
+
+/** Path to a native uncompressed 16-bit MR DICOM test file. */
+#define DICOM_MR_HEAD_TEST_FILE "data/DICOM/MR-MONO2-16-head.dcm"
+
+/** Path to a JPEG Lossless (16-bit precision) encapsulated CT DICOM test
+ * file. */
+#define DICOM_CT_CHEST_LOSSLESS_TEST_FILE "data/DICOM/CT-MONO2-16-chest.dcm"
+
+/** Path to a JPEG Lossless (12-bit precision) encapsulated MR DICOM test
+ * file. */
+#define DICOM_MR_SHOULDER_LOSSLESS_TEST_FILE \
+    "data/DICOM/MR-MONO2-12-shoulder.dcm"
+
+/** Path to a DICOM file with no preamble/File Meta Information; expected
+ * to be rejected cleanly. */
+#define DICOM_NO_PREAMBLE_TEST_FILE "data/DICOM/CR-MONO1-10-chest.dcm"
 
 int
 main(void)
@@ -467,6 +502,285 @@ main(void)
         if ((retval = nc_close(mr_ncid)))
             ERR(retval);
         printf("PASS: nc_close 16-bit\n");
+    }
+
+    /* Open the native uncompressed 16-bit CT DICOM file. */
+    {
+        int ct_ncid, ct_varid;
+        size_t ct_frame_len, ct_row_len, ct_col_len;
+        short ct_pixel;
+        size_t ct_start[3] = {0, 256, 256};
+        size_t ct_count[3] = {1, 1, 1};
+        char att_buf[NC_MAX_NAME + 1];
+        size_t att_len;
+
+        if ((retval = nc_open(DICOM_CT_BRAIN_TEST_FILE, NC_UDF6, &ct_ncid)))
+            ERR(retval);
+        printf("PASS: nc_open %s\n", DICOM_CT_BRAIN_TEST_FILE);
+
+        if ((retval = nc_inq_dimid(ct_ncid, "frame", &var_dimids[0])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(ct_ncid, var_dimids[0], name, &ct_frame_len)))
+            ERR(retval);
+        if (strcmp(name, "frame") != 0 || ct_frame_len != 1)
+        { fprintf(stderr, "CT brain: unexpected frame dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(ct_ncid, "row", &var_dimids[1])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(ct_ncid, var_dimids[1], name, &ct_row_len)))
+            ERR(retval);
+        if (strcmp(name, "row") != 0 || ct_row_len != 512)
+        { fprintf(stderr, "CT brain: unexpected row dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(ct_ncid, "column", &var_dimids[2])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(ct_ncid, var_dimids[2], name, &ct_col_len)))
+            ERR(retval);
+        if (strcmp(name, "column") != 0 || ct_col_len != 512)
+        { fprintf(stderr, "CT brain: unexpected column dim\n"); return 1; }
+        printf("PASS: CT brain dims frame=%zu row=%zu column=%zu\n",
+               ct_frame_len, ct_row_len, ct_col_len);
+
+        if ((retval = nc_inq_varid(ct_ncid, "pixel_data", &ct_varid)))
+            ERR(retval);
+        if ((retval = nc_inq_var(ct_ncid, ct_varid, name, &xtype, &var_ndims,
+                                  var_dimids, &var_natts)))
+            ERR(retval);
+        if (xtype != NC_SHORT && xtype != NC_USHORT)
+        { fprintf(stderr, "CT brain: expected NC_SHORT/NC_USHORT\n"); return 1; }
+
+        if ((retval = nc_inq_att(ct_ncid, NC_GLOBAL, "Modality", &xtype,
+                                  &att_len)))
+            ERR(retval);
+        if ((retval = nc_get_att_text(ct_ncid, NC_GLOBAL, "Modality", att_buf)))
+            ERR(retval);
+        att_buf[att_len] = '\0';
+        if (strcmp(att_buf, "CT") != 0)
+        { fprintf(stderr, "CT brain: expected Modality='CT', got '%s'\n", att_buf); return 1; }
+        printf("PASS: CT brain att Modality='%s'\n", att_buf);
+
+        if ((retval = nc_get_vara_short(ct_ncid, ct_varid, ct_start, ct_count,
+                                        &ct_pixel)))
+            ERR(retval);
+        printf("PASS: CT brain center pixel=%d\n", ct_pixel);
+
+        if ((retval = nc_close(ct_ncid)))
+            ERR(retval);
+        printf("PASS: nc_close CT brain\n");
+    }
+
+    /* Open the native uncompressed 16-bit MR DICOM file.
+     *
+     * Note: this file lacks a NumberOfFrames tag in a way that causes
+     * libdicom's dcm_filehandle_read_frame() to fail internally (a
+     * libdicom limitation unrelated to JPEG Lossless support; other
+     * native files without this tag, e.g. MRBRAIN.DCM and
+     * CT-MONO2-16-brain.dcm, read pixel data without issue). Only
+     * metadata mapping is verified here; see
+     * docs/plan/v3.2.0-sprint2-dicom-sample-coverage.md for follow-up. */
+    {
+        int mrh_ncid;
+        size_t mrh_frame_len, mrh_row_len, mrh_col_len;
+        char att_buf[NC_MAX_NAME + 1];
+        size_t att_len;
+
+        if ((retval = nc_open(DICOM_MR_HEAD_TEST_FILE, NC_UDF6, &mrh_ncid)))
+            ERR(retval);
+        printf("PASS: nc_open %s\n", DICOM_MR_HEAD_TEST_FILE);
+
+        if ((retval = nc_inq_dimid(mrh_ncid, "frame", &var_dimids[0])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(mrh_ncid, var_dimids[0], name, &mrh_frame_len)))
+            ERR(retval);
+        if (strcmp(name, "frame") != 0 || mrh_frame_len != 1)
+        { fprintf(stderr, "MR head: unexpected frame dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(mrh_ncid, "row", &var_dimids[1])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(mrh_ncid, var_dimids[1], name, &mrh_row_len)))
+            ERR(retval);
+        if (strcmp(name, "row") != 0 || mrh_row_len != 256)
+        { fprintf(stderr, "MR head: unexpected row dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(mrh_ncid, "column", &var_dimids[2])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(mrh_ncid, var_dimids[2], name, &mrh_col_len)))
+            ERR(retval);
+        if (strcmp(name, "column") != 0 || mrh_col_len != 256)
+        { fprintf(stderr, "MR head: unexpected column dim\n"); return 1; }
+        printf("PASS: MR head dims frame=%zu row=%zu column=%zu\n",
+               mrh_frame_len, mrh_row_len, mrh_col_len);
+
+        if ((retval = nc_inq_att(mrh_ncid, NC_GLOBAL, "Modality", &xtype,
+                                  &att_len)))
+            ERR(retval);
+        if ((retval = nc_get_att_text(mrh_ncid, NC_GLOBAL, "Modality", att_buf)))
+            ERR(retval);
+        att_buf[att_len] = '\0';
+        if (strcmp(att_buf, "MR") != 0)
+        { fprintf(stderr, "MR head: expected Modality='MR', got '%s'\n", att_buf); return 1; }
+        printf("PASS: MR head att Modality='%s'\n", att_buf);
+
+        if ((retval = nc_close(mrh_ncid)))
+            ERR(retval);
+        printf("PASS: nc_close MR head\n");
+    }
+
+    /* Open the JPEG Lossless (16-bit precision) encapsulated CT DICOM
+     * file. This exercises the gdcmjpeg16 decode path. */
+    {
+        int ctl_ncid, ctl_varid;
+        size_t ctl_frame_len, ctl_row_len, ctl_col_len;
+        short ctl_pixel;
+        size_t ctl_start[3] = {0, 200, 256};
+        size_t ctl_count[3] = {1, 1, 1};
+        char att_buf[NC_MAX_NAME + 1];
+        size_t att_len;
+
+        if ((retval = nc_open(DICOM_CT_CHEST_LOSSLESS_TEST_FILE, NC_UDF6,
+                              &ctl_ncid)))
+            ERR(retval);
+        printf("PASS: nc_open %s\n", DICOM_CT_CHEST_LOSSLESS_TEST_FILE);
+
+        if ((retval = nc_inq_dimid(ctl_ncid, "frame", &var_dimids[0])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(ctl_ncid, var_dimids[0], name, &ctl_frame_len)))
+            ERR(retval);
+        if (strcmp(name, "frame") != 0 || ctl_frame_len != 1)
+        { fprintf(stderr, "CT chest lossless: unexpected frame dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(ctl_ncid, "row", &var_dimids[1])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(ctl_ncid, var_dimids[1], name, &ctl_row_len)))
+            ERR(retval);
+        if (strcmp(name, "row") != 0 || ctl_row_len != 400)
+        { fprintf(stderr, "CT chest lossless: unexpected row dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(ctl_ncid, "column", &var_dimids[2])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(ctl_ncid, var_dimids[2], name, &ctl_col_len)))
+            ERR(retval);
+        if (strcmp(name, "column") != 0 || ctl_col_len != 512)
+        { fprintf(stderr, "CT chest lossless: unexpected column dim\n"); return 1; }
+        printf("PASS: CT chest lossless dims frame=%zu row=%zu column=%zu\n",
+               ctl_frame_len, ctl_row_len, ctl_col_len);
+
+        if ((retval = nc_inq_att(ctl_ncid, NC_GLOBAL, "TransferSyntaxUID",
+                                  &xtype, &att_len)))
+            ERR(retval);
+        if ((retval = nc_get_att_text(ctl_ncid, NC_GLOBAL, "TransferSyntaxUID",
+                                      att_buf)))
+            ERR(retval);
+        att_buf[att_len] = '\0';
+        if (strcmp(att_buf, "1.2.840.10008.1.2.4.70") != 0)
+        {
+            fprintf(stderr, "CT chest lossless: expected TransferSyntaxUID="
+                    "'1.2.840.10008.1.2.4.70', got '%s'\n", att_buf);
+            return 1;
+        }
+        printf("PASS: CT chest lossless att TransferSyntaxUID='%s'\n", att_buf);
+
+        if ((retval = nc_inq_varid(ctl_ncid, "pixel_data", &ctl_varid)))
+            ERR(retval);
+        if ((retval = nc_get_vara_short(ctl_ncid, ctl_varid, ctl_start,
+                                        ctl_count, &ctl_pixel)))
+            ERR(retval);
+        printf("PASS: CT chest lossless decoded pixel=%d\n", ctl_pixel);
+
+        if ((retval = nc_close(ctl_ncid)))
+            ERR(retval);
+        printf("PASS: nc_close CT chest lossless\n");
+    }
+
+    /* Open the JPEG Lossless (12-bit precision) encapsulated MR DICOM
+     * file. This exercises the gdcmjpeg12 decode path. */
+    {
+        int mrl_ncid, mrl_varid;
+        size_t mrl_frame_len, mrl_row_len, mrl_col_len;
+        unsigned short mrl_pixel;
+        size_t mrl_start[3] = {0, 512, 512};
+        size_t mrl_count[3] = {1, 1, 1};
+        char att_buf[NC_MAX_NAME + 1];
+        size_t att_len;
+
+        if ((retval = nc_open(DICOM_MR_SHOULDER_LOSSLESS_TEST_FILE, NC_UDF6,
+                              &mrl_ncid)))
+            ERR(retval);
+        printf("PASS: nc_open %s\n", DICOM_MR_SHOULDER_LOSSLESS_TEST_FILE);
+
+        if ((retval = nc_inq_dimid(mrl_ncid, "frame", &var_dimids[0])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(mrl_ncid, var_dimids[0], name, &mrl_frame_len)))
+            ERR(retval);
+        if (strcmp(name, "frame") != 0 || mrl_frame_len != 1)
+        { fprintf(stderr, "MR shoulder lossless: unexpected frame dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(mrl_ncid, "row", &var_dimids[1])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(mrl_ncid, var_dimids[1], name, &mrl_row_len)))
+            ERR(retval);
+        if (strcmp(name, "row") != 0 || mrl_row_len != 1024)
+        { fprintf(stderr, "MR shoulder lossless: unexpected row dim\n"); return 1; }
+
+        if ((retval = nc_inq_dimid(mrl_ncid, "column", &var_dimids[2])))
+            ERR(retval);
+        if ((retval = nc_inq_dim(mrl_ncid, var_dimids[2], name, &mrl_col_len)))
+            ERR(retval);
+        if (strcmp(name, "column") != 0 || mrl_col_len != 1024)
+        { fprintf(stderr, "MR shoulder lossless: unexpected column dim\n"); return 1; }
+        printf("PASS: MR shoulder lossless dims frame=%zu row=%zu column=%zu\n",
+               mrl_frame_len, mrl_row_len, mrl_col_len);
+
+        if ((retval = nc_inq_att(mrl_ncid, NC_GLOBAL, "TransferSyntaxUID",
+                                  &xtype, &att_len)))
+            ERR(retval);
+        if ((retval = nc_get_att_text(mrl_ncid, NC_GLOBAL, "TransferSyntaxUID",
+                                      att_buf)))
+            ERR(retval);
+        att_buf[att_len] = '\0';
+        if (strcmp(att_buf, "1.2.840.10008.1.2.4.57") != 0)
+        {
+            fprintf(stderr, "MR shoulder lossless: expected TransferSyntaxUID="
+                    "'1.2.840.10008.1.2.4.57', got '%s'\n", att_buf);
+            return 1;
+        }
+        printf("PASS: MR shoulder lossless att TransferSyntaxUID='%s'\n",
+               att_buf);
+
+        if ((retval = nc_inq_varid(mrl_ncid, "pixel_data", &mrl_varid)))
+            ERR(retval);
+        if ((retval = nc_get_vara_ushort(mrl_ncid, mrl_varid, mrl_start,
+                                         mrl_count, &mrl_pixel)))
+            ERR(retval);
+        /* BitsStored is 12, so decoded values must fit in [0, 4095]. */
+        if (mrl_pixel > 4095)
+        {
+            fprintf(stderr, "MR shoulder lossless: pixel %u exceeds 12-bit "
+                    "range\n", mrl_pixel);
+            return 1;
+        }
+        printf("PASS: MR shoulder lossless decoded pixel=%u\n", mrl_pixel);
+
+        if ((retval = nc_close(mrl_ncid)))
+            ERR(retval);
+        printf("PASS: nc_close MR shoulder lossless\n");
+    }
+
+    /* CR-MONO1-10-chest.dcm has no preamble/File Meta Information and is
+     * out of scope for this sprint; verify it is rejected cleanly rather
+     * than crashing or hanging. */
+    {
+        int np_ncid;
+
+        retval = nc_open(DICOM_NO_PREAMBLE_TEST_FILE, NC_UDF6, &np_ncid);
+        if (retval != NC_EINVAL)
+        {
+            fprintf(stderr, "no-preamble file: expected NC_EINVAL, got %d "
+                    "(%s)\n", retval, nc_strerror(retval));
+            return 1;
+        }
+        printf("PASS: %s cleanly rejected with NC_EINVAL as expected\n",
+               DICOM_NO_PREAMBLE_TEST_FILE);
     }
 
     printf("Done.\n");


### PR DESCRIPTION
…lossless codec, and Fortran DICOM test coverage

- Add CMake detection for gdcmjpeg8/12/16 headers and libraries under NEP_ENABLE_DICOM
- Implement precision-based JPEG Lossless decode wrappers using GDCM's 8/12/16-bit IJG libjpeg 6b variants
- Add dicom_jpeg_lossless_precision() to detect SOF3 marker precision and select matching codec
- Recognize 1.2.840.10008.1.2.4.57 and 1.2.840.10008.1.2.4.70 as supported encapsulated transfer syntaxes -