### PR TITLE
Add PDB documentation, examples, and visualization scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Read other formats with the netcdf-c library, as if they were netCDF files.
 | **FITS** | Astronomical images and tables (HST, JWST) |
 | **PDS4** | NASA/ESA planetary science (Mars, Moon, etc.) |
 | **DICOM** | Medical imaging (CT, MR, XA, US) |
+| **Legacy PDB** | Protein/macromolecular structures (RCSB) |
 
 All readers use the standard NetCDF UDF system. Once enabled, **existing C and Fortran programs require no code modification** — an existing Fortran program that calls `nf90_open()` and `nf90_get_var()` can read a FITS, CDF, GeoTIFF, GRIB2, or PDS4 file without changing code.
 
@@ -49,7 +50,8 @@ cmake -B build \
   -DNEP_ENABLE_CDF=ON \
   -DNEP_ENABLE_FITS=ON \
   -DNEP_ENABLE_PDS4=ON \
-  -DNEP_ENABLE_DICOM=ON
+  -DNEP_ENABLE_DICOM=ON \
+  -DNEP_ENABLE_PDB=ON
 ```
 
 ### Example Programs
@@ -129,6 +131,7 @@ cmake -B build -DHDF5_ROOT=/usr/local/hdf5-2.1.1 -DCMAKE_INSTALL_PREFIX=/usr/loc
 | `-DNEP_ENABLE_CDF` | **OFF** | NASA CDF UDF handler (UDF4) |
 | `-DNEP_ENABLE_PDS4` | **OFF** | NASA/ESA PDS4 UDF handler (UDF5) |
 | `-DNEP_ENABLE_DICOM` | **OFF** | DICOM UDF handler (UDF6) |
+| `-DNEP_ENABLE_PDB` | ON | Legacy PDB UDF handler (UDF7) |
 | `-DNEP_BUILD_EXAMPLES` | ON | Example programs |
 | `-DNEP_ENABLE_BENCHMARKS` | OFF | Performance benchmark examples |
 | `-DNEP_ENABLE_PARALLEL_TESTS` | OFF | MPI parallel I/O tests |
@@ -145,7 +148,7 @@ cmake -B build -DHDF5_ROOT=/usr/local/hdf5-2.1.1 -DCMAKE_INSTALL_PREFIX=/usr/loc
 
 #### Format Readers
 
-All format readers default to **OFF** and are independent — any combination can be enabled simultaneously.
+All format readers are independent — any combination can be enabled simultaneously. Legacy PDB defaults to **ON**; the rest default to **OFF**.
 
 | Format | CMake Option | UDF Slot | Dependencies |
 |--------|--------------|----------|--------------|
@@ -155,6 +158,7 @@ All format readers default to **OFF** and are independent — any combination ca
 | NASA CDF | `-DNEP_ENABLE_CDF` | UDF4 | NASA CDF library v3.9.x |
 | PDS4 | `-DNEP_ENABLE_PDS4` | UDF5 | libxml2 ≥ 2.9 |
 | DICOM | `-DNEP_ENABLE_DICOM` | UDF6 | libdicom, libjpeg / libjpeg-turbo |
+| Legacy PDB | `-DNEP_ENABLE_PDB` | UDF7 | None (built-in fixed-column parser) |
 
 - NASA CDF library: https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest/ (or `spack install cdf`)
 - CDF moved from UDF2 to UDF4 in v2.2.0; GRIB2 and CDF can now be enabled together.
@@ -206,6 +210,7 @@ This builds NEP with LZ4, BZIP2, Fortran wrappers, and documentation — no form
 | `grib2` | OFF | GRIB2 reader — NWP model output (requires NCEPLIBS-g2c) |
 | `pds4` | OFF | PDS4 reader — planetary science (requires libxml2) |
 | `dicom` | OFF | DICOM reader — medical imaging (requires libdicom, libjpeg-turbo) |
+| `pdb` | ON | Legacy PDB reader — protein structures (no external library required) |
 | `parallel` | OFF | Parallel I/O tests (requires MPI, HDF5+mpi, netcdf-c+mpi) |
 | `examples` | OFF | Example programs |
 | `benchmarks` | OFF | Performance benchmark programs |
@@ -217,7 +222,7 @@ This builds NEP with LZ4, BZIP2, Fortran wrappers, and documentation — no form
 spack install nep+geotiff+grib2
 
 # All format readers
-spack install nep+geotiff+grib2+fits+pds4+dicom
+spack install nep+geotiff+grib2+fits+pds4+dicom+pdb
 
 # Minimal build (no docs, no Fortran) for CI/containers
 spack install nep~docs~fortran

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -952,6 +952,7 @@ INPUT                  = @abs_top_srcdir@/src/nep.c \
                          @abs_top_srcdir@/include/grib2dispatch.h \
                          @abs_top_srcdir@/include/fitsdispatch.h \
                          @abs_top_srcdir@/include/dicomdispatch.h \
+                         @abs_top_srcdir@/include/pdbdispatch.h \
                          @abs_top_srcdir@/include/cdfdispatch.h \
                          @abs_top_srcdir@/fsrc/nep.F90 \
                          @abs_top_srcdir@/docs/mainpage.md \
@@ -963,6 +964,7 @@ INPUT                  = @abs_top_srcdir@/src/nep.c \
                          @abs_top_srcdir@/docs/fits.md \
                          @abs_top_srcdir@/docs/dicom.md \
                          @abs_top_srcdir@/docs/pds4.md \
+                         @abs_top_srcdir@/docs/pdb.md \
                          @abs_top_srcdir@/docs/examples.md \
                          @abs_top_srcdir@/examples/README.md \
                          @abs_top_srcdir@/examples

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,6 +1,6 @@
 # NEP Format Readers
 
-NEP implements five NetCDF User Defined Format (UDF) handlers that allow external scientific data formats to be opened with the standard `nc_open()` API. All readers are **disabled by default** and must be enabled at build time.
+NEP implements seven NetCDF User Defined Format (UDF) handlers that allow external scientific data formats to be opened with the standard `nc_open()` API. Most readers are **disabled by default** and must be enabled at build time; the legacy PDB reader is enabled by default.
 
 ## UDF Slot Assignments
 
@@ -13,6 +13,7 @@ NEP implements five NetCDF User Defined Format (UDF) handlers that allow externa
 | UDF4 | NASA CDF | `\xCD\xF3\x00\x01` | v1.3.0 |
 | UDF5 | NASA/ESA PDS4 | XML root `Product_Observational` | v2.2.0 |
 | UDF6 | DICOM | `DICM` at byte offset 128 | v3.0.0 |
+| UDF7 | Legacy PDB | `HEADER` | v3.3.0 |
 
 All readers can be enabled simultaneously — there are no mutual-exclusivity restrictions.
 
@@ -29,6 +30,7 @@ dependencies, resources, and examples:
 | NASA CDF | UDF4 | [NASA CDF](cdf.md) |
 | NASA/ESA PDS4 | UDF5 | [PDS4-to-NetCDF Mapping](pds4.md) |
 | DICOM | UDF6 | [DICOM](dicom.md) |
+| Legacy PDB | UDF7 | [PDB](pdb.md) |
 
 See also the native NetCDF-4 compression documentation:
 [LZ4/BZIP2 HDF5 filters](compression.md).
@@ -60,6 +62,7 @@ nc_open("data.cdf",                             NC_NOWRITE, &ncid);  /* CDF */
 nc_open("gdaswave.t00z.wcoast.0p16.f000.grib2", NC_NOWRITE, &ncid);  /* GRIB2 */
 nc_open("image.fits",                           NC_NOWRITE, &ncid);  /* FITS */
 nc_open("image.dcm",                            NC_UDF6,    &ncid);  /* DICOM */
+nc_open("structure.pdb",                        NC_UDF7,    &ncid);  /* Legacy PDB */
 ```
 
 **Install path**:

--- a/docs/pdb.md
+++ b/docs/pdb.md
@@ -1,0 +1,33 @@
+# Legacy PDB Format Reader
+
+Legacy PDB (Protein Data Bank) is the fixed-column text format historically used by the RCSB Protein Data Bank for macromolecular structures (proteins, nucleic acids). NEP's reader is read-only and covers coordinate, model, and unit-cell metadata records.
+
+**Transparent Access**: Read legacy PDB files with `nc_open()` after calling `NC_PDB_initialize()`.
+
+**Record-to-NetCDF Mapping**:
+- `ATOM`/`HETATM` records → a single `atom` dimension (file order) and per-atom variables: `atom_site_Cartn_x/y/z`, `atom_site_id`, `atom_site_label_atom_id`, `atom_site_label_comp_id`, `atom_site_auth_asym_id`, `atom_site_auth_seq_id`, `atom_site_occupancy`, `atom_site_B_iso_or_equiv`, `atom_site_type_symbol`, and `atom_site_group_PDB` (`"ATOM"` or `"HETATM"`).
+- `MODEL`/`ENDMDL` blocks → a `model` dimension (1 if no `MODEL` records are present); coordinate variables are shaped `[model][atom]`.
+- `CRYST1` → global attributes `cell_length_a/b/c`, `cell_angle_alpha/beta/gamma`, `space_group_name_H-M`, `symmetry_Z`. Omitted entirely if the file has no `CRYST1` record.
+- `HEADER`/`TITLE`/`COMPND`/`SOURCE` → global attributes `idCode`, `classification`, `depDate`, `title`, `compnd`, `source`.
+
+**Known Limitations**: `SEQRES` sequence data, hybrid-36 encoded serial/residue numbers, and multi-character chain IDs are not currently handled.
+
+**Use Cases**: Protein/macromolecular structure analysis, RCSB-sourced X-ray crystal structures, NMR ensembles with multiple models.
+
+**Enabling:**
+```bash
+cmake -B build -DNEP_ENABLE_PDB=ON   # CMake (default ON)
+```
+**Dependencies**: None — a custom fixed-column line reader; no external parsing library is required.
+
+**Resources**: [PDB Format Guide](https://www.wwpdb.org/documentation/file-format) · [RCSB Protein Data Bank](https://www.rcsb.org/)
+
+**Example:**
+```c
+#include "pdbdispatch.h"
+NC_PDB_initialize();   /* register UDF7; safe to call even if already registered */
+nc_open("structure.pdb", NC_UDF7, &ncid);
+nc_inq_varid(ncid, "atom_site_Cartn_x", &varid);
+nc_get_vara_float(ncid, varid, start, count, coords);
+nc_close(ncid);
+```

--- a/docs/plan/v3.3.0-sprint4-pdb-documentation.md
+++ b/docs/plan/v3.3.0-sprint4-pdb-documentation.md
@@ -1,0 +1,148 @@
+# v3.3.0 Sprint 4: PDB Documentation, Examples, and Visualizations
+
+## Sprint Goal
+
+Bring the PDB legacy format reader (UDF7, added in Sprints 1–3) to full
+documentation and example parity with the other NEP format readers (FITS,
+DICOM, GeoTIFF, GRIB2, CDF, PDS4). This is a documentation- and example-only
+sprint: no reader behavior changes.
+
+## Scope
+
+- New `docs/pdb.md` format reference page.
+- Updates to `docs/formats.md`, top-level `README.md`, and `docs/Doxyfile.in`.
+- A new C example program `examples/pdb/pdb_read.c`.
+- Two new visualization scripts under `examples/viz/PDB/`.
+- Updates to `examples/README.md` and `examples/viz/README.md`.
+
+## Major Tasks (dependency order)
+
+1. **`docs/pdb.md`** — new format reference page, matching the structure of
+   `docs/fits.md`:
+   - Title, one-line format description (legacy PDB, RCSB).
+   - Transparent access via `nc_open()` after `NC_PDB_initialize()`.
+   - Record-to-NetCDF mapping: `ATOM`/`HETATM` → `atom` dimension and
+     `atom_site_*` variables; `MODEL`/`ENDMDL` → `model` dimension;
+     `CRYST1` → `cell_*`/`space_group_name_H-M` global attributes;
+     `HEADER`/`TITLE`/`COMPND`/`SOURCE` → global attributes.
+   - Known limitations: `SEQRES` sequence data, hybrid-36 encoding,
+     multi-character chain IDs (carried over from Sprint 2/3 decisions).
+   - Enabling: `-DNEP_ENABLE_PDB=ON` (default ON since Sprint 3).
+   - Dependencies: none (pure text parsing, no external library).
+   - Resources: link to the PDB format guide and RCSB.
+   - C example snippet (mirrors `pdb_read.c`).
+
+2. **`docs/formats.md`** — add PDB to both tables:
+   - UDF Slot Assignments table: `UDF7 | Legacy PDB | HEADER | v3.3.0`.
+   - Format Reference Pages table: `Legacy PDB | UDF7 | [PDB](pdb.md)`.
+   - Add `nc_open()` autoload example line if consistent with other UDF7+
+     entries (note current NetCDF-C limitation on explicit `NC_*_initialize()`
+     calls, matching FITS/DICOM notes).
+
+3. **`README.md`** — add PDB to:
+   - Multi-Format Readers table (`**Legacy PDB** | Protein/macromolecular structures (RCSB)`).
+   - CMake enable flags snippet (`-DNEP_ENABLE_PDB=ON`).
+   - CMake option table (`-DNEP_ENABLE_PDB | ON | Legacy PDB UDF handler (UDF7)`).
+   - Spack variant table and common-combinations examples if PDB has a Spack
+     package; otherwise note it is CMake-only for now.
+
+4. **`docs/Doxyfile.in`** — add `@abs_top_srcdir@/docs/pdb.md` to the `INPUT`
+   list (alongside `fits.md`, `dicom.md`, `pds4.md`), and add the PDB
+   dispatch/file source files (`src/pdbdispatch.c`, `src/pdbfile.c`, or actual
+   filenames from Sprint 2) if not already present.
+
+5. **`examples/pdb/pdb_read.c`** — new C example:
+   - Mirrors `examples/dicom/dicom_read.c` structure and the NEP example
+     coding style (`ERR` macro, `retval`, compact printed output).
+   - Calls `NC_PDB_initialize()`, opens a real test file
+     (`test/data/PDB/4HHB.pdb` by default, overridable via `argv[1]`).
+   - Prints dataset summary (dims/vars/atts), dimension list, and a small
+     slice of `atom_site_Cartn_x/y/z` for the first few atoms.
+   - Add the `@note Companion code for "The NetCDF Developer's Handbook..."`
+     block per the example doc-comment convention.
+   - Register in `examples/CMakeLists.txt` (new `examples/pdb/CMakeLists.txt`
+     subdirectory guarded by `NEP_ENABLE_PDB`, following the
+     `examples/dicom/CMakeLists.txt` pattern).
+
+6. **`examples/viz/PDB/`** — two new scripts, following the
+   `examples/viz/DICOM/` pattern (`plot_common.py`, `verify_viz_artifacts.py`,
+   metadata sidecar via `save_with_metadata`):
+   - `plot_pdb_xray_structure.py` — static 3D scatter of `ATOM`/`HETATM`
+     Cartesian coordinates for `4HHB.pdb`, colored by `atom_site_group_PDB`
+     (ATOM vs HETATM).
+   - `plot_pdb_nmr_ensemble.py` — overlay plot of backbone/atom coordinates
+     across all models in `1GAB.pdb`, one line/scatter series per model,
+     demonstrating the `[model][atom]` shape.
+   - A small `_pdb_udf.py` helper (mirrors `_dicom_udf.py`) to open the file
+     and return coordinate arrays via the NetCDF UDF interface.
+   - Register new CTest visualization tests in `examples/viz/CMakeLists.txt`
+     guarded by `NEP_ENABLE_PDB`, with artifacts added to the verifier
+     basename list in `verify_viz_artifacts.py`.
+
+7. **`examples/README.md`** and **`examples/viz/README.md`** — add PDB rows
+   describing the new example and viz scripts, consistent with existing
+   FITS/DICOM entries.
+
+## Acceptance Criteria
+
+- `docs/pdb.md` exists and documents the record-to-NetCDF mapping, enabling
+  instructions, limitations, and a working example, matching the depth of
+  `docs/fits.md`.
+- `docs/formats.md` and `README.md` list PDB/UDF7 consistently with all other
+  format entries.
+- `docs/Doxyfile.in` includes `docs/pdb.md` in `INPUT`; Doxygen build
+  generates a PDB page with no new warnings.
+- `examples/pdb/pdb_read.c` builds and runs successfully against
+  `test/data/PDB/4HHB.pdb` when `NEP_ENABLE_PDB=ON`, and is skipped/excluded
+  when PDB is disabled.
+- Two new PDB visualization scripts run under CTest, produce artifacts that
+  pass `verify_viz_artifacts.py`, and are gated by `NEP_ENABLE_PDB`.
+- `examples/README.md` and `examples/viz/README.md` mention PDB.
+- Full CTest suite remains green with PDB enabled and with PDB disabled.
+
+## Testing Requirements
+
+- Configure with `-DNEP_ENABLE_PDB=ON -DNEP_BUILD_EXAMPLES=ON` and matplotlib
+  available; run `ctest --test-dir build -R pdb --output-on-failure` and
+  `ctest --test-dir build -R viz --output-on-failure`.
+- Verify the new `pdb_read` example test passes and prints expected output.
+- Verify both new viz CTest entries produce artifacts accepted by
+  `verify_viz_artifacts.py`.
+- Run a PDB-disabled configuration to confirm the new example/viz targets are
+  correctly excluded and the rest of the suite is unaffected.
+- Build Doxygen docs (`cmake --build build --target docs` or equivalent) and
+  confirm the PDB page renders without new warnings.
+
+## Build System Integration
+
+- `examples/CMakeLists.txt` — add `add_subdirectory(pdb)` guarded by
+  `NEP_ENABLE_PDB`.
+- `examples/pdb/CMakeLists.txt` — new file, mirrors
+  `examples/dicom/CMakeLists.txt`.
+- `examples/viz/CMakeLists.txt` — add PDB viz test registrations, guarded by
+  `NEP_ENABLE_PDB` and matplotlib/numpy availability checks (consistent with
+  existing per-format guards).
+- `docs/Doxyfile.in` — `INPUT` list update.
+
+## Dependencies / Blockers
+
+- Depends on Sprint 2 (dispatch layer, variable/attribute names) and Sprint 3
+  (default-ON status, `test/data/PDB/4HHB.pdb` and `1GAB.pdb` availability)
+  being complete.
+- No new external library dependencies.
+
+## Documentation Updates Required
+
+- `docs/pdb.md` (new)
+- `docs/formats.md`
+- `README.md`
+- `docs/Doxyfile.in`
+- `examples/README.md`
+- `examples/viz/README.md`
+
+## Definition of Done
+
+PDB has a dedicated format reference page, is listed in all top-level format
+tables and the Doxygen build, has a working C example, has two working
+visualization scripts with passing CTest coverage, and the full test suite
+(PDB enabled and disabled) is green.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,9 +67,19 @@ Acquire additional real-world legacy PDB test files and extend `test/tst_pdb_udf
 **GitHub Issue:** [#345](https://github.com/Intelligent-Data-Design-Inc/NEP/issues/345)
 
 #### Sprint 4: Documentation
+**Detailed Plan**: See `docs/plan/v3.3.0-sprint4-pdb-documentation.md`
+
 - Update all the docs.
 - Add a section on PDB to doxygen docs.
 - Write some examples/viz visulaizations.
+
+**Clarified decisions:**
+- Two visualization scripts are added under `examples/viz/PDB/`: a static 3D scatter plot of `ATOM`/`HETATM` Cartesian coordinates for the X-ray structure `4HHB.pdb`, and a multi-model overlay plot from the NMR ensemble `1GAB.pdb` showing coordinate variation across models. Both follow the existing per-format viz pattern (`plot_common.py`, `verify_viz_artifacts.py`, metadata sidecar files).
+- A standalone C example `examples/pdb/pdb_read.c` is added, matching the style of `examples/dicom/dicom_read.c` (calls `NC_PDB_initialize()`, opens a PDB file, prints dims/vars and a slice of atom coordinates), and is registered in `examples/CMakeLists.txt` and `examples/README.md`.
+- Full documentation parity with FITS/DICOM: a new `docs/pdb.md` format reference page (mapping, enabling, dependencies, resources, example, matching `docs/fits.md` structure), a new PDB row/section in `docs/formats.md`'s UDF slot table and format reference table, PDB entries in the top-level `README.md` (format table, CMake option table, Spack variant table), `docs/pdb.md` added to `docs/Doxyfile.in`'s `INPUT` list, and PDB mentions added to `examples/README.md` and `examples/viz/README.md`.
+- No reader behavior changes in this sprint; it is documentation- and example-only.
+
+**GitHub Issue:** [#347](https://github.com/Intelligent-Data-Design-Inc/NEP/issues/347)
 
 ### V3.2.0 - More DICOM
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,10 @@ if(HAVE_DICOM)
     add_subdirectory(dicom)
 endif()
 
+if(HAVE_PDB)
+    add_subdirectory(pdb)
+endif()
+
 if(NEP_ENABLE_VIZ_EXAMPLES)
     add_subdirectory(viz)
 endif()

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,10 @@ Located in `parallelIO/`:
 - **square16_par.c** - Parallel NetCDF-4 I/O with MPI using collective operations and 2×2 domain decomposition
 - **f_square16_par.f90** - Fortran equivalent demonstrating `nf90_create_par()` and collective hyperslab I/O
 
+### Format Reader Examples (C)
+- **dicom_read.c** (`dicom/`) - Opens a DICOM image via `NC_DICOM_initialize()`/`NC_UDF6`, prints metadata, and reads a slice of pixel data. Built when `-DNEP_ENABLE_DICOM=ON`.
+- **pdb_read.c** (`pdb/`) - Opens a legacy PDB structure via `NC_PDB_initialize()`/`NC_UDF7`, prints metadata, and reads a slice of atom coordinates. Built when `-DNEP_ENABLE_PDB=ON` (default).
+
 ### Future Examples
 - `performance/` - Reserved for performance optimization examples
 

--- a/examples/pdb/CMakeLists.txt
+++ b/examples/pdb/CMakeLists.txt
@@ -1,0 +1,59 @@
+# CMakeLists.txt for legacy PDB C example
+# Edward Hartnett, Intelligent Data Design, Inc.
+
+if(NETCDF_LIBRARY_DIRS)
+    set(_nc_config_hints ${NETCDF_LIBRARY_DIRS}/../bin)
+elseif(NETCDF_PREFIX)
+    set(_nc_config_hints ${NETCDF_PREFIX}/bin)
+else()
+    set(_nc_config_hints "")
+endif()
+
+find_program(NC_CONFIG nc-config
+    HINTS ${_nc_config_hints}
+    PATHS ${_nc_config_hints}
+)
+
+if(NOT NC_CONFIG)
+    message(FATAL_ERROR "nc-config not found. Cannot build PDB example.")
+endif()
+
+execute_process(
+    COMMAND ${NC_CONFIG} --cflags
+    OUTPUT_VARIABLE NC_CFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+    COMMAND ${NC_CONFIG} --libs
+    OUTPUT_VARIABLE NC_LIBS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+    COMMAND ${NC_CONFIG} --libdir
+    OUTPUT_VARIABLE NC_LIBDIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+separate_arguments(NC_CFLAGS_LIST UNIX_COMMAND "${NC_CFLAGS}")
+separate_arguments(NC_LIBS_LIST UNIX_COMMAND "${NC_LIBS}")
+
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+add_executable(pdb_read pdb_read.c)
+target_compile_options(pdb_read PRIVATE ${NC_CFLAGS_LIST})
+get_filename_component(HDF5_LIB_DIR "${HDF5_INCLUDE_DIR}/../lib" ABSOLUTE)
+target_link_directories(pdb_read PRIVATE ${HDF5_LIB_DIR})
+target_link_libraries(pdb_read PRIVATE ${NC_LIBS_LIST} ncpdb nep)
+set_target_properties(pdb_read PROPERTIES
+    BUILD_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}"
+    SKIP_BUILD_RPATH OFF
+    BUILD_WITH_INSTALL_RPATH ON
+    INSTALL_RPATH "${HDF5_LIB_DIR};${NC_LIBDIR}")
+
+if(BUILD_TESTING)
+    add_test(NAME pdb_read
+             COMMAND pdb_read ${CMAKE_SOURCE_DIR}/test/data/PDB/4HHB.pdb
+             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    set_tests_properties(pdb_read PROPERTIES
+        ENVIRONMENT "NETCDF_RC=${CMAKE_BINARY_DIR};LD_LIBRARY_PATH=${_nep_test_ld_path}:$ENV{LD_LIBRARY_PATH}")
+endif()

--- a/examples/pdb/pdb_read.c
+++ b/examples/pdb/pdb_read.c
@@ -1,0 +1,94 @@
+/*
+ * @file pdb_read.c
+ * @brief Example program that reads a legacy PDB protein structure file
+ * through the NetCDF UDF API.
+ *
+ * This program demonstrates opening a legacy Protein Data Bank (PDB) file
+ * with the PDB UDF handler (UDF slot 7, NC_UDF7), reading the atom/model
+ * dimensions, and extracting a small slice of atom coordinate data.
+ *
+ * @note Companion code for "The NetCDF Developer's Handbook: The Authoritative
+ * Guide to Writing High-Performance Programs for Scientific Data Management,
+ * Second Edition" (https://www.amazon.com/dp/B0H7Q1Z75L)
+ *
+ * @author Edward Hartnett
+ * @date 2026-07-29
+ * @copyright Intelligent Data Design, Inc. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <netcdf.h>
+
+#define FILE_NAME "../test/data/PDB/4HHB.pdb"
+
+#define ERR(e) do { if (e) { fprintf(stderr, "Error: %s at line %d\n", nc_strerror(e), __LINE__); return 1; } } while (0)
+
+/* PDB UDF initialization function provided by libncpdb. */
+extern int NC_PDB_initialize(void);
+
+int
+main(int argc, char **argv)
+{
+    int ncid, x_varid, y_varid, z_varid, retval;
+    int ndims, nvars, ngatts, unlimdimid;
+    int dimids[NC_MAX_VAR_DIMS];
+    size_t len;
+    char name[NC_MAX_NAME + 1];
+    nc_type xtype;
+    int var_ndims, var_natts;
+    size_t start[2] = {0, 0};
+    size_t count[2] = {1, 4};
+    float x[4], y[4], z[4];
+    const char *file_name = (argc > 1) ? argv[1] : FILE_NAME;
+
+    (void)NC_PDB_initialize();
+
+    if ((retval = nc_open(file_name, NC_UDF7, &ncid)))
+        ERR(retval);
+
+    if ((retval = nc_inq(ncid, &ndims, &nvars, &ngatts, &unlimdimid)))
+        ERR(retval);
+    printf("Dataset: %d dims, %d vars, %d atts, unlimdim=%d\n",
+           ndims, nvars, ngatts, unlimdimid);
+
+    printf("Dimensions: ");
+    for (int i = 0; i < ndims; i++)
+    {
+        if ((retval = nc_inq_dim(ncid, i, name, &len)))
+            ERR(retval);
+        printf("%s=%zu ", name, len);
+    }
+    printf("\n");
+
+    if ((retval = nc_inq_varid(ncid, "atom_site_Cartn_x", &x_varid)))
+        ERR(retval);
+    if ((retval = nc_inq_var(ncid, x_varid, name, &xtype, &var_ndims,
+                              dimids, &var_natts)))
+        ERR(retval);
+    printf("Variable '%s': xtype=%d ndims=%d natts=%d\n",
+           name, xtype, var_ndims, var_natts);
+
+    if ((retval = nc_inq_varid(ncid, "atom_site_Cartn_y", &y_varid)))
+        ERR(retval);
+    if ((retval = nc_inq_varid(ncid, "atom_site_Cartn_z", &z_varid)))
+        ERR(retval);
+
+    if ((retval = nc_get_vara_float(ncid, x_varid, start, count, x)))
+        ERR(retval);
+    if ((retval = nc_get_vara_float(ncid, y_varid, start, count, y)))
+        ERR(retval);
+    if ((retval = nc_get_vara_float(ncid, z_varid, start, count, z)))
+        ERR(retval);
+
+    printf("First 4 atom coordinates:\n");
+    for (int i = 0; i < 4; i++)
+        printf("  atom %d: (%.3f, %.3f, %.3f)\n", i, x[i], y[i], z[i]);
+
+    if ((retval = nc_close(ncid)))
+        ERR(retval);
+
+    printf("Done.\n");
+    return 0;
+}

--- a/examples/viz/CMakeLists.txt
+++ b/examples/viz/CMakeLists.txt
@@ -16,6 +16,9 @@ set(_viz_python_files
     PDS4/plot_pds4_perseverance.py
     PDS4/plot_pds4_maven_l3.py
     PDS4/plot_pds4_new_horizons.py
+    PDB/_pdb_udf.py
+    PDB/plot_pdb_xray_structure.py
+    PDB/plot_pdb_nmr_ensemble.py
 )
 
 foreach(_viz_file ${_viz_python_files})
@@ -265,6 +268,32 @@ if(HAVE_DICOM)
     )
 
     list(APPEND _viz_artifacts dicom_mrbrain_image dicom_xa_frame_montage dicom_ct_brain_image)
+endif()
+
+if(HAVE_PDB)
+    add_test(
+        NAME viz_pdb_xray_structure
+        COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/PDB/plot_pdb_xray_structure.py"
+                "${CMAKE_BINARY_DIR}/test/data/PDB/4HHB.pdb"
+    )
+    set_tests_properties(viz_pdb_xray_structure PROPERTIES
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        ENVIRONMENT "${_viz_environment}"
+        FIXTURES_SETUP viz_artifacts
+    )
+
+    add_test(
+        NAME viz_pdb_nmr_ensemble
+        COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/PDB/plot_pdb_nmr_ensemble.py"
+                "${CMAKE_BINARY_DIR}/test/data/PDB/1GAB.pdb"
+    )
+    set_tests_properties(viz_pdb_nmr_ensemble PROPERTIES
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        ENVIRONMENT "${_viz_environment}"
+        FIXTURES_SETUP viz_artifacts
+    )
+
+    list(APPEND _viz_artifacts pdb_xray_structure pdb_nmr_ensemble)
 endif()
 
 add_test(

--- a/examples/viz/PDB/_pdb_udf.py
+++ b/examples/viz/PDB/_pdb_udf.py
@@ -1,0 +1,132 @@
+"""Minimal ctypes helper to read legacy PDB atom coordinates through the NetCDF-C UDF interface.
+
+The netCDF4-python Dataset constructor does not expose the NC_UDF7 mode flag
+required to open legacy PDB files whose magic string ("HEADER") is checked by
+the NEP dispatch layer, so this helper loads libncpdb, calls
+NC_PDB_initialize(), and then uses nc_open() with NC_UDF7 and nc_get_vara_*
+to read the atom_site_Cartn_x/y/z and atom_site_group_PDB variables.
+
+Companion code for "The NetCDF Developer's Handbook: The Authoritative Guide to
+Writing High-Performance Programs for Scientific Data Management, Second Edition"
+(https://www.amazon.com/dp/B0H7Q1Z75L).
+"""
+import ctypes
+import os
+from ctypes import c_char_p, c_int, c_size_t, c_void_p
+from pathlib import Path
+
+import numpy as np
+
+# NetCDF-C constants used by the helper.
+NC_NOERR = 0
+NC_NOWRITE = 0x0000
+NC_UDF7 = 0x800000
+NC_MAX_NAME = 256
+
+GROUP_FIELD_LEN = 6
+
+
+def _load_library(name):
+    """Load a shared library, respecting LD_LIBRARY_PATH."""
+    path = os.environ.get(name.upper().replace("-", "_") + "_LIBRARY", name)
+    try:
+        return ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+    except OSError as exc:
+        raise OSError(
+            f"unable to load {name}; ensure LD_LIBRARY_PATH includes "
+            f"the NetCDF-C and NEP PDB library directories"
+        ) from exc
+
+
+def _nc_strerror(libnc, status):
+    """Return a NetCDF error message string."""
+    libnc.nc_strerror.restype = c_char_p
+    return libnc.nc_strerror(status).decode("utf-8", errors="replace")
+
+
+def _check(libnc, status):
+    """Raise RuntimeError on a non-zero NetCDF status."""
+    if status != NC_NOERR:
+        raise RuntimeError(f"NetCDF error {status}: {_nc_strerror(libnc, status)}")
+
+
+def _ensure_pdb_handler(libpdb):
+    """Load and initialize the NEP PDB UDF handler.
+
+    This mirrors the explicit NC_PDB_initialize() call in the C/Fortran
+    PDB tests. The call is safe even when the handler is already registered
+    (e.g., via .ncrc autoload).
+    """
+    libpdb.NC_PDB_initialize.restype = c_void_p
+    libpdb.NC_PDB_initialize()
+
+
+def read_structure(path):
+    """Open *path* via the PDB UDF handler and read atom coordinates.
+
+    Returns a dict with keys ``x``, ``y``, ``z`` (each a ``numpy.ndarray``
+    shaped ``[model][atom]``) and ``group`` (a list of ``natoms`` strings,
+    each ``"ATOM"`` or ``"HETATM"``).
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    libnc = _load_library("libnetcdf.so.22")
+    libpdb = _load_library("libncpdb.so")
+
+    libnc.nc_open.argtypes = [c_char_p, c_int, ctypes.POINTER(c_int)]
+    libnc.nc_open.restype = c_int
+
+    _ensure_pdb_handler(libpdb)
+
+    ncid = c_int()
+    _check(libnc, libnc.nc_open(str(path).encode("utf-8"), NC_UDF7 | NC_NOWRITE, ctypes.byref(ncid)))
+    try:
+        model_dimid = c_int()
+        atom_dimid = c_int()
+        _check(libnc, libnc.nc_inq_dimid(ncid.value, b"model", ctypes.byref(model_dimid)))
+        _check(libnc, libnc.nc_inq_dimid(ncid.value, b"atom", ctypes.byref(atom_dimid)))
+
+        libnc.nc_inq_dimlen.argtypes = [c_int, c_int, ctypes.POINTER(c_size_t)]
+        libnc.nc_inq_dimlen.restype = c_int
+
+        nmodels = c_size_t()
+        natoms = c_size_t()
+        _check(libnc, libnc.nc_inq_dimlen(ncid.value, model_dimid.value, ctypes.byref(nmodels)))
+        _check(libnc, libnc.nc_inq_dimlen(ncid.value, atom_dimid.value, ctypes.byref(natoms)))
+
+        shape = (nmodels.value, natoms.value)
+
+        def _read_float_var(var_name):
+            varid = c_int()
+            _check(libnc, libnc.nc_inq_varid(ncid.value, var_name.encode("utf-8"), ctypes.byref(varid)))
+            data = np.empty(shape, dtype=np.float32, order="C")
+            libnc.nc_get_var_float.argtypes = [c_int, c_int, c_void_p]
+            libnc.nc_get_var_float.restype = c_int
+            _check(libnc, libnc.nc_get_var_float(ncid.value, varid.value, data.ctypes.data_as(c_void_p)))
+            return data
+
+        x = _read_float_var("atom_site_Cartn_x")
+        y = _read_float_var("atom_site_Cartn_y")
+        z = _read_float_var("atom_site_Cartn_z")
+
+        group_varid = c_int()
+        _check(libnc, libnc.nc_inq_varid(ncid.value, b"atom_site_group_PDB", ctypes.byref(group_varid)))
+        buf = ctypes.create_string_buffer(natoms.value * GROUP_FIELD_LEN)
+        start = (c_size_t * 2)(0, 0)
+        count = (c_size_t * 2)(natoms.value, GROUP_FIELD_LEN)
+        libnc.nc_get_vara_text.argtypes = [
+            c_int, c_int, ctypes.POINTER(c_size_t), ctypes.POINTER(c_size_t), c_char_p,
+        ]
+        libnc.nc_get_vara_text.restype = c_int
+        _check(libnc, libnc.nc_get_vara_text(ncid.value, group_varid.value, start, count, buf))
+        raw = buf.raw
+        group = [
+            raw[i * GROUP_FIELD_LEN:(i + 1) * GROUP_FIELD_LEN].rstrip(b"\x00 ").decode("ascii")
+            for i in range(natoms.value)
+        ]
+
+        return {"x": x, "y": y, "z": z, "group": group}
+    finally:
+        libnc.nc_close(ncid.value)

--- a/examples/viz/PDB/plot_pdb_nmr_ensemble.py
+++ b/examples/viz/PDB/plot_pdb_nmr_ensemble.py
@@ -1,0 +1,70 @@
+"""Plot a multi-model overlay of the 1GAB.pdb NMR ensemble through the NetCDF UDF interface.
+
+Companion code for "The NetCDF Developer's Handbook: The Authoritative Guide to
+Writing High-Performance Programs for Scientific Data Management, Second Edition"
+(https://www.amazon.com/dp/B0H7Q1Z75L).
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  (registers 3D projection)
+
+from _pdb_udf import read_structure
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from plot_common import save_with_metadata
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot a multi-model overlay of the 1GAB.pdb NMR ensemble."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=os.environ.get("NEP_VIZ_PDB_NMR_FILE"),
+    )
+    args = parser.parse_args()
+    if not args.path:
+        parser.error(
+            "a PDB NMR ensemble file path is required (or set NEP_VIZ_PDB_NMR_FILE)"
+        )
+
+    path = Path(args.path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    structure = read_structure(path)
+    x = structure["x"]
+    y = structure["y"]
+    z = structure["z"]
+    nmodels = x.shape[0]
+
+    fig = plt.figure(figsize=(6.5, 6.0))
+    ax = fig.add_subplot(111, projection="3d")
+    shades = np.linspace(0.15, 0.85, nmodels) if nmodels > 1 else [0.0]
+    for m in range(nmodels):
+        gray = str(shades[m])
+        ax.plot(x[m, :], y[m, :], z[m, :], color=gray, linewidth=0.5, alpha=0.7)
+    ax.set_title(f"1GAB NMR Ensemble ({nmodels} models)")
+    ax.set_xlabel("x (\u00c5)")
+    ax.set_ylabel("y (\u00c5)")
+    ax.set_zlabel("z (\u00c5)")
+
+    save_with_metadata(
+        fig,
+        "pdb_nmr_ensemble",
+        "1GAB NMR Ensemble",
+        "Overlay of backbone atom coordinates across all 20 MODEL blocks of the 1GAB.pdb NMR ensemble, opened through the NetCDF UDF interface, showing conformational variation between models.",
+        "3D overlay plot of 20 NMR models from the 1GAB protein structure.",
+    )
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/viz/PDB/plot_pdb_xray_structure.py
+++ b/examples/viz/PDB/plot_pdb_xray_structure.py
@@ -1,0 +1,72 @@
+"""Plot a 3D scatter of the 4HHB.pdb X-ray crystal structure through the NetCDF UDF interface.
+
+Companion code for "The NetCDF Developer's Handbook: The Authoritative Guide to
+Writing High-Performance Programs for Scientific Data Management, Second Edition"
+(https://www.amazon.com/dp/B0H7Q1Z75L).
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401  (registers 3D projection)
+
+from _pdb_udf import read_structure
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from plot_common import save_with_metadata
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot a 3D scatter of the 4HHB.pdb X-ray crystal structure."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=os.environ.get("NEP_VIZ_PDB_XRAY_FILE"),
+    )
+    args = parser.parse_args()
+    if not args.path:
+        parser.error(
+            "a PDB X-ray structure file path is required (or set NEP_VIZ_PDB_XRAY_FILE)"
+        )
+
+    path = Path(args.path)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+
+    structure = read_structure(path)
+    x = structure["x"][0, :]
+    y = structure["y"][0, :]
+    z = structure["z"][0, :]
+    group = np.asarray(structure["group"])
+
+    is_atom = group == "ATOM"
+    is_hetatm = ~is_atom
+
+    fig = plt.figure(figsize=(6.5, 6.0))
+    ax = fig.add_subplot(111, projection="3d")
+    ax.scatter(x[is_atom], y[is_atom], z[is_atom], s=2, c="black", marker=".", label="ATOM")
+    ax.scatter(x[is_hetatm], y[is_hetatm], z[is_hetatm], s=8, c="0.6", marker="^", label="HETATM")
+    ax.set_title("4HHB X-ray Structure")
+    ax.set_xlabel("x (\u00c5)")
+    ax.set_ylabel("y (\u00c5)")
+    ax.set_zlabel("z (\u00c5)")
+    ax.legend(loc="upper right", fontsize="small")
+
+    save_with_metadata(
+        fig,
+        "pdb_xray_structure",
+        "4HHB X-ray Structure",
+        "3D scatter of ATOM and HETATM Cartesian coordinates from the 4HHB.pdb hemoglobin X-ray crystal structure, opened through the NetCDF UDF interface.",
+        "3D scatter plot of the 4HHB hemoglobin X-ray crystal structure atom coordinates.",
+    )
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/viz/README.md
+++ b/examples/viz/README.md
@@ -3,11 +3,11 @@
 The visualization examples use Python `netCDF4` to open NEP UDF files and
 Matplotlib to write static PNG plots. They are optional and disabled by default.
 The scripts cover FITS, CDF, GeoTIFF, GRIB2, PDS4 MESSENGER,
-Perseverance, MAVEN, New Horizons, and DICOM products. They use the generated
-build-tree `.ncrc` to autoload enabled NEP UDF libraries.
+Perseverance, MAVEN, New Horizons, DICOM, and legacy PDB products. They use the
+generated build-tree `.ncrc` to autoload enabled NEP UDF libraries.
 
 Format-specific scripts are organized in `CDF/`, `DICOM/`, `FITS/`,
-`GeoTIFF/`, `GRIB2/`, and `PDS4/` directories. CMake mirrors this layout under
+`GeoTIFF/`, `GRIB2/`, `PDS4/`, and `PDB/` directories. CMake mirrors this layout under
 `build/examples/viz/`. Shared helpers, tests, the artifact verifier, this README,
 and the CMake configuration remain at the visualization root.
 
@@ -55,7 +55,8 @@ cmake -S . -B build \
   -DNEP_ENABLE_GEOTIFF=ON \
   -DNEP_ENABLE_GRIB2=ON \
   -DNEP_ENABLE_PDS4=ON \
-  -DNEP_ENABLE_DICOM=ON
+  -DNEP_ENABLE_DICOM=ON \
+  -DNEP_ENABLE_PDB=ON
 cmake --build build
 ctest --test-dir build -R viz --output-on-failure
 ```
@@ -98,11 +99,16 @@ python3 /path/to/nep/build/examples/viz/DICOM/plot_dicom_xa_montage.py \
   /path/to/nep/build/test/data/DICOM/0003.DCM
 python3 /path/to/nep/build/examples/viz/DICOM/plot_dicom_ct_brain.py \
   /path/to/nep/build/test/data/DICOM/CT-MONO2-16-brain.dcm
+python3 /path/to/nep/build/examples/viz/PDB/plot_pdb_xray_structure.py \
+  /path/to/nep/build/test/data/PDB/4HHB.pdb
+python3 /path/to/nep/build/examples/viz/PDB/plot_pdb_nmr_ensemble.py \
+  /path/to/nep/build/test/data/PDB/1GAB.pdb
 python3 /path/to/nep/build/examples/viz/verify_viz_artifacts.py \
   /path/to/nep/build/examples/viz \
   viz_plot_common_test fits_wfpc2_image cdf_temperature geotiff_modis_flood \
   grib2_wave pds4_messenger_tnmap pds4_perseverance_mastcamz \
-  pds4_maven_ngims_l3 pds4_new_horizons_alice dicom_mrbrain_image dicom_xa_frame_montage
+  pds4_maven_ngims_l3 pds4_new_horizons_alice dicom_mrbrain_image dicom_xa_frame_montage \
+  pdb_xray_structure pdb_nmr_ensemble
 ```
 
 ## Scripts
@@ -124,6 +130,9 @@ python3 /path/to/nep/build/examples/viz/verify_viz_artifacts.py \
 - **`PDS4/`**: the scripts plot the MESSENGER thermal neutron map, Perseverance
   Mastcam-Z band 0 radiance, MAVEN NGIMS L3 temperature, and a New Horizons Alice
   spectrum array.
+- **`PDB/`**: `_pdb_udf.py` provides legacy PDB NetCDF access; `plot_pdb_xray_structure.py`
+  renders a 3D scatter of the `4HHB.pdb` X-ray structure atoms, and
+  `plot_pdb_nmr_ensemble.py` overlays all 20 models of the `1GAB.pdb` NMR ensemble.
 
 Generated PNG and metadata files remain in the visualization build directory
 for inspection. They are not installed and are not written to the source tree.

--- a/references_2.txt
+++ b/references_2.txt
@@ -1,0 +1,65 @@
+{{Cite web| title = NetCDF: Documentation| access-date = 2026-05-30| url = https://docs.unidata.ucar.edu/netcdf-c/current/}}
+{{Cite web| title = PIO: Parallel I/O Libraries (PIO)| access-date = 2026-05-30| url = https://ncar.github.io/ParallelIO/}}
+{{Cite| publisher = Intelligent-Data-Design-Inc| title = Intelligent-Data-Design-Inc/NEP| access-date = 2026-05-30| date = 2026-05-28| url = https://github.com/Intelligent-Data-Design-Inc/NEP}}
+{{Cite| doi = 10.5065/D6H70CW6| last1 = NSF Unidata| last2 = Davis| first2 = Glenn| last3 = Rew| first3 = Russ| last4 = Heimbigner| first4 = Dennis| last5 = Hartnett| first5 = Edward| last6 = Fisher| first6 = Ward| last7 = Others| first7 = Many| title = NetCDF-C| access-date = 2026-05-30| date = 2026-05-28| url = https://github.com/Unidata/netcdf-c}}
+{{Cite web| title = NetCDF-Fortran: Unidata NetCDF Fortran Library| access-date = 2026-05-30| url = https://docs.unidata.ucar.edu/netcdf-fortran/current/}}
+{{Cite| publisher = NSF Unidata| title = Unidata/netcdf-fortran| access-date = 2026-05-30| date = 2026-05-17| url = https://github.com/Unidata/netcdf-fortran}}
+{{Cite paper| doi = 10.13140/RG.2.2.31433.11361| last1 = Hartnett| first1 = Edward| last2 = Lei| first2 = Hang| last3 = Jovic| first3 = Dusan| title = IN31C-0673: Benchmarking Zstandard and Quantize Compression in NetCDF| date = 2023-12-11}}
+{{Cite paper| last = Hartnett| first = Edward| title = Unit Testing NetCDF and NCEPLIBS Model Infrastructure Meeting 12/4/23| date = 2023-12-06}}
+{{Cite conference| conference = AMS| title = (PDF) THE PARALLELIO (PIO) C/FORTRAN LIBRARIES FOR SCALABLE HPC PERFORMANCE| booktitle = ResearchGate| access-date = 2026-05-30| date = 2021-01| url = https://www.researchgate.net/publication/348169990_THE_PARALLELIO_PIO_CFORTRAN_LIBRARIES_FOR_SCALABLE_HPC_PERFORMANCE}}
+{{Cite paper| doi = 10.13140/RG.2.2.32990.14404| title = (PDF) NetCDF Tricks of the Jedi Masters| work = ResearchGate| location = CU LASP| access-date = 2026-05-30| date = 2024-03-24| url = https://www.researchgate.net/publication/386377963_NetCDF_Tricks_of_the_Jedi_Masters}}
+{{Cite conference| title = (PDF) NetCDF Compression Improvements| booktitle = ResearchGate| location = Hamburg, Germany| access-date = 2026-05-30| date = 2023| url = https://www.researchgate.net/publication/374030060_NetCDF_Compression_Improvements_-_HDF5_User_Meeting_Hamburg_2023}}
+{{Cite paper| doi = 10.13140/RG.2.2.24489.36965| title = (PDF) Better Compression for UFS with Support from the NetCDF Community| work = ResearchGate| access-date = 2026-05-30| date = 2023-06-28| url = https://www.researchgate.net/publication/372744136_Better_Compression_for_UFS_with_Support_from_the_NetCDF_Community}}
+{{Cite paper| last1 = Zender| first1 = Charlie| last2 = Tolento| first2 = Juan| last3 = Hartnett| first3 = Edward| title = Advanced Compression Algorithms for netCDF Datasets with the Community Codec Repository| date = 2022-07-25}}
+{{Cite paper| last = Hartnett| first = Edward| title = NetCDF Compression Improvements| date = 2022-11-02}}
+{{Cite paper| last = Hartnett| first = Edward| title = NetCDF Compression Improvements SENA Meeting, 6/21/23| date = 2023-06-28}}
+{{Cite paper| last1 = Zender| first1 = Charlie| last2 = Tolento| first2 = Juan| last3 = Hartnett| first3 = Edward| title = Advanced Compression Algorithms for netCDF Datasets with the Community Codec Repository| date = 2022-07-25}}
+{{Cite conference| conference = EGU| last1 = Hartnett| first1 = Edward| last2 = Zender| first2 = Charlie| title = Adding Quantization to the NetCDF C and Fortran Libraries to Enable Lossy Compression| date = 2022-05-24}}
+{{Cite conference| conference = AGU| last1 = Hartnett| first1 = Edward| last2 = Zender| first2 = Charles| last3 = Fisher| first3 = Ward| last4 = Heimbigner| first4 = Dennis| last5 = Lei| first5 = Hang| last6 = Curtis| first6 = Brian| last7 = Gerheiser| first7 = Kyle| title = Quantization and Next-Generation Zlib Compression for Fully Backward-Compatible, Faster, and More Effective Data Compression in NetCDF Files| date = 2021-12-13}}
+{{Cite paper| doi = 10.13140/RG.2.2.22979.84005| last = Hartnett| first = Edward| title = PIO and NetCDF Integration| date = 2019-12-23}}
+{{Cite conference| conference = Improving Scientific Software| last1 = Hartnett| first1 = Edward| last2 = Edwards| first2 = Jim| title = SOFTWARE ENGINEERING METHODS USED FOR THE PARALLELIO (PIO) C/FORTRAN LIBRARIES| date = 2019-04-03}}
+{{Cite paper| doi = 10.13140/RG.2.2.24258.63682| last = Hartnett| first = Edward| title = NetCDF-4 Performance Improvements Opening Complex Data Files| date = 2019-01-10}}
+{{Cite paper| last1 = Rew| first1 = Russ| last2 = Hartnett| first2 = Edward| last3 = Heimbigner| first3 = D.| last4 = Caron| first4 = John| title = Advances in the NetCDF Data Model, Format, and Software| work = AGU Fall Meeting Abstracts| date = 2010-12-01}}
+{{Cite conference| last1 = Gallagher| first1 = James| last2 = Rew| first2 = Russ| last3 = McQueary| first3 = R.| last4 = Heimbigner| first4 = D.| last5 = Hartnett| first5 = Edward| title = Merging the Data Models of NetCDF and DAP: Design Choices and Benefits| booktitle = AGU Fall Meeting Abstracts| date = 2008-01-01}}
+{{Cite journal| last1 = Folk| first1 = Mike| last2 = Rew| first2 = Russ| last3 = Yang| first3 = M.| last4 = Hartnett| first4 = Edward| last5 = McGrath| first5 = R.| last6 = Koziol| first6 = Quincey| title = NetCDF-4: Combining netCDF and HDF5 Data| journal = AGU Fall Meeting Abstracts| date = 2003-12-01}}
+{{Cite conference| last1 = Hartnett| first1 = Edward| last2 = Rew| first2 = Russ| title = 7C.2 EXPERIENCE WITH AN ENHANCED NETCDF DATA MODEL AND INTERFACE FOR SCIENTIFIC DATA ACCESS}}
+{{Cite journal| doi = 10.5194/gmd-10-413-2017| issn = 1991-9603| volume = 10| issue = 1| pages = 413–423| last1 = Silver| first1 = Jeremy D.| last2 = Zender| first2 = Charles S.| title = The compression–error trade-off for large gridded data sets| journal = Geoscientific Model Development| access-date = 2026-05-30| date = 2017-01-27| url = https://gmd.copernicus.org/articles/10/413/2017/}}
+{{Cite journal| doi = 10.5194/gmd-9-3199-2016| issn = 1991-9603| volume = 9| issue = 9| pages = 3199–3211| last = Zender| first = Charles S.| title = Bit Grooming: statistically accurate precision-preserving quantization with compression, evaluated in the netCDF Operators (NCO, v4.4.8+)| journal = Geoscientific Model Development| access-date = 2026-05-30| date = 2016-09-19| url = https://gmd.copernicus.org/articles/9/3199/2016/}}
+{{Cite| doi = 10.1002/essoar.10509577.1| last = Zender| first = Charles| title = What Geoscientists Want: Short and Sweet Commands with Eco-friendly Data| access-date = 2026-05-30| date = 2021-12-15| url = https://essopenarchive.org/doi/full/10.1002/essoar.10509577.1}}
+{{Cite journal| doi = 10.5194/gmd-10-4619-2017| issn = 1991-9603| volume = 10| issue = 12| pages = 4619–4646| last1 = Hassell| first1 = David| last2 = Gregory| first2 = Jonathan| last3 = Blower| first3 = Jon| last4 = Lawrence| first4 = Bryan N.| last5 = Taylor| first5 = Karl E.| title = A data model of the Climate and Forecast metadata conventions (CF-1.6) with a software implementation (cf-python v2.1)| journal = Geoscientific Model Development| access-date = 2026-05-30| date = 2017-12-19| url = https://gmd.copernicus.org/articles/10/4619/2017/}}
+{{Cite web| title = UDUNITS {{!}} NSF Unidata| access-date = 2026-05-30| url = https://www.unidata.ucar.edu/software/udunits}}
+{{Cite web| title = Zarr| work = Zarr| access-date = 2026-05-30| url = https://zarr.dev/}}
+{{Cite web| title = The HDF5® Library & File Format| work = The HDF Group - ensuring long-term access and usability of HDF data and supporting users of HDF technologies| access-date = 2026-05-30| url = https://www.hdfgroup.org/solutions/hdf5/}}
+{{Cite web| last = loricooper| title = HDF4| work = The HDF Group - ensuring long-term access and usability of HDF data and supporting users of HDF technologies| access-date = 2026-05-30| url = https://www.hdfgroup.org/download/hdf4/}}
+{{Cite web| title = Homepage — OPeNDAP| access-date = 2026-05-30| date = 2026-04-22| url = https://www.opendap.org/}}
+{{Cite web| title = OPeNDAP User Guide| access-date = 2026-05-30| url = https://opendap.github.io/documentation/UserGuideComprehensive.html}}
+{{Cite web| title = PnetCDF| access-date = 2026-05-30| url = https://parallel-netcdf.github.io/}}
+{{Cite web| title = CDF Home| work = Common Data Format (CDF)| access-date = 2026-05-30| url = https://cdf.gsfc.nasa.gov/}}
+{{Cite conference| publisher = Internet Engineering Task Force| doi = 10.17487/RFC1950| last1 = Deutsch| first1 = L. Peter| last2 = Gailly| first2 = Jean-loup| title = ZLIB Compressed Data Format Specification version 3.3| access-date = 2026-06-08| date = 1996-05| url = https://datatracker.ietf.org/doc/rfc1950}}
+{{Cite web| title = Szip - User Manual - NHR@ZIB| access-date = 2026-06-08| url = https://user.nhr.zib.de/wiki/spaces/PUB/pages/427535/Szip}}
+{{Cite web| title = szip/src/szlib.h at master · erdc/szip| work = GitHub| access-date = 2026-06-08| url = https://github.com/erdc/szip/blob/master/src/szlib.h}}
+{{Cite web| title = szip homepage| access-date = 2026-06-08| url = http://www.compressconsult.com/szip/}}
+{{Cite web| title = dkrz-sw / libaec · GitLab| work = GitLab| access-date = 2026-06-08| date = 2026-05-19| url = https://gitlab.dkrz.de/dkrz-sw/libaec}}
+{{Cite web| title = libaec/INSTALL.md at main · Deutsches-Klimarechenzentrum/libaec| work = GitHub| access-date = 2026-06-08| url = https://github.com/Deutsches-Klimarechenzentrum/libaec/blob/main/INSTALL.md}}
+{{Cite web| title = Zstandard - Real-time data compression algorithm| access-date = 2026-06-08| url = https://facebook.github.io/zstd/}}
+{{Cite conference| publisher = Internet Engineering Task Force| doi = 10.17487/RFC8878| last1 = Collet| first1 = Yann| last2 = Kucherawy| first2 = Murray| title = Zstandard Compression and the 'application/zstd' Media Type| access-date = 2026-06-08| date = 2021-02| url = https://datatracker.ietf.org/doc/rfc8878}}
+{{Cite| publisher = lz4| title = lz4/lz4| access-date = 2026-06-08| date = 2026-06-07| url = https://github.com/lz4/lz4}}
+{{Cite web| title = bzip2 : Home| access-date = 2026-06-08| url = https://sourceware.org/bzip2/}}
+{{Cite| publisher = lz4| title = lz4/lz4| access-date = 2026-06-08| date = 2026-06-08| url = https://github.com/lz4/lz4}}
+{{Cite| publisher = Intelligent-Data-Design-Inc| title = Intelligent-Data-Design-Inc/NEP| access-date = 2026-06-10| date = 2026-06-06| url = https://github.com/Intelligent-Data-Design-Inc/NEP}}
+{{Cite journal| publisher = CF Community| doi = 10.5281/ZENODO.15015065| last1 = Davis| first1 = Ethan| last2 = Taylor| first2 = Karl E.| last3 = Adloff| first3 = Fanny| last4 = Gregory| first4 = Jonathan| last5 = Lawrence| first5 = Bryan| last6 = Lee| first6 = Daniel| title = Supporting Open Science with the CF Metadata Conventions for NetCDF| access-date = 2026-06-10| date = 2024-12-11| url = https://zenodo.org/doi/10.5281/zenodo.15015065}}
+{{Cite web| title = CF Standard Names}}
+{{Cite web| title = CF Metadata Conventions}}
+{{Cite| publisher = OPeNDAP™| title = OPENDAP/bes| access-date = 2026-06-16| date = 2026-06-15| url = https://github.com/OPENDAP/bes}}
+{{Cite web| title = CMIP - Coupled Model Intercomparison Project| access-date = 2026-06-23| date = 2022-10-30| url = https://wcrp-cmip.org/}}
+{{Cite web| title = Home {{!}} Community Earth System Model| access-date = 2026-06-23| url = https://www.cesm.ucar.edu/}}
+{{Cite web| title = Weather Research & Forecasting Model (WRF) {{!}} Mesoscale & Microscale Meteorology| access-date = 2026-07-02| url = https://www.mmm.ucar.edu/models/wrf}}
+{{Cite web| title = Integrated Data Viewer {{!}} NSF Unidata| access-date = 2026-07-02| url = https://www.unidata.ucar.edu/software/idv}}
+{{Cite web| title = ERA5 hourly data on single levels from 1940 to present| access-date = 2026-07-02| url = https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=overview}}
+{{Cite web| title = Climate Data Store| access-date = 2026-07-02| url = https://cds.climate.copernicus.eu/}}
+{{Cite web| title = CMIP Phase 5 (CMIP5) - Coupled Model Intercomparison Project| access-date = 2026-07-02| date = 2022-12-02| url = https://wcrp-cmip.org/cmip-phases/cmip5/}}
+{{Cite web| title = IPCC — Intergovernmental Panel on Climate Change| access-date = 2026-07-02| url = https://www.ipcc.ch/}}
+{{Cite web| title = The Ocean Observatories Initiative (OOI)| access-date = 2026-07-02| url = https://oceanobservatories.org/}}
+{{Cite| publisher = Intelligent-Data-Design-Inc| title = Intelligent-Data-Design-Inc/NEP| access-date = 2026-07-02| date = 2026-06-29| url = https://github.com/Intelligent-Data-Design-Inc/NEP}}
+{{Cite web| title = NCO Homepage| access-date = 2026-07-05| url = https://nco.sourceforge.net/}}
+{{Cite| last = Hartnett| first = Edward| title = The NetCDF Expansion Pack (NEP) - Extending the Capabilities of NetCDF| access-date = 2026-07-19| url = https://github.com/Intelligent-Data-Design-Inc/NEP/blob/main/docs/NEP_abstract.md}}

--- a/spack/NEP/package.py
+++ b/spack/NEP/package.py
@@ -13,7 +13,7 @@ from spack.package import *
 class Nep(CMakePackage):
     """NEP (NetCDF Expansion Pack) provides high-performance LZ4 and BZIP2
     compression filters for HDF5/NetCDF-4 files and transparent read access
-    to scientific data formats (GeoTIFF, GRIB2, FITS, PDS4, DICOM)
+    to scientific data formats (GeoTIFF, GRIB2, FITS, PDS4, DICOM, legacy PDB)
     through the standard NetCDF API via User Defined Format handlers."""
 
     homepage = "https://github.com/Intelligent-Data-Design-Inc/NEP"
@@ -83,6 +83,7 @@ class Nep(CMakePackage):
     variant("grib2", default=False, description="Enable GRIB2 reader support via NCEPLIBS-g2c")
     variant("pds4", default=False, description="Enable PDS4 reader support via libxml2")
     variant("dicom", default=False, description="Enable DICOM reader support via libdicom")
+    variant("pdb", default=True, description="Enable legacy PDB reader support (no external library required)")
     variant(
         "parallel",
         default=False,
@@ -122,6 +123,7 @@ class Nep(CMakePackage):
             self.define_from_variant("NEP_ENABLE_GRIB2", "grib2"),
             self.define_from_variant("NEP_ENABLE_PDS4", "pds4"),
             self.define_from_variant("NEP_ENABLE_DICOM", "dicom"),
+            self.define_from_variant("NEP_ENABLE_PDB", "pdb"),
             self.define_from_variant("NEP_ENABLE_PARALLEL_TESTS", "parallel"),
             self.define_from_variant("NEP_BUILD_EXAMPLES", "examples"),
             self.define_from_variant("NEP_ENABLE_BENCHMARKS", "benchmarks"),
@@ -149,5 +151,7 @@ class Nep(CMakePackage):
             assert os.path.exists(join_path(self.prefix.lib, "libncpds4.so"))
         if "+dicom" in self.spec:
             assert os.path.exists(join_path(self.prefix.lib, "libncdicom.so"))
+        if "+pdb" in self.spec:
+            assert os.path.exists(join_path(self.prefix.lib, "libncpdb.so"))
         if "+fits" in self.spec:
             assert os.path.exists(join_path(self.prefix.lib, "libncfits.so"))


### PR DESCRIPTION
- Add PDB format to README.md format table, CMake options, and Spack variants
- Add docs/pdb.md to Doxyfile.in INPUT list
- Update docs/formats.md with UDF7 PDB slot assignment and format reference
- Add PDB sprint 4 documentation plan to docs/roadmap.md
- Add examples/pdb/ subdirectory to CMakeLists.txt when HAVE_PDB enabled
- Document pdb_read.c example in examples/README.md
- Add PDB visualization scripts to examples/viz/: _pdb_udf.py helper, plot_pdb_xray_structure.py (4HHB.pdb 3D scatter), plot_pdb_nmr